### PR TITLE
Task/validation rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
  "bld_sock",
  "bld_utils",
  "chrono",
+ "cron",
  "futures",
  "futures-util",
  "regex",

--- a/crates/bld_runner/Cargo.toml
+++ b/crates/bld_runner/Cargo.toml
@@ -29,3 +29,4 @@ tracing = "0.1.36"
 yaml-rust = "0.4.5"
 uuid = { version = "1.3.4", features = ["v4"] }
 regex = "1.8.1"
+cron = "0.12.0"

--- a/crates/bld_runner/src/pipeline/v2.rs
+++ b/crates/bld_runner/src/pipeline/v2.rs
@@ -57,11 +57,6 @@ impl Pipeline {
     pub async fn apply_tokens<'a>(&mut self, context: &'a PipelineContext<'a>) -> Result<()> {
         self.runs_on.apply_tokens(context).await?;
 
-        self.dispose = context
-            .transform(self.dispose.to_string())
-            .await?
-            .parse::<bool>()?;
-
         for (_, v) in self.environment.iter_mut() {
             *v = context.transform(v.to_owned()).await?;
         }

--- a/crates/bld_runner/src/pipeline/versioned.rs
+++ b/crates/bld_runner/src/pipeline/versioned.rs
@@ -114,7 +114,7 @@ impl VersionedPipeline {
                 validator_v1::PipelineValidator::new(pip, config, proxy).validate()
             }
             Self::Version2(pip) => {
-                validator_v2::PipelineValidator::new(pip, config, proxy).validate()
+                validator_v2::PipelineValidator::new(pip, config, proxy)?.validate()
             }
         }
         .map_err(|e| anyhow!("Expression errors\r\n\r\n{e}"))

--- a/crates/bld_runner/src/token_context/v2.rs
+++ b/crates/bld_runner/src/token_context/v2.rs
@@ -92,7 +92,7 @@ pub struct PipelineContext<'a> {
 
 impl<'a> PipelineContext<'a> {
     fn get_regex_pattern(keyword: &'a str) -> String {
-        format!("{}{}{}", "\\$\\{\\{\\s*", keyword, "\\s*\\}\\}")
+        format!("{}{}{}", r"\$\{\{\s*", keyword, r"\s*\}\}")
     }
 
     async fn cache_new_regex(&self, pattern: String) -> Result<Arc<Regex>> {

--- a/crates/bld_runner/src/validator/v2.rs
+++ b/crates/bld_runner/src/validator/v2.rs
@@ -166,7 +166,11 @@ impl<'a> PipelineValidator<'a> {
 
         match self.proxy.path(pipeline) {
             Ok(path) if !path.is_yaml() => {
-                let _ = writeln!(self.errors, "[external > pipeline > {}] Not found", pipeline);
+                let _ = writeln!(
+                    self.errors,
+                    "[external > pipeline > {}] Not found",
+                    pipeline
+                );
             }
             Err(e) => {
                 let _ = writeln!(self.errors, "[external > pipeline > {}] {e}", pipeline);
@@ -236,7 +240,9 @@ impl<'a> PipelineValidator<'a> {
                 self.validate_exec(&section, exec);
             }
             BuildStep::Many {
-                exec, working_dir, name
+                exec,
+                working_dir,
+                name,
             } => {
                 if let Some(name) = name {
                     let _ = write!(section, " > {name}");

--- a/crates/bld_runner/src/validator/v2.rs
+++ b/crates/bld_runner/src/validator/v2.rs
@@ -1,9 +1,15 @@
 use crate::pipeline::v2::Pipeline;
+use crate::platform::v2::Platform;
 use crate::step::v2::{BuildStep, BuildStepExec};
 use anyhow::{bail, Result};
+use bld_config::definitions::{
+    KEYWORD_BLD_DIR_V2, KEYWORD_RUN_PROPS_ID_V2, KEYWORD_RUN_PROPS_START_TIME_V2,
+};
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
 use bld_utils::fs::IsYaml;
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -11,6 +17,8 @@ pub struct PipelineValidator<'a> {
     pipeline: &'a Pipeline,
     config: Arc<BldConfig>,
     proxy: Arc<PipelineFileSystemProxy>,
+    regex: Regex,
+    symbols: HashSet<&'a str>,
 }
 
 impl<'a> PipelineValidator<'a> {
@@ -18,16 +26,49 @@ impl<'a> PipelineValidator<'a> {
         pipeline: &'a Pipeline,
         config: Arc<BldConfig>,
         proxy: Arc<PipelineFileSystemProxy>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let regex = Regex::new(r"\$\{\{\s*(\b\w+\b)\s*\}\}")?;
+        let symbols = Self::prepare_symbols(pipeline);
+        Ok(Self {
             pipeline,
             config,
             proxy,
+            regex,
+            symbols,
+        })
+    }
+
+    fn prepare_symbols(pipeline: &'a Pipeline) -> HashSet<&'a str> {
+        let mut symbols = HashSet::new();
+        symbols.insert(KEYWORD_BLD_DIR_V2);
+        symbols.insert(KEYWORD_RUN_PROPS_ID_V2);
+        symbols.insert(KEYWORD_RUN_PROPS_START_TIME_V2);
+
+        for (k, _) in pipeline.variables.iter() {
+            symbols.insert(k);
         }
+
+        for (k, _) in pipeline.environment.iter() {
+            symbols.insert(k);
+        }
+
+        symbols
     }
 
     pub fn validate(&self) -> Result<()> {
         let mut errors = String::new();
+
+        if let Err(e) = self.validate_runs_on() {
+            write!(errors, "{e}")?;
+        }
+
+        if let Err(e) = self.validate_variables(None, &self.pipeline.variables) {
+            write!(errors, "{e}")?;
+        }
+
+        if let Err(e) = self.validate_environment(None, &self.pipeline.environment) {
+            write!(errors, "{e}")?;
+        }
 
         if let Err(e) = self.validate_external() {
             write!(errors, "{e}")?;
@@ -48,46 +89,192 @@ impl<'a> PipelineValidator<'a> {
         }
     }
 
+    fn sanitize_symbol(symbol: &'a str) -> &'a str {
+        symbol[3..symbol.len() - 2].trim()
+    }
+
+    fn validate_symbols(&self, section: &'a str, value: &'a str) -> Result<()> {
+        let mut errors = String::new();
+
+        for symbol in self.regex.find_iter(value).map(|x| x.as_str()) {
+            if !self.symbols.contains(Self::sanitize_symbol(symbol)) {
+                writeln!(
+                    errors,
+                    "[{section} > {symbol}] expression isn't a keyword or variable",
+                )?;
+            }
+        }
+
+        if !errors.is_empty() {
+            bail!(errors)
+        }
+
+        Ok(())
+    }
+
+    fn validate_runs_on(&self) -> Result<()> {
+        match &self.pipeline.runs_on {
+            Platform::Build {
+                name,
+                tag,
+                dockerfile,
+            } => {
+                let mut errors = String::new();
+
+                if let Err(e) = self.validate_symbols("runs_on > name", name) {
+                    write!(errors, "{e}")?;
+                }
+
+                if let Err(e) = self.validate_symbols("runs_on > tag", tag) {
+                    write!(errors, "{e}")?;
+                }
+
+                if let Err(e) = self.validate_symbols("runs_on > dockerfile", dockerfile) {
+                    write!(errors, "{e}")?;
+                }
+
+                if !errors.is_empty() {
+                    bail!(errors)
+                }
+            }
+
+            Platform::Pull { image, .. } => self.validate_symbols("runs_on > image", image)?,
+
+            Platform::ContainerOrMachine(value) => self.validate_symbols("runs_on >", value)?,
+        }
+        Ok(())
+    }
+
+    fn validate_variables(
+        &self,
+        section: Option<&str>,
+        variables: &HashMap<String, String>,
+    ) -> Result<()> {
+        let mut errors = String::new();
+
+        for (k, v) in variables.iter() {
+            let section = section
+                .map(|x| format!("{x} > "))
+                .unwrap_or_else(String::new);
+            let section = format!("{section}variables > {k}");
+            if let Err(e) = self.validate_symbols(&section, v) {
+                write!(errors, "{e}")?;
+            }
+        }
+
+        if !errors.is_empty() {
+            bail!(errors)
+        }
+
+        Ok(())
+    }
+
+    fn validate_environment(
+        &self,
+        section: Option<&str>,
+        environment: &HashMap<String, String>,
+    ) -> Result<()> {
+        let mut errors = String::new();
+
+        for (k, v) in environment.iter() {
+            let section = section
+                .map(|x| format!("{x} > "))
+                .unwrap_or_else(String::new);
+            let section = format!("{section}environment > {k}");
+            if let Err(e) = self.validate_symbols(&section, v) {
+                write!(errors, "{e}")?;
+            }
+        }
+
+        if !errors.is_empty() {
+            bail!(errors)
+        }
+
+        Ok(())
+    }
+
     fn validate_external(&self) -> Result<()> {
         let mut errors = String::new();
 
         for entry in &self.pipeline.external {
+            if let Err(e) = self.validate_external_name(entry.name.as_deref()) {
+                writeln!(errors, "{e}")?;
+            }
+
             if let Err(e) = self.validate_external_pipeline(&entry.pipeline) {
                 writeln!(errors, "{e}")?;
             }
 
-            if let Err(e) = self.validate_external_server(entry.server.as_ref()) {
+            if let Err(e) = self.validate_external_server(entry.server.as_deref()) {
+                writeln!(errors, "{e}")?;
+            }
+
+            if let Err(e) = self.validate_variables(Some("external"), &entry.variables) {
+                writeln!(errors, "{e}")?;
+            }
+
+            if let Err(e) = self.validate_environment(Some("external"), &entry.environment) {
                 writeln!(errors, "{e}")?;
             }
         }
 
-        if errors.is_empty() {
-            Ok(())
-        } else {
+        if !errors.is_empty() {
             bail!(errors)
         }
+
+        Ok(())
+    }
+
+    fn validate_external_name(&self, name: Option<&str>) -> Result<()> {
+        let Some(name) = name else {
+            return Ok(());
+        };
+        self.validate_symbols("external > name", name)
     }
 
     fn validate_external_pipeline(&self, pipeline: &str) -> Result<()> {
+        let mut errors = String::new();
+
+        if let Err(e) = self.validate_symbols("external > pipeline", pipeline) {
+            write!(errors, "{e}")?;
+        }
+
         match self.proxy.path(pipeline) {
             Ok(path) if !path.is_yaml() => {
-                bail!("[external > pipeline: {}] Not found", pipeline)
+                write!(errors, "[external > pipeline: {}] Not found", pipeline)?;
             }
-            Err(e) => bail!("[external > pipeline: {}] {e}", pipeline),
-            _ => Ok(()),
+            Err(e) => write!(errors, "[external > pipeline: {}] {e}", pipeline)?,
+            _ => {}
         }
+
+        if !errors.is_empty() {
+            bail!(errors)
+        }
+
+        Ok(())
     }
 
-    fn validate_external_server(&self, server: Option<&String>) -> Result<()> {
+    fn validate_external_server(&self, server: Option<&str>) -> Result<()> {
         let Some(server) = server else {
             return Ok(());
         };
 
+        let mut errors = String::new();
+
+        if let Err(e) = self.validate_symbols("external > server", server) {
+            write!(errors, "{e}")?;
+        }
+
         if self.config.server(server).is_err() {
-            bail!(
+            write!(
+                errors,
                 "[external > server: {}] Doesn't exist in current config",
                 server
-            );
+            )?;
+        }
+
+        if !errors.is_empty() {
+            bail!(errors)
         }
 
         Ok(())

--- a/crates/bld_server/src/server.rs
+++ b/crates/bld_server/src/server.rs
@@ -1,6 +1,8 @@
 use crate::cron::CronScheduler;
-use crate::endpoints::{home, auth, check, hist, list, remove, run, push, deps, pull, stop, print, cron};
-use crate::sockets::{exec, monit, login};
+use crate::endpoints::{
+    auth, check, cron, deps, hist, home, list, print, pull, push, remove, run, stop,
+};
+use crate::sockets::{exec, login, monit};
 use crate::supervisor::channel::SupervisorMessageSender;
 use actix_web::web::{get, resource};
 use actix_web::{middleware, App, HttpServer};


### PR DESCRIPTION
In this PR:

- Updated validator for v2 pipeline in order to check for errors regarding keywords, variables and environment variables.
- Updated the existing rules and added new rules for runs_on, cron and jobs.
- Refactored the validator so that the validate function will take ownership and mutate a single errors string that will be check in the end and be returned if anything has been added.
- Added a dependency to the cron crate for the bld_runner in order to validate the cron schedule for the pipeline.