### PR TITLE
Bugfix/Wrong output of root dir keyword

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,4 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.2.1"
+tag_format = "$version"

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -2,7 +2,8 @@ use crate::command::BldCommand;
 use anyhow::{bail, Result};
 use bld_config::definitions::{
     default_client_config, default_server_config, DEFAULT_V2_PIPELINE_CONTENT, LOCAL_DB,
-    LOCAL_LOGS, LOCAL_SERVER_PIPELINES, TOOL_DEFAULT_CONFIG_FILE, TOOL_DEFAULT_PIPELINE, TOOL_DIR, TOOL_DEFAULT_PIPELINE_FILE,
+    LOCAL_LOGS, LOCAL_SERVER_PIPELINES, TOOL_DEFAULT_CONFIG_FILE, TOOL_DEFAULT_PIPELINE,
+    TOOL_DEFAULT_PIPELINE_FILE, TOOL_DIR,
 };
 use bld_config::path;
 use bld_utils::term::print_info;

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -11,6 +11,7 @@ pub const KEYWORD_RUN_PROPS_ID_V1: &str = "bld:run:id";
 pub const KEYWORD_RUN_PROPS_START_TIME_V1: &str = "bld:run:start_time";
 
 pub const KEYWORD_BLD_DIR_V2: &str = "bld_root_dir";
+pub const KEYWORD_PROJECT_DIR_V2: &str = "bld_project_dir";
 pub const KEYWORD_RUN_PROPS_ID_V2: &str = "bld_run_id";
 pub const KEYWORD_RUN_PROPS_START_TIME_V2: &str = "bld_start_time";
 

--- a/crates/bld_runner/src/sync/builder.rs
+++ b/crates/bld_runner/src/sync/builder.rs
@@ -187,7 +187,8 @@ impl RunnerBuilder {
 
             VersionedPipeline::Version2(mut pipeline) => {
                 let pipeline_context = PipelineContextBuilder::default()
-                    .bld_directory(&config.path)
+                    .root_dir(&config.root_dir)
+                    .project_dir(&config.project_dir)
                     .add_variables(&pipeline.variables)
                     .add_variables(&vars)
                     .add_environment(&pipeline.environment)

--- a/crates/bld_runner/src/validator/v2.rs
+++ b/crates/bld_runner/src/validator/v2.rs
@@ -3,7 +3,8 @@ use crate::platform::v2::Platform;
 use crate::step::v2::{BuildStep, BuildStepExec};
 use anyhow::{bail, Result};
 use bld_config::definitions::{
-    KEYWORD_BLD_DIR_V2, KEYWORD_RUN_PROPS_ID_V2, KEYWORD_RUN_PROPS_START_TIME_V2,
+    KEYWORD_BLD_DIR_V2, KEYWORD_PROJECT_DIR_V2, KEYWORD_RUN_PROPS_ID_V2,
+    KEYWORD_RUN_PROPS_START_TIME_V2,
 };
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
@@ -49,6 +50,7 @@ impl<'a> PipelineValidator<'a> {
     fn prepare_keywords() -> HashSet<&'a str> {
         let mut keywords = HashSet::new();
         keywords.insert(KEYWORD_BLD_DIR_V2);
+        keywords.insert(KEYWORD_PROJECT_DIR_V2);
         keywords.insert(KEYWORD_RUN_PROPS_ID_V2);
         keywords.insert(KEYWORD_RUN_PROPS_START_TIME_V2);
         keywords
@@ -57,6 +59,7 @@ impl<'a> PipelineValidator<'a> {
     fn prepare_symbols(pipeline: &'a Pipeline) -> HashSet<&'a str> {
         let mut symbols = HashSet::new();
         symbols.insert(KEYWORD_BLD_DIR_V2);
+        symbols.insert(KEYWORD_PROJECT_DIR_V2);
         symbols.insert(KEYWORD_RUN_PROPS_ID_V2);
         symbols.insert(KEYWORD_RUN_PROPS_START_TIME_V2);
 
@@ -93,10 +96,7 @@ impl<'a> PipelineValidator<'a> {
 
     fn validate_keywords(&mut self, section: &str, name: &'a str) {
         if self.keywords.contains(name) {
-            let _ = writeln!(
-                self.errors,
-                "[{section}] Invalid name, reserved as keyword",
-            );
+            let _ = writeln!(self.errors, "[{section}] Invalid name, reserved as keyword",);
         }
     }
 


### PR DESCRIPTION
In this PR:

- Updated the configuration code in order to retrieve both the path of the `.bld` directory as well as the project directory.
- Added new const string in the definitions about the `bld_project_dir` keyword.
- Updated the pipeline context to apply the `bld_project_dir` keyword.
- Updated the validator for the new keyword.
- Added commitizen file.