### PR TITLE
V0.3/task/additional subcommands cp mv

### DIFF
--- a/.bld/build-musl.yaml
+++ b/.bld/build-musl.yaml
@@ -2,7 +2,7 @@ name: Bld build pipeline for musl
 version: 2
 runs_on:
   name: bld-musl-builder
-  dockerfile: ./musl/Dockerfile
+  dockerfile: ${{bld_project_dir}}/musl/Dockerfile
   tag: latest
 
 variables:

--- a/.bld/release.yaml
+++ b/.bld/release.yaml
@@ -11,7 +11,7 @@ external:
 
 jobs:
   main:
-  - rm -r ${{bld_project_dir}}/dist/*
+  - rm -r ${{bld_project_dir}}/dist/* || true
   - ext: build-musl.yaml
   - working_dir: ${{bld_project_dir}}/dist
     exec:

--- a/.bld/release.yaml
+++ b/.bld/release.yaml
@@ -1,0 +1,19 @@
+runs_on: machine
+version: 2
+
+variables:
+  branch: master
+
+external:
+- pipeline: build-musl.yaml
+  variables:
+    branch: ${{branch}}
+
+jobs:
+  main:
+  - rm -r ${{bld_project_dir}}/dist/*
+  - ext: build-musl.yaml
+  - working_dir: ${{bld_project_dir}}/dist
+    exec:
+    - tar -czvf bld-x86_64-unknown-linux-musl.tar.gz bld
+    - sha256sum bld-x86_64-unknown-linux-musl.tar.gz | awk '{{ print $1 }}' >> SHA256

--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,4 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.0.1"
+tag_format = "$version"

--- a/.cz.toml
+++ b/.cz.toml
@@ -1,4 +1,8 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
+<<<<<<< HEAD
 version = "0.0.1"
+=======
+version = "0.2.1"
+>>>>>>> bfe1c32 (Bugfix/Wrong output of root dir keyword)
 tag_format = "$version"

--- a/.cz.toml
+++ b/.cz.toml
@@ -1,8 +1,15 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
 <<<<<<< HEAD
+<<<<<<< HEAD
 version = "0.0.1"
 =======
 version = "0.2.1"
 >>>>>>> bfe1c32 (Bugfix/Wrong output of root dir keyword)
+=======
+version = "0.2.1"
+=======
+version = "0.0.1"
+>>>>>>> 8ff3f10 (style(.cz.toml): Added .cz.toml configuration file)
+>>>>>>> b369ec3 (style(.cz.toml): Added .cz.toml configuration file)
 tag_format = "$version"

--- a/.cz.toml
+++ b/.cz.toml
@@ -1,15 +1,4 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-<<<<<<< HEAD
-<<<<<<< HEAD
-version = "0.0.1"
-=======
 version = "0.2.1"
->>>>>>> bfe1c32 (Bugfix/Wrong output of root dir keyword)
-=======
-version = "0.2.1"
-=======
-version = "0.0.1"
->>>>>>> 8ff3f10 (style(.cz.toml): Added .cz.toml configuration file)
->>>>>>> b369ec3 (style(.cz.toml): Added .cz.toml configuration file)
 tag_format = "$version"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vscode
 /.vimspector.json
 /dist
-/.bld
+/.bld/**/*
 !/.bld/config.yaml
 !/.bld/build-musl.yaml
+!/.bld/release.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bld"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bld_commands",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "bld_commands"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix",
  "actix-codec",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "bld_config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "openidconnect",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "bld_core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix",
  "actix-web",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "bld_runner"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix",
  "actix-codec",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "bld_server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix",
  "actix-codec",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "bld_sock"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix",
  "actix-codec",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "bld_supervisor"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix",
  "actix-codec",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "bld_utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[package]
+name = "bld"
+version = "0.2.1"
+authors = ["Kostas Vlachos <kvl_93@outlook.com>"]
+edition = "2021"
+
 [workspace]
 members = [
   "crates/bld_core",
@@ -9,12 +15,6 @@ members = [
   "crates/bld_server",
   "crates/bld_commands"
 ]
-
-[package]
-name = "bld"
-version = "0.2.0"
-authors = ["Kostas Vlachos <kvl_93@outlook.com>"]
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/bld_commands/Cargo.toml
+++ b/crates/bld_commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_commands"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_commands/src/cli.rs
+++ b/crates/bld_commands/src/cli.rs
@@ -3,6 +3,7 @@ use crate::cat::CatCommand;
 use crate::check::CheckCommand;
 use crate::command::BldCommand;
 use crate::config::ConfigCommand;
+use crate::copy::CopyCommand;
 use crate::edit::EditCommand;
 use crate::hist::HistCommand;
 use crate::init::InitCommand;
@@ -27,6 +28,7 @@ enum Commands {
     Cat(CatCommand),
     Check(CheckCommand),
     Config(ConfigCommand),
+    Cp(CopyCommand),
     Cron(CronCommand),
     Edit(EditCommand),
     Hist(HistCommand),
@@ -59,6 +61,7 @@ impl Cli {
             Commands::Cat(cat) => cat.invoke(),
             Commands::Check(check) => check.invoke(),
             Commands::Config(config) => config.invoke(),
+            Commands::Cp(copy) => copy.invoke(),
             Commands::Cron(cron) => cron.invoke(),
             Commands::Edit(edit) => edit.invoke(),
             Commands::Hist(hist) => hist.invoke(),

--- a/crates/bld_commands/src/cli.rs
+++ b/crates/bld_commands/src/cli.rs
@@ -11,6 +11,7 @@ use crate::list::ListCommand;
 use crate::monit::MonitCommand;
 use crate::pull::PullCommand;
 use crate::push::PushCommand;
+use crate::r#move::MoveCommand;
 use crate::remove::RemoveCommand;
 use crate::run::RunCommand;
 use crate::server::ServerCommand;
@@ -36,6 +37,7 @@ enum Commands {
     Add(AddCommand),
     Ls(ListCommand),
     Monit(MonitCommand),
+    Mv(MoveCommand),
     Pull(PullCommand),
     Push(PushCommand),
     Rm(RemoveCommand),
@@ -69,6 +71,7 @@ impl Cli {
             Commands::Add(add) => add.invoke(),
             Commands::Ls(list) => list.invoke(),
             Commands::Monit(monit) => monit.invoke(),
+            Commands::Mv(r#move) => r#move.invoke(),
             Commands::Pull(pull) => pull.invoke(),
             Commands::Push(push) => push.invoke(),
             Commands::Rm(remove) => remove.invoke(),

--- a/crates/bld_commands/src/copy/command.rs
+++ b/crates/bld_commands/src/copy/command.rs
@@ -1,6 +1,7 @@
+use actix::System;
 use anyhow::Result;
 use bld_config::BldConfig;
-use bld_core::proxies::PipelineFileSystemProxy;
+use bld_core::{proxies::PipelineFileSystemProxy, request::HttpClient};
 use bld_utils::sync::IntoArc;
 use clap::Args;
 
@@ -21,7 +22,7 @@ pub struct CopyCommand {
     #[arg(
         short = 's',
         long = "server",
-        help = "The name of the server to copy the pipeline"
+        help = "The name of the server to execute the copy operation"
     )]
     pub server: Option<String>,
 }
@@ -33,8 +34,12 @@ impl CopyCommand {
         proxy.copy(&self.pipeline, &self.target)
     }
 
-    fn remote_copy(&self, _srv: &str) -> Result<()> {
-        Ok(())
+    fn remote_copy(&self, server: &str) -> Result<()> {
+        System::new().block_on(async move {
+            let config = BldConfig::load()?.into_arc();
+            let client = HttpClient::new(config, server);
+            client.copy(&self.pipeline, &self.target).await
+        })
     }
 }
 

--- a/crates/bld_commands/src/copy/command.rs
+++ b/crates/bld_commands/src/copy/command.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use bld_config::BldConfig;
+use bld_core::proxies::PipelineFileSystemProxy;
+use bld_utils::sync::IntoArc;
+use clap::Args;
+
+use crate::command::BldCommand;
+
+#[derive(Args)]
+#[command(about = "Copy a source pipeline to a target location")]
+pub struct CopyCommand {
+    #[arg(long = "verbose", help = "Sets the level of verbosity")]
+    pub verbose: bool,
+
+    #[arg(short = 'p', long = "pipeline", help = "The pipeline to copy")]
+    pub pipeline: String,
+
+    #[arg(short = 't', long = "target", help = "The target path")]
+    pub target: String,
+
+    #[arg(
+        short = 's',
+        long = "server",
+        help = "The name of the server to copy the pipeline"
+    )]
+    pub server: Option<String>,
+}
+
+impl CopyCommand {
+    fn local_copy(&self) -> Result<()> {
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config);
+        proxy.copy(&self.pipeline, &self.target)
+    }
+
+    fn remote_copy(&self, _srv: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl BldCommand for CopyCommand {
+    fn verbose(&self) -> bool {
+        self.verbose
+    }
+
+    fn exec(self) -> Result<()> {
+        match self.server.as_ref() {
+            Some(srv) => self.remote_copy(srv),
+            None => self.local_copy(),
+        }
+    }
+}

--- a/crates/bld_commands/src/copy/mod.rs
+++ b/crates/bld_commands/src/copy/mod.rs
@@ -1,0 +1,3 @@
+mod command;
+
+pub use command::*;

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -2,7 +2,8 @@ use crate::command::BldCommand;
 use anyhow::{bail, Result};
 use bld_config::definitions::{
     default_client_config, default_server_config, DEFAULT_V2_PIPELINE_CONTENT, LOCAL_DB,
-    LOCAL_LOGS, LOCAL_SERVER_PIPELINES, TOOL_DEFAULT_CONFIG_FILE, TOOL_DEFAULT_PIPELINE, TOOL_DIR, TOOL_DEFAULT_PIPELINE_FILE,
+    LOCAL_LOGS, LOCAL_SERVER_PIPELINES, TOOL_DEFAULT_CONFIG_FILE, TOOL_DEFAULT_PIPELINE,
+    TOOL_DEFAULT_PIPELINE_FILE, TOOL_DIR,
 };
 use bld_config::path;
 use bld_utils::term::print_info;

--- a/crates/bld_commands/src/lib.rs
+++ b/crates/bld_commands/src/lib.rs
@@ -5,6 +5,7 @@ mod check;
 pub mod cli;
 pub mod command;
 mod config;
+mod copy;
 mod cron;
 mod edit;
 mod hist;

--- a/crates/bld_commands/src/lib.rs
+++ b/crates/bld_commands/src/lib.rs
@@ -12,6 +12,7 @@ mod hist;
 mod init;
 mod list;
 mod monit;
+mod r#move;
 mod pull;
 mod push;
 mod remove;

--- a/crates/bld_commands/src/move/command.rs
+++ b/crates/bld_commands/src/move/command.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use bld_config::BldConfig;
+use bld_core::proxies::PipelineFileSystemProxy;
+use bld_utils::sync::IntoArc;
+use clap::Args;
+
+use crate::command::BldCommand;
+
+#[derive(Args)]
+#[command(about = "Move a source pipeline to a target location")]
+pub struct MoveCommand {
+    #[arg(long = "verbose", help = "Sets the level of verbosity")]
+    pub verbose: bool,
+
+    #[arg(short = 'p', long = "pipeline", help = "The pipeline to move")]
+    pub pipeline: String,
+
+    #[arg(short = 't', long = "target", help = "The target path")]
+    pub target: String,
+
+    #[arg(
+        short = 's',
+        long = "server",
+        help = "The name of the server to execute the move operation"
+    )]
+    pub server: Option<String>,
+}
+
+impl MoveCommand {
+    fn local_move(&self) -> Result<()> {
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config);
+        proxy.mv(&self.pipeline, &self.target)
+    }
+
+    fn remote_move(&self, _srv: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl BldCommand for MoveCommand {
+    fn verbose(&self) -> bool {
+        self.verbose
+    }
+
+    fn exec(self) -> Result<()> {
+        match self.server.as_ref() {
+            Some(srv) => self.remote_move(srv),
+            None => self.local_move(),
+        }
+    }
+}

--- a/crates/bld_commands/src/move/mod.rs
+++ b/crates/bld_commands/src/move/mod.rs
@@ -1,0 +1,3 @@
+mod command;
+
+pub use command::*;

--- a/crates/bld_config/Cargo.toml
+++ b/crates/bld_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_config"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -1,4 +1,4 @@
-pub const VERSION: &str = "0.2";
+pub const VERSION: &str = "0.2.1";
 pub const TOOL_DIR: &str = ".bld";
 pub const DB_NAME: &str = "bld-server.db";
 pub const PUSH: &str = "push";

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -11,6 +11,7 @@ pub const KEYWORD_RUN_PROPS_ID_V1: &str = "bld:run:id";
 pub const KEYWORD_RUN_PROPS_START_TIME_V1: &str = "bld:run:start_time";
 
 pub const KEYWORD_BLD_DIR_V2: &str = "bld_root_dir";
+pub const KEYWORD_PROJECT_DIR_V2: &str = "bld_project_dir";
 pub const KEYWORD_RUN_PROPS_ID_V2: &str = "bld_run_id";
 pub const KEYWORD_RUN_PROPS_START_TIME_V2: &str = "bld_start_time";
 

--- a/crates/bld_core/Cargo.toml
+++ b/crates/bld_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_core/src/database/pipeline.rs
+++ b/crates/bld_core/src/database/pipeline.rs
@@ -25,6 +25,7 @@ struct InsertPipeline<'a> {
 pub fn select_all(conn: &mut SqliteConnection) -> Result<Vec<Pipeline>> {
     debug!("loading all pipelines from the database");
     pipeline
+        .order_by(name)
         .load(conn)
         .map(|p| {
             debug!("loaded all pipelines successfully");

--- a/crates/bld_core/src/database/pipeline.rs
+++ b/crates/bld_core/src/database/pipeline.rs
@@ -66,6 +66,19 @@ pub fn select_by_name(conn: &mut SqliteConnection, pip_name: &str) -> Result<Pip
         })
 }
 
+pub fn update_name(conn: &mut SqliteConnection, pip_id: &str, pip_name: &str) -> Result<()> {
+    debug!("updating pipeline with id: {pip_id} with new name: {pip_name}");
+    diesel::update(pipeline)
+        .set(name.eq(pip_name))
+        .filter(id.eq(pip_id))
+        .execute(conn)
+        .map(|_| debug!("pipeline updated successfully"))
+        .map_err(|e| {
+            error!("could not update pipeline due to {e}");
+            anyhow!(e)
+        })
+}
+
 pub fn insert(conn: &mut SqliteConnection, pip_id: &str, pip_name: &str) -> Result<Pipeline> {
     debug!("inserting new pipeline to the database");
     let model = InsertPipeline {

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -11,7 +11,7 @@ use diesel::{
 use std::{
     env::current_dir,
     fmt::Write as FmtWrite,
-    fs::{copy, create_dir_all, read_to_string, remove_file, rename, File},
+    fs::{copy, create_dir_all, read_to_string, remove_file, File},
     io::Write,
     path::PathBuf,
     process::{Command, ExitStatus},
@@ -190,6 +190,7 @@ impl PipelineFileSystemProxy {
         match self {
             Self::Local { .. } => {
                 let source_path = self.path(source)?;
+<<<<<<< HEAD
                 if !source_path.is_yaml() {
                     bail!("invalid source pipeline path");
                 }
@@ -239,6 +240,16 @@ impl PipelineFileSystemProxy {
                 let mut conn = pool.get()?;
                 let source_pipeline = pipeline::select_by_name(&mut conn, source)?;
                 if pipeline::select_by_name(&mut conn, target).is_ok() {
+=======
+                let target_path = self.path(target)?;
+                copy(source_path, target_path)?;
+                Ok(())
+            }
+            Self::Server { pool, .. } => {
+                let mut conn = pool.get()?;
+                let source_pipeline = pipeline::select_by_name(&mut conn, source)?;
+                let Err(_) = pipeline::select_by_name(&mut conn, target) else {
+>>>>>>> 2f70165 (feat(proxies): Added the copy method in the file system proxy)
                     bail!("target pipeline already exist");
                 };
                 pipeline::update_name(&mut conn, &source_pipeline.id, target)

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -171,10 +171,18 @@ impl PipelineFileSystemProxy {
     }
 
     pub fn copy(&self, source: &str, target: &str) -> Result<()> {
+        let source_path = self.path(source)?;
+        if !source_path.is_yaml() {
+            bail!("invalid source pipeline path");
+        }
+
+        let target_path = self.path(target)?;
+        if !target_path.valid_path() {
+            bail!("invalid target pipeline path");
+        }
+
         match self {
             Self::Local { .. } => {
-                let source_path = self.path(source)?;
-                let target_path = self.path(target)?;
                 copy(source_path, target_path)?;
                 Ok(())
             }
@@ -186,10 +194,18 @@ impl PipelineFileSystemProxy {
     }
 
     pub fn mv(&self, source: &str, target: &str) -> Result<()> {
+        let source_path = self.path(source)?;
+        if !source_path.is_yaml() {
+            bail!("invalid source pipeline path");
+        }
+
+        let target_path = self.path(target)?;
+        if !target_path.valid_path() {
+            bail!("invalid target pipeline path");
+        }
+
         match self {
             Self::Local { .. } => {
-                let source_path = self.path(source)?;
-                let target_path = self.path(target)?;
                 rename(source_path, target_path)?;
                 Ok(())
             }

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -193,16 +193,16 @@ impl PipelineFileSystemProxy {
                 if !source_path.is_yaml() {
                     bail!("invalid source pipeline path");
                 }
-
                 let target_path = self.path(target)?;
                 if !target_path.valid_path() {
                     bail!("invalid target pipeline path");
                 }
-
                 if target_path.is_yaml() {
                     bail!("target pipeline already exists");
                 }
-
+                if let Some(parent) = target_path.parent() {
+                    create_dir_all(parent)?;
+                }
                 copy(source_path, target_path)?;
                 Ok(())
             }
@@ -228,6 +228,9 @@ impl PipelineFileSystemProxy {
             Self::Local { .. } => {
                 if target_path.is_yaml() {
                     bail!("target pipeline already exist");
+                }
+                if let Some(parent) = target_path.parent() {
+                    create_dir_all(parent)?;
                 }
                 rename(source_path, target_path)?;
                 Ok(())

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -11,7 +11,7 @@ use diesel::{
 use std::{
     env::current_dir,
     fmt::Write as FmtWrite,
-    fs::{copy, create_dir_all, read_to_string, remove_file, File},
+    fs::{copy, create_dir_all, read_to_string, remove_file, rename, File},
     io::Write,
     path::PathBuf,
     process::{Command, ExitStatus},
@@ -190,7 +190,6 @@ impl PipelineFileSystemProxy {
         match self {
             Self::Local { .. } => {
                 let source_path = self.path(source)?;
-<<<<<<< HEAD
                 if !source_path.is_yaml() {
                     bail!("invalid source pipeline path");
                 }
@@ -240,16 +239,6 @@ impl PipelineFileSystemProxy {
                 let mut conn = pool.get()?;
                 let source_pipeline = pipeline::select_by_name(&mut conn, source)?;
                 if pipeline::select_by_name(&mut conn, target).is_ok() {
-=======
-                let target_path = self.path(target)?;
-                copy(source_path, target_path)?;
-                Ok(())
-            }
-            Self::Server { pool, .. } => {
-                let mut conn = pool.get()?;
-                let source_pipeline = pipeline::select_by_name(&mut conn, source)?;
-                let Err(_) = pipeline::select_by_name(&mut conn, target) else {
->>>>>>> 2f70165 (feat(proxies): Added the copy method in the file system proxy)
                     bail!("target pipeline already exist");
                 };
                 pipeline::update_name(&mut conn, &source_pipeline.id, target)

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -185,7 +185,7 @@ impl PipelineFileSystemProxy {
         }
     }
 
-    pub fn r#move(&self, source: &str, target: &str) -> Result<()> {
+    pub fn mv(&self, source: &str, target: &str) -> Result<()> {
         match self {
             Self::Local { .. } => {
                 let source_path = self.path(source)?;

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -171,18 +171,18 @@ impl PipelineFileSystemProxy {
     }
 
     pub fn copy(&self, source: &str, target: &str) -> Result<()> {
-        let source_path = self.path(source)?;
-        if !source_path.is_yaml() {
-            bail!("invalid source pipeline path");
-        }
-
-        let target_path = self.path(target)?;
-        if !target_path.valid_path() {
-            bail!("invalid target pipeline path");
-        }
-
         match self {
             Self::Local { .. } => {
+                let source_path = self.path(source)?;
+                if !source_path.is_yaml() {
+                    bail!("invalid source pipeline path");
+                }
+
+                let target_path = self.path(target)?;
+                if !target_path.valid_path() {
+                    bail!("invalid target pipeline path");
+                }
+
                 copy(source_path, target_path)?;
                 Ok(())
             }
@@ -194,18 +194,18 @@ impl PipelineFileSystemProxy {
     }
 
     pub fn mv(&self, source: &str, target: &str) -> Result<()> {
-        let source_path = self.path(source)?;
-        if !source_path.is_yaml() {
-            bail!("invalid source pipeline path");
-        }
-
-        let target_path = self.path(target)?;
-        if !target_path.valid_path() {
-            bail!("invalid target pipeline path");
-        }
-
         match self {
             Self::Local { .. } => {
+                let source_path = self.path(source)?;
+                if !source_path.is_yaml() {
+                    bail!("invalid source pipeline path");
+                }
+
+                let target_path = self.path(target)?;
+                if !target_path.valid_path() {
+                    bail!("invalid target pipeline path");
+                }
+
                 rename(source_path, target_path)?;
                 Ok(())
             }

--- a/crates/bld_core/src/requests/common.rs
+++ b/crates/bld_core/src/requests/common.rs
@@ -12,3 +12,18 @@ impl PipelineQueryParams {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipelinePathRequest {
+    pub pipeline: String,
+    pub target: String,
+}
+
+impl PipelinePathRequest {
+    pub fn new(pipeline: &str, target: &str) -> Self {
+        Self {
+            pipeline: pipeline.to_string(),
+            target: target.to_string(),
+        }
+    }
+}

--- a/crates/bld_runner/Cargo.toml
+++ b/crates/bld_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_runner"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_runner/src/sync/builder.rs
+++ b/crates/bld_runner/src/sync/builder.rs
@@ -187,7 +187,8 @@ impl RunnerBuilder {
 
             VersionedPipeline::Version2(mut pipeline) => {
                 let pipeline_context = PipelineContextBuilder::default()
-                    .bld_directory(&config.path)
+                    .root_dir(&config.root_dir)
+                    .project_dir(&config.project_dir)
                     .add_variables(&pipeline.variables)
                     .add_variables(&vars)
                     .add_environment(&pipeline.environment)

--- a/crates/bld_runner/src/validator/v2.rs
+++ b/crates/bld_runner/src/validator/v2.rs
@@ -93,10 +93,7 @@ impl<'a> PipelineValidator<'a> {
 
     fn validate_keywords(&mut self, section: &str, name: &'a str) {
         if self.keywords.contains(name) {
-            let _ = writeln!(
-                self.errors,
-                "[{section}] Invalid name, reserved as keyword",
-            );
+            let _ = writeln!(self.errors, "[{section}] Invalid name, reserved as keyword",);
         }
     }
 

--- a/crates/bld_runner/src/validator/v2.rs
+++ b/crates/bld_runner/src/validator/v2.rs
@@ -3,7 +3,8 @@ use crate::platform::v2::Platform;
 use crate::step::v2::{BuildStep, BuildStepExec};
 use anyhow::{bail, Result};
 use bld_config::definitions::{
-    KEYWORD_BLD_DIR_V2, KEYWORD_RUN_PROPS_ID_V2, KEYWORD_RUN_PROPS_START_TIME_V2,
+    KEYWORD_BLD_DIR_V2, KEYWORD_PROJECT_DIR_V2, KEYWORD_RUN_PROPS_ID_V2,
+    KEYWORD_RUN_PROPS_START_TIME_V2,
 };
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
@@ -49,6 +50,7 @@ impl<'a> PipelineValidator<'a> {
     fn prepare_keywords() -> HashSet<&'a str> {
         let mut keywords = HashSet::new();
         keywords.insert(KEYWORD_BLD_DIR_V2);
+        keywords.insert(KEYWORD_PROJECT_DIR_V2);
         keywords.insert(KEYWORD_RUN_PROPS_ID_V2);
         keywords.insert(KEYWORD_RUN_PROPS_START_TIME_V2);
         keywords
@@ -57,6 +59,7 @@ impl<'a> PipelineValidator<'a> {
     fn prepare_symbols(pipeline: &'a Pipeline) -> HashSet<&'a str> {
         let mut symbols = HashSet::new();
         symbols.insert(KEYWORD_BLD_DIR_V2);
+        symbols.insert(KEYWORD_PROJECT_DIR_V2);
         symbols.insert(KEYWORD_RUN_PROPS_ID_V2);
         symbols.insert(KEYWORD_RUN_PROPS_START_TIME_V2);
 

--- a/crates/bld_server/Cargo.toml
+++ b/crates/bld_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_server/src/endpoints/copy.rs
+++ b/crates/bld_server/src/endpoints/copy.rs
@@ -1,0 +1,22 @@
+use actix_web::{
+    post,
+    web::{Data, Json},
+    HttpResponse, Responder,
+};
+use bld_core::{proxies::PipelineFileSystemProxy, requests::PipelinePathRequest};
+use tracing::info;
+
+use crate::extractors::User;
+
+#[post("/copy")]
+pub async fn post(
+    _user: User,
+    proxy: Data<PipelineFileSystemProxy>,
+    body: Json<PipelinePathRequest>,
+) -> impl Responder {
+    info!("Reached handler for /copy route");
+    match proxy.copy(&body.pipeline, &body.target) {
+        Ok(_) => HttpResponse::Ok().body(""),
+        Err(e) => HttpResponse::BadRequest().body(e.to_string()),
+    }
+}

--- a/crates/bld_server/src/endpoints/copy.rs
+++ b/crates/bld_server/src/endpoints/copy.rs
@@ -16,7 +16,7 @@ pub async fn post(
 ) -> impl Responder {
     info!("Reached handler for /copy route");
     match proxy.copy(&body.pipeline, &body.target) {
-        Ok(_) => HttpResponse::Ok().body(""),
+        Ok(_) => HttpResponse::Ok().json(""),
         Err(e) => HttpResponse::BadRequest().body(e.to_string()),
     }
 }

--- a/crates/bld_server/src/endpoints/mod.rs
+++ b/crates/bld_server/src/endpoints/mod.rs
@@ -1,10 +1,12 @@
 pub mod auth;
 pub mod check;
+pub mod copy;
 pub mod cron;
 pub mod deps;
 pub mod hist;
 pub mod home;
 pub mod list;
+pub mod r#move;
 pub mod print;
 pub mod pull;
 pub mod push;

--- a/crates/bld_server/src/endpoints/move.rs
+++ b/crates/bld_server/src/endpoints/move.rs
@@ -16,7 +16,7 @@ pub async fn patch(
 ) -> impl Responder {
     info!("Reached handler for /move route");
     match proxy.mv(&body.pipeline, &body.target) {
-        Ok(_) => HttpResponse::Ok().body(""),
+        Ok(_) => HttpResponse::Ok().json(""),
         Err(e) => HttpResponse::BadRequest().body(e.to_string()),
     }
 }

--- a/crates/bld_server/src/endpoints/move.rs
+++ b/crates/bld_server/src/endpoints/move.rs
@@ -1,0 +1,22 @@
+use actix_web::{
+    patch,
+    web::{Data, Json},
+    HttpResponse, Responder,
+};
+use bld_core::{proxies::PipelineFileSystemProxy, requests::PipelinePathRequest};
+use tracing::info;
+
+use crate::extractors::User;
+
+#[patch("/move")]
+pub async fn patch(
+    _user: User,
+    proxy: Data<PipelineFileSystemProxy>,
+    body: Json<PipelinePathRequest>,
+) -> impl Responder {
+    info!("Reached handler for /move route");
+    match proxy.mv(&body.pipeline, &body.target) {
+        Ok(_) => HttpResponse::Ok().body(""),
+        Err(e) => HttpResponse::BadRequest().body(e.to_string()),
+    }
+}

--- a/crates/bld_server/src/server.rs
+++ b/crates/bld_server/src/server.rs
@@ -1,6 +1,7 @@
 use crate::cron::CronScheduler;
 use crate::endpoints::{
-    auth, check, cron, deps, hist, home, list, print, pull, push, remove, run, stop,
+    auth, check, copy, cron, deps, hist, home, list, print, pull, push, remove, run, stop,
+    r#move
 };
 use crate::sockets::{exec, login, monit};
 use crate::supervisor::channel::SupervisorMessageSender;
@@ -52,6 +53,7 @@ pub async fn start(config: BldConfig, host: String, port: i64) -> Result<()> {
             .service(auth::redirect)
             .service(auth::refresh)
             .service(check::get)
+            .service(copy::post)
             .service(hist::get)
             .service(list::get)
             .service(remove::delete)
@@ -60,6 +62,7 @@ pub async fn start(config: BldConfig, host: String, port: i64) -> Result<()> {
             .service(deps::get)
             .service(pull::get)
             .service(stop::post)
+            .service(r#move::patch)
             .service(print::get)
             .service(cron::get)
             .service(cron::post)

--- a/crates/bld_server/src/server.rs
+++ b/crates/bld_server/src/server.rs
@@ -1,7 +1,6 @@
 use crate::cron::CronScheduler;
 use crate::endpoints::{
-    auth, check, copy, cron, deps, hist, home, list, print, pull, push, remove, run, stop,
-    r#move
+    auth, check, copy, cron, deps, hist, home, list, print, pull, push, r#move, remove, run, stop,
 };
 use crate::sockets::{exec, login, monit};
 use crate::supervisor::channel::SupervisorMessageSender;

--- a/crates/bld_sock/Cargo.toml
+++ b/crates/bld_sock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_sock"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_supervisor/Cargo.toml
+++ b/crates/bld_supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_supervisor"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_utils/Cargo.toml
+++ b/crates/bld_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_utils"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
In this PR:
- Extended the PipelineFileSystemProxy struct with the copy and mv methods.
- Added the cp and mv subcommands.
- Added new endpoints for the server in order to copy and move pipeline files.