### PR TITLE
Search for bld directory in parent directories

### DIFF
--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -57,7 +57,7 @@ impl AddCommand {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
             let proxy = PipelineFileSystemProxy::local(config.clone());
-            let client = HttpClient::new(config, server);
+            let client = HttpClient::new(config, server)?;
             let tmp_name = format!("{}.yaml", Uuid::new_v4());
 
             println!("Creating temporary local pipeline {}", tmp_name);

--- a/crates/bld_commands/src/auth/command.rs
+++ b/crates/bld_commands/src/auth/command.rs
@@ -29,12 +29,13 @@ pub struct AuthCommand {
 impl AuthCommand {
     async fn login(config: Arc<BldConfig>, server: String) -> Result<()> {
         let server = config.server(&server)?;
+        let auth_path = config.auth_full_path(&server.name);
         let url = format!("{}/ws-login/", server.base_url_ws());
 
         debug!("establishing web socket connection on {}", url);
 
         let (_, framed) = WebSocket::new(&url)?
-            .auth(config.clone(), server)
+            .auth(&auth_path)
             .request()
             .connect()
             .await

--- a/crates/bld_commands/src/cat/command.rs
+++ b/crates/bld_commands/src/cat/command.rs
@@ -40,7 +40,7 @@ impl CatCommand {
     fn remote_print(&self, server: &str) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
-            HttpClient::new(config, server)
+            HttpClient::new(config, server)?
                 .print(&self.pipeline)
                 .await
                 .map(|r| println!("{r}"))

--- a/crates/bld_commands/src/check/command.rs
+++ b/crates/bld_commands/src/check/command.rs
@@ -37,7 +37,7 @@ impl CheckCommand {
     fn remote_check(&self, server: &str) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
-            HttpClient::new(config, server).check(&self.pipeline).await
+            HttpClient::new(config, server)?.check(&self.pipeline).await
         })
     }
 }

--- a/crates/bld_commands/src/copy/command.rs
+++ b/crates/bld_commands/src/copy/command.rs
@@ -37,7 +37,7 @@ impl CopyCommand {
     fn remote_copy(&self, server: &str) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
-            let client = HttpClient::new(config, server);
+            let client = HttpClient::new(config, server)?;
             client.copy(&self.pipeline, &self.target).await
         })
     }

--- a/crates/bld_commands/src/cron/add.rs
+++ b/crates/bld_commands/src/cron/add.rs
@@ -55,7 +55,7 @@ impl BldCommand for CronAddCommand {
 
     fn exec(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server);
+        let client = HttpClient::new(config, &self.server)?;
         let variables = Some(parse_variables(&self.variables));
         let environment = Some(parse_variables(&self.environment));
         let request =

--- a/crates/bld_commands/src/cron/cat.rs
+++ b/crates/bld_commands/src/cron/cat.rs
@@ -32,7 +32,7 @@ impl BldCommand for CronCatCommand {
 
     fn exec(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server);
+        let client = HttpClient::new(config, &self.server)?;
         let filters = JobFiltersParams::new(Some(self.id), None, None, None, None);
         let response = System::new().block_on(async move { client.cron_list(&filters).await })?;
 

--- a/crates/bld_commands/src/cron/list.rs
+++ b/crates/bld_commands/src/cron/list.rs
@@ -65,7 +65,7 @@ impl BldCommand for CronListCommand {
 
     fn exec(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server);
+        let client = HttpClient::new(config, &self.server)?;
         let filters = JobFiltersParams::new(
             self.id,
             self.pipeline,

--- a/crates/bld_commands/src/cron/remove.rs
+++ b/crates/bld_commands/src/cron/remove.rs
@@ -30,7 +30,7 @@ impl BldCommand for CronRemoveCommand {
 
     fn exec(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server);
+        let client = HttpClient::new(config, &self.server)?;
         System::new().block_on(async move { client.cron_remove(&self.cron_job_id).await })
     }
 }

--- a/crates/bld_commands/src/cron/update.rs
+++ b/crates/bld_commands/src/cron/update.rs
@@ -51,7 +51,7 @@ impl BldCommand for CronUpdateCommand {
 
     fn exec(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server);
+        let client = HttpClient::new(config, &self.server)?;
         let variables = Some(parse_variables(&self.variables));
         let environment = Some(parse_variables(&self.environment));
         let update_job = UpdateJobRequest::new(self.id, self.schedule, variables, environment);

--- a/crates/bld_commands/src/edit/command.rs
+++ b/crates/bld_commands/src/edit/command.rs
@@ -36,7 +36,7 @@ impl EditCommand {
     fn remote_edit(&self, server: &str) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
-            let client = HttpClient::new(config.clone(), server);
+            let client = HttpClient::new(config.clone(), server)?;
             let proxy = PipelineFileSystemProxy::local(config);
             println!("Pulling pipline {}", self.pipeline);
 

--- a/crates/bld_commands/src/hist/command.rs
+++ b/crates/bld_commands/src/hist/command.rs
@@ -65,7 +65,7 @@ impl BldCommand for HistCommand {
                 self.server, self.limit,
             );
 
-            let history = HttpClient::new(config, &self.server)
+            let history = HttpClient::new(config, &self.server)?
                 .hist(state, self.pipeline, self.limit)
                 .await?;
 

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -79,7 +79,7 @@ fn create_build_dir() -> Result<()> {
 
 fn create_logs_dir(is_server: bool) -> Result<()> {
     if is_server {
-        let path = Path::new(LOCAL_LOGS);
+        let path = path![TOOL_DIR, LOCAL_LOGS];
         create_dir(path)?;
         print_dir_created(LOCAL_LOGS)?;
     }
@@ -88,7 +88,7 @@ fn create_logs_dir(is_server: bool) -> Result<()> {
 
 fn create_db_dir(is_server: bool) -> Result<()> {
     if is_server {
-        let path = Path::new(LOCAL_DB);
+        let path = path![TOOL_DIR, LOCAL_DB];
         create_dir(path)?;
         print_dir_created(LOCAL_DB)?;
     }
@@ -97,7 +97,7 @@ fn create_db_dir(is_server: bool) -> Result<()> {
 
 fn create_server_pipelines_dir(is_server: bool) -> Result<()> {
     if is_server {
-        let path = Path::new(LOCAL_SERVER_PIPELINES);
+        let path = path![TOOL_DIR, LOCAL_SERVER_PIPELINES];
         create_dir(path)?;
         print_dir_created(LOCAL_SERVER_PIPELINES)?;
     }

--- a/crates/bld_commands/src/list/command.rs
+++ b/crates/bld_commands/src/list/command.rs
@@ -32,7 +32,7 @@ impl ListCommand {
     fn remote_list(&self, server: &str) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
-            HttpClient::new(config, server)
+            HttpClient::new(config, server)?
                 .list()
                 .await
                 .map(|r| println!("{r}"))

--- a/crates/bld_commands/src/move/command.rs
+++ b/crates/bld_commands/src/move/command.rs
@@ -37,8 +37,9 @@ impl MoveCommand {
     fn remote_move(&self, server: &str) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
-            let client = HttpClient::new(config, server);
-            client.mv(&self.pipeline, &self.target).await
+            HttpClient::new(config, server)?
+                .mv(&self.pipeline, &self.target)
+                .await
         })
     }
 }

--- a/crates/bld_commands/src/pull/command.rs
+++ b/crates/bld_commands/src/pull/command.rs
@@ -39,7 +39,7 @@ pub struct PullCommand {
 impl PullCommand {
     async fn request(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config.clone(), &self.server);
+        let client = HttpClient::new(config.clone(), &self.server)?;
         let proxy = PipelineFileSystemProxy::local(config);
 
         debug!(

--- a/crates/bld_commands/src/push/command.rs
+++ b/crates/bld_commands/src/push/command.rs
@@ -39,7 +39,7 @@ pub struct PushCommand {
 impl PushCommand {
     async fn push(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config.clone(), &self.server);
+        let client = HttpClient::new(config.clone(), &self.server)?;
         let proxy = PipelineFileSystemProxy::local(config.clone());
 
         debug!(

--- a/crates/bld_commands/src/push/command.rs
+++ b/crates/bld_commands/src/push/command.rs
@@ -40,7 +40,7 @@ impl PushCommand {
     async fn push(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
         let client = HttpClient::new(config.clone(), &self.server);
-        let proxy = PipelineFileSystemProxy::local(config);
+        let proxy = PipelineFileSystemProxy::local(config.clone());
 
         debug!(
             "running push subcommand with --server: {} and --pipeline: {}",
@@ -52,7 +52,7 @@ impl PushCommand {
         if !self.ignore_deps {
             print!("Resolving dependecies...");
 
-            let mut deps = VersionedPipeline::dependencies(&proxy, &self.pipeline)
+            let mut deps = VersionedPipeline::dependencies(&config, &proxy, &self.pipeline)
                 .map(|pips| {
                     println!("Done.");
                     pips

--- a/crates/bld_commands/src/remove/command.rs
+++ b/crates/bld_commands/src/remove/command.rs
@@ -33,7 +33,7 @@ impl RemoveCommand {
 
     fn remote_remove(&self, server: &str) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, server);
+        let client = HttpClient::new(config, server)?;
 
         debug!(
             "running remove subcommand with --server: {:?} and --pipeline: {}",

--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -221,6 +221,7 @@ impl RunAdapter {
 
     async fn run_web_socket(mode: WebSocketRequest) -> Result<()> {
         let server = mode.config.server(&mode.server)?;
+        let auth_path = mode.config.auth_full_path(&server.name);
         let url = format!("{}/ws-exec/", server.base_url_ws());
         let data = ExecClientMessage::EnqueueRun {
             name: mode.pipeline,
@@ -228,7 +229,7 @@ impl RunAdapter {
             variables: Some(mode.variables),
         };
 
-        let web_socket = WebSocket::new(&url)?.auth(mode.config.clone(), server);
+        let web_socket = WebSocket::new(&url)?.auth(&auth_path);
 
         let (_, framed) = web_socket
             .request()
@@ -259,7 +260,7 @@ impl RunAdapter {
     }
 
     async fn run_http(mode: HttpRequest) -> Result<()> {
-        HttpClient::new(mode.config, &mode.server)
+        HttpClient::new(mode.config, &mode.server)?
             .run(&mode.pipeline, Some(mode.environment), Some(mode.variables))
             .await
             .map(|_| println!("pipeline has been scheduled to run"))

--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -5,6 +5,7 @@ use bld_config::BldConfig;
 use bld_core::context::ContextSender;
 use bld_core::logger::LoggerSender;
 use bld_core::messages::ExecClientMessage;
+use bld_core::proxies::PipelineFileSystemProxy;
 use bld_core::request::{HttpClient, WebSocket};
 use bld_runner::RunnerBuilder;
 use bld_sock::clients::ExecClient;
@@ -201,6 +202,7 @@ impl RunAdapter {
 
         let runner = RunnerBuilder::default()
             .config(mode.config.clone())
+            .proxy(PipelineFileSystemProxy::local(mode.config.clone()).into_arc())
             .pipeline(&mode.pipeline)
             .logger(LoggerSender::shell().into_arc())
             .context(ContextSender::local(mode.config.clone()).into_arc())

--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -228,7 +228,7 @@ impl RunAdapter {
             variables: Some(mode.variables),
         };
 
-        let web_socket = WebSocket::new(&url)?.auth(server);
+        let web_socket = WebSocket::new(&url)?.auth(mode.config.clone(), server);
 
         let (_, framed) = web_socket
             .request()

--- a/crates/bld_commands/src/stop/command.rs
+++ b/crates/bld_commands/src/stop/command.rs
@@ -35,7 +35,7 @@ impl BldCommand for StopCommand {
 
     fn exec(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server);
+        let client = HttpClient::new(config, &self.server)?;
         System::new().block_on(async move { client.stop(&self.pipeline_id).await })
     }
 }

--- a/crates/bld_commands/src/worker/command.rs
+++ b/crates/bld_commands/src/worker/command.rs
@@ -75,7 +75,7 @@ impl BldCommand for WorkerCommand {
         let variables = parse_variables(&self.variables).into_arc();
         let environment = parse_variables(&self.environment).into_arc();
 
-        let pool = new_connection_pool(&config.local.db)?.into_arc();
+        let pool = new_connection_pool(config.clone())?.into_arc();
         let mut conn = pool.get()?;
         let pipeline_run = pipeline_runs::select_by_id(&mut conn, &run_id)?;
         let start_date_time = pipeline_run.start_date_time;

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -22,20 +22,20 @@ pub const TOOL_DEFAULT_CONFIG_FILE: &str = "config.yaml";
 
 pub const LOCAL_SERVER_HOST: &str = "127.0.0.1";
 pub const LOCAL_SERVER_PORT: i64 = 6080;
-pub const LOCAL_SERVER_PIPELINES: &str = ".bld/server_pipelines";
+pub const LOCAL_SERVER_PIPELINES: &str = "server_pipelines";
 pub const LOCAL_SUPERVISOR_HOST: &str = "127.0.0.1";
 pub const LOCAL_SUPERVISOR_PORT: i64 = 7080;
 pub const LOCAL_SUPERVISOR_WORKERS: i64 = 5;
 pub const LOCAL_HA_MODE: bool = false;
-pub const LOCAL_LOGS: &str = ".bld/logs";
-pub const LOCAL_DB: &str = ".bld/db";
+pub const LOCAL_LOGS: &str = "logs";
+pub const LOCAL_DB: &str = "db";
 pub const LOCAL_DOCKER_URL: &str = "tcp://127.0.0.1:2376";
-pub const LOCAL_MACHINE_TMP_DIR: &str = ".bld/tmp";
+pub const LOCAL_MACHINE_TMP_DIR: &str = "tmp";
 
 pub const REMOTE_SERVER_NAME: &str = "demo_server";
 pub const REMOTE_SERVER_HOST: &str = "127.0.0.1";
 pub const REMOTE_SERVER_PORT: i64 = 6080;
-pub const REMOTE_SERVER_AUTH: &str = ".bld/auth";
+pub const REMOTE_SERVER_AUTH: &str = "auth";
 
 pub const DEFAULT_EDITOR: &str = "vi";
 

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -135,6 +135,10 @@ impl BldConfig {
         path![&self.root_dir, REMOTE_SERVER_AUTH, server]
     }
 
+    pub fn server_auth_full_path(&self, server: &str) -> Result<PathBuf> {
+        self.server(server).map(|s| self.auth_full_path(&s.name))
+    }
+
     pub fn config_full_path(&self) -> PathBuf {
         path![&self.root_dir, TOOL_DEFAULT_CONFIG_FILE]
     }

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -21,7 +21,9 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use tracing::debug;
 
-use crate::definitions::{LOCAL_MACHINE_TMP_DIR, TOOL_DEFAULT_CONFIG_FILE};
+use crate::definitions::{
+    DB_NAME, LOCAL_MACHINE_TMP_DIR, REMOTE_SERVER_AUTH, TOOL_DEFAULT_CONFIG_FILE,
+};
 
 pub fn err_server_not_in_config() -> Error {
     anyhow!("server not found in config")
@@ -119,6 +121,18 @@ impl BldConfig {
 
     pub fn server_pipelines(&self) -> PathBuf {
         path![&self.root_dir, &self.local.server.pipelines]
+    }
+
+    pub fn log_full_path(&self, id: &str) -> PathBuf {
+        path![&self.root_dir, &self.local.logs, id]
+    }
+
+    pub fn db_full_path(&self) -> PathBuf {
+        path![&self.root_dir, &self.local.db, DB_NAME]
+    }
+
+    pub fn auth_full_path(&self, server: &str) -> PathBuf {
+        path![&self.root_dir, REMOTE_SERVER_AUTH, server]
     }
 
     pub fn config_full_path(&self) -> PathBuf {

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -46,11 +46,24 @@ pub struct BldConfig {
 
 impl BldConfig {
     pub fn path() -> Result<PathBuf> {
-        Ok(path![
-            current_dir()?,
-            definitions::TOOL_DIR,
-            format!("{}.yaml", definitions::TOOL_DEFAULT_CONFIG)
-        ])
+        let mut current = current_dir()?;
+        loop {
+            let cfg_file = path![
+                &current,
+                definitions::TOOL_DIR,
+                format!("{}.yaml", definitions::TOOL_DEFAULT_CONFIG)
+            ];
+
+            if !cfg_file.exists() {
+                current = current
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .ok_or_else(|| anyhow!(".bld directory not found"))?;
+                continue;
+            }
+
+            return Ok(cfg_file);
+        }
     }
 
     pub fn load() -> Result<Self> {

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -21,6 +21,8 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use tracing::debug;
 
+use crate::definitions::{LOCAL_MACHINE_TMP_DIR, TOOL_DEFAULT_CONFIG_FILE};
+
 pub fn err_server_not_in_config() -> Error {
     anyhow!("server not found in config")
 }
@@ -113,5 +115,21 @@ impl BldConfig {
         } else {
             Ok(None)
         }
+    }
+
+    pub fn server_pipelines(&self) -> PathBuf {
+        path![&self.root_dir, &self.local.server.pipelines]
+    }
+
+    pub fn config_full_path(&self) -> PathBuf {
+        path![&self.root_dir, TOOL_DEFAULT_CONFIG_FILE]
+    }
+
+    pub fn full_path(&self, name: &str) -> PathBuf {
+        path![&self.root_dir, name]
+    }
+
+    pub fn tmp_full_path(&self, name: &str) -> PathBuf {
+        path![&self.root_dir, LOCAL_MACHINE_TMP_DIR, name]
     }
 }

--- a/crates/bld_core/src/auth/mod.rs
+++ b/crates/bld_core/src/auth/mod.rs
@@ -2,13 +2,12 @@ use std::{
     collections::HashMap,
     fs::{create_dir_all, remove_file, File},
     io::{Read, Write},
-    path::PathBuf,
     sync::Arc,
 };
 
 use actix_web::rt::spawn;
 use anyhow::{anyhow, bail, Result};
-use bld_config::{definitions::REMOTE_SERVER_AUTH, path, BldConfig};
+use bld_config::BldConfig;
 use serde_derive::{Deserialize, Serialize};
 use tokio::sync::{
     mpsc::{channel, Receiver, Sender},
@@ -129,7 +128,7 @@ impl RefreshTokenParams {
 }
 
 pub fn read_tokens(config: Arc<BldConfig>, server: &str) -> Result<AuthTokens> {
-    let path = path![&config.root_dir, REMOTE_SERVER_AUTH, server];
+    let path = config.auth_full_path(server);
 
     if !path.is_file() {
         bail!("file not found");
@@ -141,7 +140,7 @@ pub fn read_tokens(config: Arc<BldConfig>, server: &str) -> Result<AuthTokens> {
 }
 
 pub fn write_tokens(config: Arc<BldConfig>, server: &str, tokens: AuthTokens) -> Result<()> {
-    let mut path = path![&config.root_dir, REMOTE_SERVER_AUTH];
+    let mut path = config.auth_full_path(server);
 
     create_dir_all(&path)?;
 

--- a/crates/bld_core/src/context/mod.rs
+++ b/crates/bld_core/src/context/mod.rs
@@ -287,7 +287,7 @@ impl Context {
         let url = format!("{}/stop", server.base_url_http());
 
         let _: String = Request::post(&url)
-            .auth(server)
+            .auth(config.clone(), server)
             .send_json(&run.run_id)
             .await?;
 

--- a/crates/bld_core/src/context/mod.rs
+++ b/crates/bld_core/src/context/mod.rs
@@ -284,10 +284,11 @@ impl Context {
 
     async fn cleanup_remote_run(config: Arc<BldConfig>, run: &RemoteRun) -> Result<()> {
         let server = config.server(&run.server)?;
+        let auth_path = config.auth_full_path(&server.name);
         let url = format!("{}/stop", server.base_url_http());
 
         let _: String = Request::post(&url)
-            .auth(config.clone(), server)
+            .auth(&auth_path)
             .send_json(&run.run_id)
             .await?;
 

--- a/crates/bld_core/src/database/connect.rs
+++ b/crates/bld_core/src/database/connect.rs
@@ -1,13 +1,11 @@
 use crate::database::run_migrations;
 use anyhow::Result;
-use bld_config::definitions::DB_NAME;
-use bld_config::{path, BldConfig};
+use bld_config::BldConfig;
 use diesel::connection::SimpleConnection;
 use diesel::r2d2::{ConnectionManager, CustomizeConnection, Error, Pool};
 use diesel::result::Error as DieselError;
 use diesel::sqlite::SqliteConnection;
 use std::fmt::Write;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error};
@@ -50,9 +48,7 @@ impl CustomizeConnection<SqliteConnection, Error> for SqliteConnectionOptions {
 pub fn new_connection_pool(
     config: Arc<BldConfig>,
 ) -> Result<Pool<ConnectionManager<SqliteConnection>>> {
-    let path = path![&config.root_dir, &config.local.db, DB_NAME]
-        .display()
-        .to_string();
+    let path = config.db_full_path().display().to_string();
 
     debug!("creating sqlite connection pool");
 

--- a/crates/bld_core/src/logger/mod.rs
+++ b/crates/bld_core/src/logger/mod.rs
@@ -53,7 +53,7 @@ impl LoggerReceiver {
     }
 
     pub fn file(config: Arc<BldConfig>, run_id: &str) -> Result<Self> {
-        let path = path![&config.local.logs, run_id];
+        let path = path![&config.root_dir, &config.local.logs, run_id];
         Ok(Self::File {
             handle: if path.is_file() {
                 File::open(&path)?

--- a/crates/bld_core/src/logger/mod.rs
+++ b/crates/bld_core/src/logger/mod.rs
@@ -1,8 +1,8 @@
-use std::{fmt::Write as FormatWrite, fs::File, io::Read, io::Write, path::PathBuf, sync::Arc};
+use std::{fmt::Write as FormatWrite, fs::File, io::Read, io::Write, sync::Arc};
 
 use actix_web::rt::spawn;
 use anyhow::{anyhow, Result};
-use bld_config::{path, BldConfig};
+use bld_config::BldConfig;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use tokio::sync::{
     mpsc::{channel, Receiver, Sender},
@@ -53,7 +53,7 @@ impl LoggerReceiver {
     }
 
     pub fn file(config: Arc<BldConfig>, run_id: &str) -> Result<Self> {
-        let path = path![&config.root_dir, &config.local.logs, run_id];
+        let path = config.log_full_path(run_id);
         Ok(Self::File {
             handle: if path.is_file() {
                 File::open(&path)?

--- a/crates/bld_core/src/platform/machine.rs
+++ b/crates/bld_core/src/platform/machine.rs
@@ -1,7 +1,6 @@
 use crate::logger::LoggerSender;
-use crate::proxies::PipelineFileSystemProxy;
 use anyhow::{bail, Result};
-use bld_config::{os_name, path, OSname};
+use bld_config::{os_name, path, OSname, BldConfig};
 use std::{
     collections::HashMap,
     fmt::Write,
@@ -19,11 +18,11 @@ pub struct Machine {
 impl Machine {
     pub fn new(
         id: &str,
-        proxy: Arc<PipelineFileSystemProxy>,
+        config: Arc<BldConfig>,
         pipeline_env: &HashMap<String, String>,
         env: Arc<HashMap<String, String>>,
     ) -> Result<Self> {
-        let tmp_path = proxy.tmp_path(id)?;
+        let tmp_path = config.tmp_full_path(id);
         if !tmp_path.is_dir() {
             create_dir_all(&tmp_path)?;
         }

--- a/crates/bld_core/src/platform/machine.rs
+++ b/crates/bld_core/src/platform/machine.rs
@@ -1,14 +1,15 @@
 use crate::logger::LoggerSender;
+use crate::proxies::PipelineFileSystemProxy;
 use anyhow::{bail, Result};
-use bld_config::definitions::LOCAL_MACHINE_TMP_DIR;
 use bld_config::{os_name, path, OSname};
-use std::collections::HashMap;
-use std::env::current_dir;
-use std::fmt::Write;
-use std::fs::{copy, create_dir_all, remove_dir_all};
-use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    fmt::Write,
+    fs::{copy, create_dir_all, remove_dir_all},
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus},
+    sync::Arc,
+};
 
 pub struct Machine {
     tmp_dir: String,
@@ -18,16 +19,16 @@ pub struct Machine {
 impl Machine {
     pub fn new(
         id: &str,
+        proxy: Arc<PipelineFileSystemProxy>,
         pipeline_env: &HashMap<String, String>,
         env: Arc<HashMap<String, String>>,
     ) -> Result<Self> {
-        let tmp_path = path![current_dir()?, LOCAL_MACHINE_TMP_DIR, id];
-        let tmp_dir = tmp_path.display().to_string();
+        let tmp_path = proxy.tmp_path(id)?;
         if !tmp_path.is_dir() {
-            create_dir_all(tmp_path)?;
+            create_dir_all(&tmp_path)?;
         }
         Ok(Self {
-            tmp_dir,
+            tmp_dir: tmp_path.display().to_string(),
             env: Self::create_environment(pipeline_env, env),
         })
     }

--- a/crates/bld_core/src/platform/machine.rs
+++ b/crates/bld_core/src/platform/machine.rs
@@ -1,6 +1,6 @@
 use crate::logger::LoggerSender;
 use anyhow::{bail, Result};
-use bld_config::{os_name, path, OSname, BldConfig};
+use bld_config::{os_name, path, BldConfig, OSname};
 use std::{
     collections::HashMap,
     fmt::Write,

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -52,8 +52,8 @@ impl PipelineFileSystemProxy {
     }
 
     fn local_path(&self, name: &str) -> Result<PathBuf> {
-        let Self::Local { config } = self else {
-            bail!("local path isn't supported for a server proxy");
+        let config = match self {
+            Self::Local { config } | Self::Server { config, .. } => config,
         };
         Ok(path![&config.root_dir, name])
     }
@@ -77,6 +77,7 @@ impl PipelineFileSystemProxy {
             bail!("pipeline path isn't supported for a local proxy");
         };
         Ok(path![
+            &config.root_dir,
             &config.local.server.pipelines,
             format!("{}.yaml", pipeline.id)
         ])

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -9,7 +9,6 @@ use diesel::{
     sqlite::SqliteConnection,
 };
 use std::{
-    env::current_dir,
     fmt::Write as FmtWrite,
     fs::{copy, create_dir_all, read_to_string, remove_file, rename, File},
     io::Write,
@@ -91,7 +90,11 @@ impl PipelineFileSystemProxy {
     }
 
     pub fn tmp_path(&self, name: &str) -> Result<PathBuf> {
-        Ok(path![current_dir()?, LOCAL_MACHINE_TMP_DIR, name])
+        let config = match self {
+            Self::Local { config } => config,
+            Self::Server { config, .. } => config,
+        };
+        Ok(path![&config.root_dir, LOCAL_MACHINE_TMP_DIR, name])
     }
 
     fn read_internal(&self, path: &PathBuf) -> Result<String> {

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -73,7 +73,7 @@ impl PipelineFileSystemProxy {
 
     pub fn path(&self, name: &str) -> Result<PathBuf> {
         match self {
-            Self::Local { .. } => Ok(self.config().full_path(name)),
+            Self::Local { config } => Ok(config.full_path(name)),
             Self::Server { .. } => self.server_path(name),
         }
     }

--- a/crates/bld_core/src/request/mod.rs
+++ b/crates/bld_core/src/request/mod.rs
@@ -21,7 +21,7 @@ use bld_utils::tls::load_root_certificates;
 use rustls::ClientConfig;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tracing::debug;
+use tracing::{error, debug};
 
 #[derive(Debug)]
 struct RequestError {
@@ -190,7 +190,8 @@ impl HttpClient {
         let url = format!("{}/refresh", self.base_url);
         let tokens = read_tokens(&self.auth_path)?;
         let Some(refresh_token) = tokens.refresh_token else {
-            bail!("no refresh token found");
+            error!("no refresh token found");
+            bail!("request failed with status code: 401 Unauthorized");
         };
         let params = RefreshTokenParams::new(&refresh_token);
         let tokens: AuthTokens = Request::get(&url).query(&params)?.send().await?;

--- a/crates/bld_core/src/scanner/mod.rs
+++ b/crates/bld_core/src/scanner/mod.rs
@@ -1,4 +1,4 @@
-use bld_config::{path, BldConfig};
+use bld_config::BldConfig;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ pub struct FileScanner {
 impl FileScanner {
     pub fn new(cfg: Arc<BldConfig>, run_id: &str) -> Self {
         Self {
-            path: path![&cfg.root_dir, &cfg.local.logs, run_id],
+            path: cfg.log_full_path(run_id),
             file_handle: None,
         }
     }

--- a/crates/bld_core/src/scanner/mod.rs
+++ b/crates/bld_core/src/scanner/mod.rs
@@ -12,7 +12,7 @@ pub struct FileScanner {
 impl FileScanner {
     pub fn new(cfg: Arc<BldConfig>, run_id: &str) -> Self {
         Self {
-            path: path![&cfg.local.logs, run_id],
+            path: path![&cfg.root_dir, &cfg.local.logs, run_id],
             file_handle: None,
         }
     }

--- a/crates/bld_runner/src/pipeline/v1.rs
+++ b/crates/bld_runner/src/pipeline/v1.rs
@@ -1,6 +1,7 @@
 use crate::artifacts::v1::Artifacts;
 use crate::external::v1::External;
 use crate::step::v1::BuildStep;
+use bld_config::BldConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -33,8 +34,8 @@ impl Pipeline {
         true
     }
 
-    pub fn local_dependencies(&self) -> Vec<String> {
-        let from_steps = self.steps.iter().flat_map(|s| s.local_dependencies());
+    pub fn local_dependencies(&self, config: &BldConfig) -> Vec<String> {
+        let from_steps = self.steps.iter().flat_map(|s| s.local_dependencies(config));
 
         let from_external = self
             .external

--- a/crates/bld_runner/src/pipeline/v2.rs
+++ b/crates/bld_runner/src/pipeline/v2.rs
@@ -4,6 +4,7 @@ use crate::platform::v2::Platform;
 use crate::step::v2::BuildStep;
 use crate::token_context::v2::PipelineContext;
 use anyhow::Result;
+use bld_config::BldConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -38,12 +39,12 @@ impl Pipeline {
         true
     }
 
-    pub fn local_dependencies(&self) -> Vec<String> {
+    pub fn local_dependencies(&self, config: &BldConfig) -> Vec<String> {
         let from_steps = self
             .jobs
             .iter()
             .flat_map(|(_, steps)| steps)
-            .flat_map(|s| s.local_dependencies());
+            .flat_map(|s| s.local_dependencies(config));
 
         let from_external = self
             .external

--- a/crates/bld_runner/src/pipeline/versioned.rs
+++ b/crates/bld_runner/src/pipeline/versioned.rs
@@ -59,16 +59,18 @@ impl VersionedPipeline {
     }
 
     pub fn dependencies(
+        config: &BldConfig,
         proxy: &PipelineFileSystemProxy,
         name: &str,
     ) -> Result<HashMap<String, String>> {
-        Self::dependencies_recursive(proxy, name).map(|mut hs| {
+        Self::dependencies_recursive(config, proxy, name).map(|mut hs| {
             hs.remove(name);
             hs.into_iter().collect()
         })
     }
 
     fn dependencies_recursive(
+        config: &BldConfig,
         proxy: &PipelineFileSystemProxy,
         name: &str,
     ) -> Result<HashMap<String, String>> {
@@ -83,12 +85,12 @@ impl VersionedPipeline {
         set.insert(name.to_string(), src);
 
         let local_pipelines = match pipeline {
-            Self::Version1(pip) => pip.local_dependencies(),
-            Self::Version2(pip) => pip.local_dependencies(),
+            Self::Version1(pip) => pip.local_dependencies(config),
+            Self::Version2(pip) => pip.local_dependencies(config),
         };
 
         for pipeline in local_pipelines.iter() {
-            for (k, v) in Self::dependencies_recursive(proxy, pipeline)? {
+            for (k, v) in Self::dependencies_recursive(config, proxy, pipeline)? {
                 set.insert(k, v);
             }
         }

--- a/crates/bld_runner/src/platform/builder.rs
+++ b/crates/bld_runner/src/platform/builder.rs
@@ -6,7 +6,6 @@ use bld_core::{
     context::ContextSender,
     logger::LoggerSender,
     platform::{Container, Image, Machine, TargetPlatform},
-    proxies::PipelineFileSystemProxy,
 };
 use bld_utils::sync::IntoArc;
 
@@ -19,7 +18,6 @@ pub struct TargetPlatformBuilder<'a> {
     environment: Option<Arc<HashMap<String, String>>>,
     logger: Option<Arc<LoggerSender>>,
     context: Option<Arc<ContextSender>>,
-    proxy: Option<Arc<PipelineFileSystemProxy>>,
 }
 
 impl<'a> TargetPlatformBuilder<'a> {
@@ -58,11 +56,6 @@ impl<'a> TargetPlatformBuilder<'a> {
         self
     }
 
-    pub fn proxy(mut self, proxy: Arc<PipelineFileSystemProxy>) -> Self {
-        self.proxy = Some(proxy);
-        self
-    }
-
     pub async fn build(self) -> Result<Arc<TargetPlatform>> {
         let run_id = self
             .run_id
@@ -88,10 +81,6 @@ impl<'a> TargetPlatformBuilder<'a> {
             .context
             .ok_or_else(|| anyhow!("no context provided for target platform builder"))?;
 
-        let proxy = self
-            .proxy
-            .ok_or_else(|| anyhow!("no file system proxy for target platform builder"))?;
-
         let platform = match self.image {
             Some(image) => {
                 let container = Container::new(
@@ -106,7 +95,7 @@ impl<'a> TargetPlatformBuilder<'a> {
                 TargetPlatform::container(Box::new(container))
             }
             None => {
-                let machine = Machine::new(run_id, proxy, pipeline_environment, environment)?;
+                let machine = Machine::new(run_id, config, pipeline_environment, environment)?;
                 TargetPlatform::machine(Box::new(machine))
             }
         }

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -304,7 +304,7 @@ impl Runner {
         );
 
         let (_, framed) = WebSocket::new(&url)?
-            .auth(server)
+            .auth(self.config.clone(), server)
             .request()
             .connect()
             .await

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -284,6 +284,7 @@ impl Runner {
     async fn server_external(&self, server: &str, details: &External) -> Result<()> {
         let server_name = server.to_owned();
         let server = self.config.server(server)?;
+        let auth_path = self.config.auth_full_path(&server.name);
         let variables = details
             .variables
             .iter()
@@ -304,7 +305,7 @@ impl Runner {
         );
 
         let (_, framed) = WebSocket::new(&url)?
-            .auth(self.config.clone(), server)
+            .auth(&auth_path)
             .request()
             .connect()
             .await

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -329,7 +329,6 @@ impl Runner {
             .environment(self.env.clone())
             .logger(self.logger.clone())
             .context(self.context.clone())
-            .proxy(self.proxy.clone())
             .build()
             .await?;
 

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -185,6 +185,7 @@ impl Job {
     async fn server_external(&self, server: &str, details: &External) -> Result<()> {
         let server_name = server.to_owned();
         let server = self.config.server(server)?;
+        let auth_path = self.config.auth_full_path(&server.name);
         let variables = details.variables.clone();
         let environment = details.environment.clone();
 
@@ -196,7 +197,7 @@ impl Job {
         );
 
         let (_, framed) = WebSocket::new(&url)?
-            .auth(self.config.clone(), server)
+            .auth(&auth_path)
             .request()
             .connect()
             .await

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -196,7 +196,7 @@ impl Job {
         );
 
         let (_, framed) = WebSocket::new(&url)?
-            .auth(server)
+            .auth(self.config.clone(), server)
             .request()
             .connect()
             .await
@@ -329,6 +329,7 @@ impl Runner {
             .environment(self.env.clone())
             .logger(self.logger.clone())
             .context(self.context.clone())
+            .proxy(self.proxy.clone())
             .build()
             .await?;
 

--- a/crates/bld_runner/src/step/v1.rs
+++ b/crates/bld_runner/src/step/v1.rs
@@ -1,8 +1,6 @@
-use bld_config::path;
 use bld_config::BldConfig;
 use bld_utils::fs::IsYaml;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct BuildStep {
@@ -15,11 +13,10 @@ pub struct BuildStep {
 
 impl BuildStep {
     pub fn local_dependencies(&self, config: &BldConfig) -> Vec<String> {
-        let root_dir = &config.root_dir;
         self.exec
             .iter()
             .flat_map(|e| match e {
-                BuildStepExec::External { value } if path![root_dir, value].is_yaml() => {
+                BuildStepExec::External { value } if config.full_path(value).is_yaml() => {
                     Some(value.to_owned())
                 }
                 _ => None,

--- a/crates/bld_runner/src/step/v1.rs
+++ b/crates/bld_runner/src/step/v1.rs
@@ -1,5 +1,5 @@
-use bld_config::definitions::TOOL_DIR;
 use bld_config::path;
+use bld_config::BldConfig;
 use bld_utils::fs::IsYaml;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -14,11 +14,12 @@ pub struct BuildStep {
 }
 
 impl BuildStep {
-    pub fn local_dependencies(&self) -> Vec<String> {
+    pub fn local_dependencies(&self, config: &BldConfig) -> Vec<String> {
+        let root_dir = &config.root_dir;
         self.exec
             .iter()
             .flat_map(|e| match e {
-                BuildStepExec::External { value } if path![TOOL_DIR, value].is_yaml() => {
+                BuildStepExec::External { value } if path![root_dir, value].is_yaml() => {
                     Some(value.to_owned())
                 }
                 _ => None,

--- a/crates/bld_runner/src/step/v2.rs
+++ b/crates/bld_runner/src/step/v2.rs
@@ -1,9 +1,7 @@
 use anyhow::Result;
-use bld_config::path;
 use bld_config::BldConfig;
 use bld_utils::fs::IsYaml;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 use crate::token_context::v2::PipelineContext;
 
@@ -73,9 +71,8 @@ pub enum BuildStepExec {
 
 impl BuildStepExec {
     pub fn local_dependencies(&self, config: &BldConfig) -> Option<String> {
-        let root_dir = &config.root_dir;
         match self {
-            BuildStepExec::External { value } if path![root_dir, value].is_yaml() => {
+            BuildStepExec::External { value } if config.full_path(value).is_yaml() => {
                 Some(value.to_owned())
             }
             _ => None,

--- a/crates/bld_runner/src/sync/builder.rs
+++ b/crates/bld_runner/src/sync/builder.rs
@@ -162,7 +162,6 @@ impl RunnerBuilder {
                     .environment(env.clone())
                     .logger(self.logger.clone())
                     .context(context.clone())
-                    .proxy(self.proxy.clone())
                     .build()
                     .await?;
 

--- a/crates/bld_runner/src/sync/builder.rs
+++ b/crates/bld_runner/src/sync/builder.rs
@@ -162,6 +162,7 @@ impl RunnerBuilder {
                     .environment(env.clone())
                     .logger(self.logger.clone())
                     .context(context.clone())
+                    .proxy(self.proxy.clone())
                     .build()
                     .await?;
 

--- a/crates/bld_server/src/endpoints/deps.rs
+++ b/crates/bld_server/src/endpoints/deps.rs
@@ -1,26 +1,34 @@
 use crate::extractors::User;
-use actix_web::web::{Data, Query};
-use actix_web::{get, HttpResponse, Responder};
+use actix_web::{
+    get,
+    web::{Data, Query},
+    HttpResponse, Responder,
+};
 use anyhow::Result;
-use bld_core::proxies::PipelineFileSystemProxy;
-use bld_core::requests::PipelineQueryParams;
+use bld_config::BldConfig;
+use bld_core::{proxies::PipelineFileSystemProxy, requests::PipelineQueryParams};
 use bld_runner::VersionedPipeline;
 use tracing::info;
 
 #[get("/deps")]
 pub async fn get(
     _user: User,
-    prx: Data<PipelineFileSystemProxy>,
+    config: Data<BldConfig>,
+    proxy: Data<PipelineFileSystemProxy>,
     params: Query<PipelineQueryParams>,
 ) -> impl Responder {
     info!("Reached handler for /deps route");
-    match do_deps(prx.get_ref(), &params) {
+    match do_deps(&config, &proxy, &params) {
         Ok(r) => HttpResponse::Ok().json(r),
         Err(e) => HttpResponse::BadRequest().body(e.to_string()),
     }
 }
 
-fn do_deps(prx: &PipelineFileSystemProxy, params: &PipelineQueryParams) -> Result<Vec<String>> {
-    let dependencies = VersionedPipeline::dependencies(prx, &params.pipeline)?;
+fn do_deps(
+    config: &BldConfig,
+    proxy: &PipelineFileSystemProxy,
+    params: &PipelineQueryParams,
+) -> Result<Vec<String>> {
+    let dependencies = VersionedPipeline::dependencies(config, proxy, &params.pipeline)?;
     Ok(dependencies.into_keys().collect())
 }

--- a/crates/bld_server/src/server.rs
+++ b/crates/bld_server/src/server.rs
@@ -24,7 +24,7 @@ pub async fn start(config: BldConfig, host: String, port: i64) -> Result<()> {
     let config = config.into_data();
     let client = config.openid_core_client().await?.into_data();
     let config_clone = config.clone();
-    let pool = new_connection_pool(&config.local.db)?;
+    let pool = new_connection_pool(Arc::clone(&config))?;
     let supervisor_sender = SupervisorMessageSender::new(Arc::clone(&config)).into_data();
     let logins = LoginProcess::new().into_data();
     let pool = pool.into_data();

--- a/crates/bld_sock/src/clients/login.rs
+++ b/crates/bld_sock/src/clients/login.rs
@@ -84,7 +84,8 @@ impl LoginClient {
             }
 
             LoginServerMessage::Completed(tokens) => {
-                if let Err(e) = write_tokens(self.config.clone(), &self.server, tokens) {
+                let auth_path = self.config.auth_full_path(&self.server);
+                if let Err(e) = write_tokens(&auth_path, tokens) {
                     println!("Login failed, {e}");
                 } else {
                     println!("Login completed successfully!");

--- a/crates/bld_supervisor/src/supervisor.rs
+++ b/crates/bld_supervisor/src/supervisor.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::queues::worker_queue_channel;
 use crate::sockets::{ws_server_socket, ws_worker_socket};
 use actix_web::web::{get, resource};
@@ -16,7 +18,7 @@ pub async fn start(config: BldConfig) -> Result<()> {
     );
     let config = config.into_data();
     let config_clone = config.clone();
-    let pool = new_connection_pool(&config.local.db)?.into_data();
+    let pool = new_connection_pool(Arc::clone(&config))?.into_data();
     let worker_queue_sender = worker_queue_channel(
         config.local.supervisor.workers.try_into()?,
         config.clone(),


### PR DESCRIPTION
In this PR:
- Changed how the path for the bld config directory is found to search in all parent directories.
- Refactored in various parts of the code base the assumption that the current directory is the one containing the .bld directory.
- Refactored the use of the path! macro and the definition constants and instead exposed necessary paths through method from the BldConfig struct.