### PR TITLE
Refactor and use async fs and process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "bld_config",
  "bld_core",
  "futures",
+ "futures-util",
  "rustls 0.20.9",
  "serde",
  "serde_derive",

--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -63,7 +63,9 @@ impl AddCommand {
 
         println!("Creating temporary local pipeline {}", tmp_name);
         debug!("creating temporary pipeline file: {tmp_name}");
-        proxy.create_tmp(&tmp_name, DEFAULT_V2_PIPELINE_CONTENT, true).await?;
+        proxy
+            .create_tmp(&tmp_name, DEFAULT_V2_PIPELINE_CONTENT, true)
+            .await?;
 
         if self.edit {
             println!("Editing temporary local pipeline {}", tmp_name);

--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -41,7 +41,7 @@ pub struct AddCommand {
 
 impl AddCommand {
     async fn local_add(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
 
         proxy
@@ -56,30 +56,30 @@ impl AddCommand {
     }
 
     async fn remote_add(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config.clone());
         let client = HttpClient::new(config, server)?;
         let tmp_name = format!("{}.yaml", Uuid::new_v4());
 
         println!("Creating temporary local pipeline {}", tmp_name);
         debug!("creating temporary pipeline file: {tmp_name}");
-        proxy.create_tmp(&tmp_name, DEFAULT_V2_PIPELINE_CONTENT, true)?;
+        proxy.create_tmp(&tmp_name, DEFAULT_V2_PIPELINE_CONTENT, true).await?;
 
         if self.edit {
             println!("Editing temporary local pipeline {}", tmp_name);
             debug!("starting editor for temporary pipeline file: {tmp_name}");
-            proxy.edit_tmp(&tmp_name)?;
+            proxy.edit_tmp(&tmp_name).await?;
         }
 
         debug!("reading content of temporary pipeline file: {tmp_name}");
-        let tmp_content = proxy.read_tmp(&tmp_name)?;
+        let tmp_content = proxy.read_tmp(&tmp_name).await?;
 
         println!("Pushing updated content for {}", self.pipeline);
 
         client.push(&self.pipeline, &tmp_content).await?;
 
         debug!("deleting temporary pipeline file: {tmp_name}");
-        proxy.remove_tmp(&tmp_name)?;
+        proxy.remove_tmp(&tmp_name).await?;
 
         Ok(())
     }

--- a/crates/bld_commands/src/auth/command.rs
+++ b/crates/bld_commands/src/auth/command.rs
@@ -36,6 +36,7 @@ impl AuthCommand {
 
         let (_, framed) = WebSocket::new(&url)?
             .auth(&auth_path)
+            .await
             .request()
             .connect()
             .await
@@ -63,13 +64,15 @@ impl BldCommand for AuthCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
-        let server = self.server.to_owned();
-
-        debug!("running login subcommand with --server: {}", self.server);
-
         let system = System::new();
-        let res = system.block_on(async move { Self::login(config, server).await });
+        let res = system.block_on(async move {
+            let config = BldConfig::load().await?.into_arc();
+            let server = self.server.to_owned();
+
+            debug!("running login subcommand with --server: {}", self.server);
+
+            Self::login(config, server).await
+        });
 
         let _ = system.run();
         res

--- a/crates/bld_commands/src/cat/command.rs
+++ b/crates/bld_commands/src/cat/command.rs
@@ -30,7 +30,7 @@ pub struct CatCommand {
 
 impl CatCommand {
     async fn local_print(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         let pipeline = proxy.read(&self.pipeline).await?;
         println!("{pipeline}");
@@ -38,7 +38,7 @@ impl CatCommand {
     }
 
     async fn remote_print(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         HttpClient::new(config, server)?
             .print(&self.pipeline)
             .await

--- a/crates/bld_commands/src/check/command.rs
+++ b/crates/bld_commands/src/check/command.rs
@@ -27,7 +27,7 @@ pub struct CheckCommand {
 
 impl CheckCommand {
     async fn local_check(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config.clone()).into_arc();
         let content = proxy.read(&self.pipeline).await?;
         let pipeline = Yaml::load_with_verbose_errors(&content)?;
@@ -35,7 +35,7 @@ impl CheckCommand {
     }
 
     async fn remote_check(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         HttpClient::new(config, server)?.check(&self.pipeline).await
     }
 }

--- a/crates/bld_commands/src/copy/command.rs
+++ b/crates/bld_commands/src/copy/command.rs
@@ -29,13 +29,13 @@ pub struct CopyCommand {
 
 impl CopyCommand {
     async fn local_copy(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         proxy.copy(&self.pipeline, &self.target).await
     }
 
     async fn remote_copy(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let client = HttpClient::new(config, server)?;
         client.copy(&self.pipeline, &self.target).await
     }

--- a/crates/bld_commands/src/cron/add.rs
+++ b/crates/bld_commands/src/cron/add.rs
@@ -54,12 +54,14 @@ impl BldCommand for CronAddCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server)?;
-        let variables = Some(parse_variables(&self.variables));
-        let environment = Some(parse_variables(&self.environment));
-        let request =
-            AddJobRequest::new(self.schedule, self.pipeline, variables, environment, false);
-        System::new().block_on(async move { client.cron_add(&request).await })
+        System::new().block_on(async move {
+            let config = BldConfig::load().await?.into_arc();
+            let client = HttpClient::new(config, &self.server)?;
+            let variables = Some(parse_variables(&self.variables));
+            let environment = Some(parse_variables(&self.environment));
+            let request =
+                AddJobRequest::new(self.schedule, self.pipeline, variables, environment, false);
+            client.cron_add(&request).await
+        })
     }
 }

--- a/crates/bld_commands/src/cron/cat.rs
+++ b/crates/bld_commands/src/cron/cat.rs
@@ -35,7 +35,8 @@ impl BldCommand for CronCatCommand {
             let config = BldConfig::load().await?.into_arc();
             let client = HttpClient::new(config, &self.server)?;
             let filters = JobFiltersParams::new(Some(self.id), None, None, None, None);
-            let response = System::new().block_on(async move { client.cron_list(&filters).await })?;
+            let response =
+                System::new().block_on(async move { client.cron_list(&filters).await })?;
 
             if !response.is_empty() {
                 let entry = &response[0];

--- a/crates/bld_commands/src/cron/cat.rs
+++ b/crates/bld_commands/src/cron/cat.rs
@@ -31,43 +31,45 @@ impl BldCommand for CronCatCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server)?;
-        let filters = JobFiltersParams::new(Some(self.id), None, None, None, None);
-        let response = System::new().block_on(async move { client.cron_list(&filters).await })?;
+        System::new().block_on(async move {
+            let config = BldConfig::load().await?.into_arc();
+            let client = HttpClient::new(config, &self.server)?;
+            let filters = JobFiltersParams::new(Some(self.id), None, None, None, None);
+            let response = System::new().block_on(async move { client.cron_list(&filters).await })?;
 
-        if !response.is_empty() {
-            let entry = &response[0];
-            let mut message = String::new();
+            if !response.is_empty() {
+                let entry = &response[0];
+                let mut message = String::new();
 
-            writeln!(message, "{:<13}: {}", "id", entry.id)?;
-            writeln!(message, "{:<13}: {}", "schedule", entry.schedule)?;
-            writeln!(message, "{:<13}: {}", "pipeline", entry.pipeline)?;
-            writeln!(message, "{:<13}: {}", "is_default", entry.is_default)?;
-            writeln!(message, "{:<13}: {:?}", "variables", entry.variables)?;
-            writeln!(message, "{:<13}: {:?}", "environment", entry.environment)?;
-            writeln!(message)?;
-            write!(
-                message,
-                "bld cron update -s {} -i {} -S '{}'",
-                self.server, entry.id, entry.schedule
-            )?;
+                writeln!(message, "{:<13}: {}", "id", entry.id)?;
+                writeln!(message, "{:<13}: {}", "schedule", entry.schedule)?;
+                writeln!(message, "{:<13}: {}", "pipeline", entry.pipeline)?;
+                writeln!(message, "{:<13}: {}", "is_default", entry.is_default)?;
+                writeln!(message, "{:<13}: {:?}", "variables", entry.variables)?;
+                writeln!(message, "{:<13}: {:?}", "environment", entry.environment)?;
+                writeln!(message)?;
+                write!(
+                    message,
+                    "bld cron update -s {} -i {} -S '{}'",
+                    self.server, entry.id, entry.schedule
+                )?;
 
-            if let Some(variables) = &entry.variables {
-                for (k, v) in variables {
-                    write!(message, " -v {}='{}'", k, v)?;
+                if let Some(variables) = &entry.variables {
+                    for (k, v) in variables {
+                        write!(message, " -v {}='{}'", k, v)?;
+                    }
                 }
+
+                if let Some(environment) = &entry.environment {
+                    for (k, v) in environment {
+                        write!(message, " -e {}='{}'", k, v)?;
+                    }
+                }
+
+                print!("{message}");
             }
 
-            if let Some(environment) = &entry.environment {
-                for (k, v) in environment {
-                    write!(message, " -e {}='{}'", k, v)?;
-                }
-            }
-
-            print!("{message}");
-        }
-
-        Ok(())
+            Ok(())
+        })
     }
 }

--- a/crates/bld_commands/src/cron/remove.rs
+++ b/crates/bld_commands/src/cron/remove.rs
@@ -29,8 +29,10 @@ impl BldCommand for CronRemoveCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server)?;
-        System::new().block_on(async move { client.cron_remove(&self.cron_job_id).await })
+        System::new().block_on(async move {
+            let config = BldConfig::load().await?.into_arc();
+            let client = HttpClient::new(config, &self.server)?;
+            client.cron_remove(&self.cron_job_id).await
+        })
     }
 }

--- a/crates/bld_commands/src/cron/update.rs
+++ b/crates/bld_commands/src/cron/update.rs
@@ -50,11 +50,13 @@ impl BldCommand for CronUpdateCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server)?;
-        let variables = Some(parse_variables(&self.variables));
-        let environment = Some(parse_variables(&self.environment));
-        let update_job = UpdateJobRequest::new(self.id, self.schedule, variables, environment);
-        System::new().block_on(async move { client.cron_update(&update_job).await })
+        System::new().block_on(async move {
+            let config = BldConfig::load().await?.into_arc();
+            let client = HttpClient::new(config, &self.server)?;
+            let variables = Some(parse_variables(&self.variables));
+            let environment = Some(parse_variables(&self.environment));
+            let update_job = UpdateJobRequest::new(self.id, self.schedule, variables, environment);
+            client.cron_update(&update_job).await
+        })
     }
 }

--- a/crates/bld_commands/src/edit/command.rs
+++ b/crates/bld_commands/src/edit/command.rs
@@ -28,13 +28,13 @@ pub struct EditCommand {
 
 impl EditCommand {
     async fn local_edit(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         proxy.edit(&self.pipeline).await
     }
 
     async fn remote_edit(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let client = HttpClient::new(config.clone(), server)?;
         let proxy = PipelineFileSystemProxy::local(config);
         println!("Pulling pipline {}", self.pipeline);
@@ -46,20 +46,20 @@ impl EditCommand {
         println!("Editing temporary local pipeline {}", tmp_name);
 
         debug!("creating temporary pipeline file: {tmp_name}");
-        proxy.create_tmp(&tmp_name, &data.content, true)?;
+        proxy.create_tmp(&tmp_name, &data.content, true).await?;
 
         debug!("starting editor for temporary pipeline file: {tmp_name}");
-        proxy.edit_tmp(&tmp_name)?;
+        proxy.edit_tmp(&tmp_name).await?;
 
         debug!("reading content of temporary pipeline file: {tmp_name}");
-        let tmp_content = proxy.read_tmp(&tmp_name)?;
+        let tmp_content = proxy.read_tmp(&tmp_name).await?;
 
         println!("Pushing updated content for {}", self.pipeline);
 
         client.push(&self.pipeline, &tmp_content).await?;
 
         debug!("deleting temporary pipeline file: {tmp_name}");
-        proxy.remove_tmp(&tmp_name)?;
+        proxy.remove_tmp(&tmp_name).await?;
 
         Ok(())
     }

--- a/crates/bld_commands/src/hist/command.rs
+++ b/crates/bld_commands/src/hist/command.rs
@@ -52,7 +52,7 @@ impl BldCommand for HistCommand {
 
     fn exec(self) -> Result<()> {
         System::new().block_on(async move {
-            let config = BldConfig::load()?.into_arc();
+            let config = BldConfig::load().await?.into_arc();
 
             let state = if self.state != "all" {
                 Some(self.state.to_string())

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -1,4 +1,5 @@
 use crate::command::BldCommand;
+use actix::System;
 use anyhow::{bail, Result};
 use bld_config::definitions::{LOCAL_DEFAULT_DB_DIR, LOCAL_DEFAULT_DB_NAME};
 use bld_config::path;
@@ -11,6 +12,7 @@ use bld_config::{
 };
 use bld_utils::term::print_info;
 use clap::Args;
+use tokio::fs::{read_dir, create_dir, File, write};
 use std::env::current_dir;
 use std::path::Component::Normal;
 use std::path::{Path, PathBuf};
@@ -36,18 +38,20 @@ impl BldCommand for InitCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let build_dir_exists = build_dir_exists()?;
-        if !build_dir_exists {
-            debug!("running init subcommand with --server: {}", self.is_server);
-            return create_build_dir()
-                .and_then(|_| create_logs_dir(self.is_server))
-                .and_then(|_| create_db(self.is_server))
-                .and_then(|_| create_server_pipelines_dir(self.is_server))
-                .and_then(|_| create_default_yaml())
-                .and_then(|_| create_config_yaml(self.is_server));
-        }
-        let message = format!("{} dir already exists in the current directory", TOOL_DIR);
-        bail!(message)
+        System::new().block_on(async move {
+            let build_dir_exists = build_dir_exists().await?;
+            if !build_dir_exists {
+                debug!("running init subcommand with --server: {}", self.is_server);
+                create_build_dir().await?;
+                create_logs_dir(self.is_server).await?;
+                create_db(self.is_server).await?;
+                create_server_pipelines_dir(self.is_server).await?;
+                create_default_yaml().await?;
+                create_config_yaml(self.is_server).await?;
+            }
+            let message = format!("{} dir already exists in the current directory", TOOL_DIR);
+            bail!(message)
+        })
     }
 }
 
@@ -55,10 +59,10 @@ fn print_dir_created(dir: &str) -> Result<()> {
     print_info(&format!("{} directory created", dir))
 }
 
-fn build_dir_exists() -> Result<bool> {
+async fn build_dir_exists() -> Result<bool> {
     let curr_dir = current_dir()?;
-    for entry in read_dir(curr_dir)? {
-        let entry = entry?;
+    let mut read_dir = read_dir(curr_dir).await?;
+    while let Ok(Some(entry)) = read_dir.next_entry().await {
         let path = entry.path();
         if path.is_dir() {
             let component = path.components().last();
@@ -72,56 +76,56 @@ fn build_dir_exists() -> Result<bool> {
     Ok(false)
 }
 
-fn create_build_dir() -> Result<()> {
+async fn create_build_dir() -> Result<()> {
     let path = Path::new(TOOL_DIR);
-    create_dir(path)?;
+    create_dir(path).await?;
     print_dir_created(TOOL_DIR)?;
     Ok(())
 }
 
-fn create_logs_dir(is_server: bool) -> Result<()> {
+async fn create_logs_dir(is_server: bool) -> Result<()> {
     if is_server {
         let path = path![TOOL_DIR, LOCAL_LOGS];
-        create_dir(path)?;
+        create_dir(path).await?;
         print_dir_created(LOCAL_LOGS)?;
     }
     Ok(())
 }
 
-fn create_db(is_server: bool) -> Result<()> {
+async fn create_db(is_server: bool) -> Result<()> {
     if is_server {
         let mut path = path![TOOL_DIR, LOCAL_DEFAULT_DB_DIR];
-        create_dir(&path)?;
+        create_dir(&path).await?;
         path.push(LOCAL_DEFAULT_DB_NAME);
-        File::create(&path)?;
+        File::create(&path).await?;
         print_dir_created(LOCAL_DEFAULT_DB_DIR)?;
     }
     Ok(())
 }
 
-fn create_server_pipelines_dir(is_server: bool) -> Result<()> {
+async  fn create_server_pipelines_dir(is_server: bool) -> Result<()> {
     if is_server {
         let path = path![TOOL_DIR, LOCAL_SERVER_PIPELINES];
-        create_dir(path)?;
+        create_dir(path).await?;
         print_dir_created(LOCAL_SERVER_PIPELINES)?;
     }
     Ok(())
 }
 
-fn create_default_yaml() -> Result<()> {
+async fn create_default_yaml() -> Result<()> {
     let path = path![TOOL_DIR, TOOL_DEFAULT_PIPELINE_FILE];
-    write(path, DEFAULT_V2_PIPELINE_CONTENT)?;
+    write(path, DEFAULT_V2_PIPELINE_CONTENT).await?;
     print_info(&format!("{} yaml file created", TOOL_DEFAULT_PIPELINE))?;
     Ok(())
 }
 
-fn create_config_yaml(is_server: bool) -> Result<()> {
+async fn create_config_yaml(is_server: bool) -> Result<()> {
     let path = path![TOOL_DIR, TOOL_DEFAULT_CONFIG_FILE];
     let content = match is_server {
         true => BldConfig::default_yaml_for_server()?,
         false => BldConfig::default_yaml_for_client()?,
     };
-    write(path, content)?;
+    write(path, content).await?;
     print_info("config file created")?;
     Ok(())
 }

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -12,10 +12,10 @@ use bld_config::{
 };
 use bld_utils::term::print_info;
 use clap::Args;
-use tokio::fs::{read_dir, create_dir, File, write};
 use std::env::current_dir;
 use std::path::Component::Normal;
 use std::path::{Path, PathBuf};
+use tokio::fs::{create_dir, read_dir, write, File};
 use tracing::debug;
 
 #[derive(Args)]
@@ -103,7 +103,7 @@ async fn create_db(is_server: bool) -> Result<()> {
     Ok(())
 }
 
-async  fn create_server_pipelines_dir(is_server: bool) -> Result<()> {
+async fn create_server_pipelines_dir(is_server: bool) -> Result<()> {
     if is_server {
         let path = path![TOOL_DIR, LOCAL_SERVER_PIPELINES];
         create_dir(path).await?;

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -12,7 +12,6 @@ use bld_config::{
 use bld_utils::term::print_info;
 use clap::Args;
 use std::env::current_dir;
-use std::fs::{create_dir, read_dir, write, File};
 use std::path::Component::Normal;
 use std::path::{Path, PathBuf};
 use tracing::debug;

--- a/crates/bld_commands/src/list/command.rs
+++ b/crates/bld_commands/src/list/command.rs
@@ -22,7 +22,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     async fn local_list(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         let content = proxy.list().await?.join("\n");
         println!("{content}");
@@ -30,7 +30,7 @@ impl ListCommand {
     }
 
     async fn remote_list(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         HttpClient::new(config, server)?
             .list()
             .await

--- a/crates/bld_commands/src/monit/command.rs
+++ b/crates/bld_commands/src/monit/command.rs
@@ -45,7 +45,7 @@ pub struct MonitCommand {
 
 impl MonitCommand {
     async fn request(self) -> Result<()> {
-        let config = BldConfig::load()?;
+        let config = BldConfig::load().await?;
         let server = config.server(&self.server)?;
         let auth_path = config.auth_full_path(&server.name);
         let url = format!("{}/ws-monit/", server.base_url_ws());
@@ -54,6 +54,7 @@ impl MonitCommand {
 
         let (_, framed) = WebSocket::new(&url)?
             .auth(&auth_path)
+            .await
             .request()
             .connect()
             .await

--- a/crates/bld_commands/src/move/command.rs
+++ b/crates/bld_commands/src/move/command.rs
@@ -29,13 +29,13 @@ pub struct MoveCommand {
 
 impl MoveCommand {
     async fn local_move(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         proxy.mv(&self.pipeline, &self.target).await
     }
 
     async fn remote_move(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         HttpClient::new(config, server)?
             .mv(&self.pipeline, &self.target)
             .await

--- a/crates/bld_commands/src/pull/command.rs
+++ b/crates/bld_commands/src/pull/command.rs
@@ -38,7 +38,7 @@ pub struct PullCommand {
 
 impl PullCommand {
     async fn request(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let client = HttpClient::new(config.clone(), &self.server)?;
         let proxy = PipelineFileSystemProxy::local(config);
 

--- a/crates/bld_commands/src/push/command.rs
+++ b/crates/bld_commands/src/push/command.rs
@@ -38,7 +38,7 @@ pub struct PushCommand {
 
 impl PushCommand {
     async fn push(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let client = HttpClient::new(config.clone(), &self.server)?;
         let proxy = PipelineFileSystemProxy::local(config.clone()).into_arc();
 

--- a/crates/bld_commands/src/remove/command.rs
+++ b/crates/bld_commands/src/remove/command.rs
@@ -26,13 +26,13 @@ pub struct RemoveCommand {
 
 impl RemoveCommand {
     async fn local_remove(&self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         proxy.remove(&self.pipeline).await
     }
 
     async fn remote_remove(&self, server: &str) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
+        let config = BldConfig::load().await?.into_arc();
         let client = HttpClient::new(config, server)?;
 
         debug!(

--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -1,5 +1,4 @@
 use actix::{io::SinkWrite, Actor, StreamHandler};
-use actix_web::rt::System;
 use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
 use bld_core::context::ContextSender;
@@ -229,7 +228,7 @@ impl RunAdapter {
             variables: Some(mode.variables),
         };
 
-        let web_socket = WebSocket::new(&url)?.auth(&auth_path);
+        let web_socket = WebSocket::new(&url)?.auth(&auth_path).await;
 
         let (_, framed) = web_socket
             .request()
@@ -266,13 +265,11 @@ impl RunAdapter {
             .map(|_| println!("pipeline has been scheduled to run"))
     }
 
-    pub fn run(self) -> Result<()> {
-        System::new().block_on(async move {
-            match self.config {
-                RunConfiguration::Local(run) => Self::run_local(run).await,
-                RunConfiguration::Http(http) => Self::run_http(http).await,
-                RunConfiguration::WebSocket(socket) => Self::run_web_socket(socket).await,
-            }
-        })
+    pub async fn run(self) -> Result<()> {
+        match self.config {
+            RunConfiguration::Local(run) => Self::run_local(run).await,
+            RunConfiguration::Http(http) => Self::run_http(http).await,
+            RunConfiguration::WebSocket(socket) => Self::run_web_socket(socket).await,
+        }
     }
 }

--- a/crates/bld_commands/src/server/command.rs
+++ b/crates/bld_commands/src/server/command.rs
@@ -32,11 +32,13 @@ impl BldCommand for ServerCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?;
-        let host = self
-            .host
-            .unwrap_or_else(|| config.local.server.host.to_owned());
-        let port = self.port.unwrap_or(config.local.server.port);
-        System::new().block_on(bld_server::start(config, host, port))
+        System::new().block_on(async move {
+            let config = BldConfig::load().await?;
+            let host = self
+                .host
+                .unwrap_or_else(|| config.local.server.host.to_owned());
+            let port = self.port.unwrap_or(config.local.server.port);
+            bld_server::start(config, host, port).await
+        })
     }
 }

--- a/crates/bld_commands/src/stop/command.rs
+++ b/crates/bld_commands/src/stop/command.rs
@@ -34,8 +34,10 @@ impl BldCommand for StopCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
-        let client = HttpClient::new(config, &self.server)?;
-        System::new().block_on(async move { client.stop(&self.pipeline_id).await })
+        System::new().block_on(async move {
+            let config = BldConfig::load().await?.into_arc();
+            let client = HttpClient::new(config, &self.server)?;
+            client.stop(&self.pipeline_id).await
+        })
     }
 }

--- a/crates/bld_commands/src/supervisor/command.rs
+++ b/crates/bld_commands/src/supervisor/command.rs
@@ -21,11 +21,9 @@ impl BldCommand for SupervisorCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?;
-
-        debug!("starting supervisor");
-
         System::new().block_on(async move {
+            let config = BldConfig::load().await?;
+            debug!("starting supervisor");
             if let Err(e) = supervisor::start(config).await {
                 error!("{e}");
                 bail!("")

--- a/crates/bld_commands/src/worker/command.rs
+++ b/crates/bld_commands/src/worker/command.rs
@@ -69,7 +69,7 @@ impl BldCommand for WorkerCommand {
 
     fn exec(self) -> Result<()> {
         System::new().block_on(async move {
-            let config = BldConfig::load()?.into_arc();
+            let config = BldConfig::load().await?.into_arc();
             let socket_cfg = config.clone();
 
             let pipeline = self.pipeline.into_arc();
@@ -89,7 +89,7 @@ impl BldCommand for WorkerCommand {
 
             let (worker_tx, worker_rx) = channel(4096);
             let worker_tx = Some(worker_tx).into_arc();
-            let logger = LoggerSender::file(config.clone(), &run_id)?.into_arc();
+            let logger = LoggerSender::file(config.clone(), &run_id).await?.into_arc();
             let context = ContextSender::server(config.clone(), conn, &run_id).into_arc();
             let (cmd_signals, signals_rx) = CommandSignals::new()?;
 

--- a/crates/bld_commands/src/worker/command.rs
+++ b/crates/bld_commands/src/worker/command.rs
@@ -89,7 +89,9 @@ impl BldCommand for WorkerCommand {
 
             let (worker_tx, worker_rx) = channel(4096);
             let worker_tx = Some(worker_tx).into_arc();
-            let logger = LoggerSender::file(config.clone(), &run_id).await?.into_arc();
+            let logger = LoggerSender::file(config.clone(), &run_id)
+                .await?
+                .into_arc();
             let context = ContextSender::server(config.clone(), conn, &run_id).into_arc();
             let (cmd_signals, signals_rx) = CommandSignals::new()?;
 

--- a/crates/bld_config/Cargo.toml
+++ b/crates/bld_config/Cargo.toml
@@ -11,4 +11,5 @@ tracing = "0.1.36"
 serde = "1.0.126"
 serde_derive = "1.0.126"
 serde_yaml = "0.9.14"
+tokio = { version = "1.24.2", features = ["full"] }
 openidconnect = "3.1.1"

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -18,8 +18,8 @@ pub use tls::*;
 use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
 use std::env::current_dir;
-use std::fs::read_to_string;
 use std::path::PathBuf;
+use tokio::fs::read_to_string;
 use tracing::debug;
 
 use crate::definitions::{
@@ -72,7 +72,7 @@ impl BldConfig {
         }
     }
 
-    pub fn load() -> Result<Self> {
+    pub async fn load() -> Result<Self> {
         let path = Self::path()?;
 
         let root_dir = path
@@ -85,8 +85,8 @@ impl BldConfig {
 
         debug!("loading config file from: {}", &path.display());
 
-        let mut instance: Self =
-            serde_yaml::from_str(&read_to_string(&path)?).map_err(|e| anyhow!(e))?;
+        let content = read_to_string(&path).await?;
+        let mut instance: Self = serde_yaml::from_str(&content).map_err(|e| anyhow!(e))?;
 
         instance.root_dir = root_dir
             .to_str()

--- a/crates/bld_core/src/auth/mod.rs
+++ b/crates/bld_core/src/auth/mod.rs
@@ -4,8 +4,8 @@ use actix_web::rt::spawn;
 use anyhow::{anyhow, bail, Result};
 use serde_derive::{Deserialize, Serialize};
 use tokio::{
-    fs::{create_dir_all, remove_file, File},
-    io::{AsyncReadExt, AsyncWriteExt},
+    fs::{create_dir_all, read_to_string, remove_file, File},
+    io::AsyncWriteExt,
     sync::{
         mpsc::{channel, Receiver, Sender},
         oneshot,
@@ -132,9 +132,8 @@ pub async fn read_tokens(path: &Path) -> Result<AuthTokens> {
         bail!("file not found");
     }
 
-    let mut buf = Vec::new();
-    File::open(path).await?.read_to_end(&mut buf).await?;
-    serde_json::from_slice(&buf).map_err(|e| anyhow!(e))
+    let content = read_to_string(path).await?;
+    serde_json::from_str(&content).map_err(|e| anyhow!(e))
 }
 
 pub async fn write_tokens(path: &Path, tokens: AuthTokens) -> Result<()> {

--- a/crates/bld_core/src/context/mod.rs
+++ b/crates/bld_core/src/context/mod.rs
@@ -284,6 +284,7 @@ impl Context {
 
         let _: String = Request::post(&url)
             .auth(&auth_path)
+            .await
             .send_json(&run.run_id)
             .await?;
 

--- a/crates/bld_core/src/logger/mod.rs
+++ b/crates/bld_core/src/logger/mod.rs
@@ -100,7 +100,7 @@ impl LoggerReceiver {
             }
             Self::File { handle } => {
                 let bytes = text.as_bytes();
-                handle.write(&bytes).await?;
+                handle.write_all(bytes).await?;
             }
             Self::InMemory { output } => {
                 write!(output, "{text}")?;
@@ -120,7 +120,7 @@ impl LoggerReceiver {
             Self::File { handle } => {
                 let text = format!("{text}\n");
                 let bytes = text.as_bytes();
-                handle.write(&bytes).await?;
+                handle.write_all(bytes).await?;
             }
             Self::InMemory { output } => {
                 writeln!(output, "{text}")?;
@@ -142,7 +142,7 @@ impl LoggerReceiver {
             }
             Self::File { handle } => {
                 let bytes = text.as_bytes();
-                handle.write(&bytes).await?;
+                handle.write_all(bytes).await?;
             }
             Self::InMemory { output } => {
                 write!(output, "{text}")?;
@@ -165,7 +165,7 @@ impl LoggerReceiver {
             Self::File { handle } => {
                 let text = format!("{text}\n");
                 let bytes = text.as_bytes();
-                handle.write(&bytes).await?;
+                handle.write_all(bytes).await?;
             }
             Self::InMemory { output } => {
                 writeln!(output, "{text}")?;
@@ -187,7 +187,7 @@ impl LoggerReceiver {
             }
             Self::File { handle } => {
                 let bytes = text.as_bytes();
-                handle.write(&bytes).await?;
+                handle.write_all(bytes).await?;
             }
             Self::InMemory { output } => {
                 write!(output, "{text}")?;
@@ -210,7 +210,7 @@ impl LoggerReceiver {
             Self::File { handle } => {
                 let text = format!("{text}\n");
                 let bytes = text.as_bytes();
-                handle.write(&bytes).await?;
+                handle.write_all(bytes).await?;
             }
             Self::InMemory { output } => {
                 writeln!(output, "{text}")?;

--- a/crates/bld_core/src/logger/mod.rs
+++ b/crates/bld_core/src/logger/mod.rs
@@ -1,12 +1,15 @@
-use std::{fmt::Write as FormatWrite, fs::File, io::Read, io::Write, sync::Arc};
-
 use actix_web::rt::spawn;
 use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
+use std::{fmt::Write as FmtWrite, io::Write, sync::Arc};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
-use tokio::sync::{
-    mpsc::{channel, Receiver, Sender},
-    oneshot,
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        oneshot,
+    },
 };
 use tracing::error;
 
@@ -52,13 +55,13 @@ impl LoggerReceiver {
         Self::Shell
     }
 
-    pub fn file(config: Arc<BldConfig>, run_id: &str) -> Result<Self> {
+    pub async fn file(config: Arc<BldConfig>, run_id: &str) -> Result<Self> {
         let path = config.log_full_path(run_id);
         Ok(Self::File {
             handle: if path.is_file() {
-                File::open(&path)?
+                File::open(&path).await?
             } else {
-                File::create(&path)?
+                File::create(&path).await?
             },
         })
     }
@@ -72,34 +75,35 @@ impl LoggerReceiver {
     async fn receive(mut self, mut rx: Receiver<LoggerMessage>) -> Result<()> {
         while let Some(msg) = rx.recv().await {
             match msg {
-                LoggerMessage::Write { text, resp_tx } => self.write(&text, resp_tx)?,
-                LoggerMessage::WriteLine { text, resp_tx } => self.write_line(&text, resp_tx)?,
-                LoggerMessage::Info { text, resp_tx } => self.info(&text, resp_tx)?,
-                LoggerMessage::InfoLine { text, resp_tx } => self.info_line(&text, resp_tx)?,
-                LoggerMessage::Error { text, resp_tx } => self.error(&text, resp_tx)?,
-                LoggerMessage::ErrorLine { text, resp_tx } => self.error_line(&text, resp_tx)?,
+                LoggerMessage::Write { text, resp_tx } => self.write(&text, resp_tx).await?,
+                LoggerMessage::WriteLine { text, resp_tx } => {
+                    self.write_line(&text, resp_tx).await?
+                }
+                LoggerMessage::Info { text, resp_tx } => self.info(&text, resp_tx).await?,
+                LoggerMessage::InfoLine { text, resp_tx } => self.info_line(&text, resp_tx).await?,
+                LoggerMessage::Error { text, resp_tx } => self.error(&text, resp_tx).await?,
+                LoggerMessage::ErrorLine { text, resp_tx } => {
+                    self.error_line(&text, resp_tx).await?
+                }
                 LoggerMessage::TryRetrieveOutput { resp_tx } => {
-                    self.try_retrieve_output(resp_tx)?
+                    self.try_retrieve_output(resp_tx).await?
                 }
             }
         }
         Ok(())
     }
 
-    pub fn write(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    pub async fn write(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
         match self {
             Self::Shell => {
                 print!("{}", text);
             }
             Self::File { handle } => {
-                if let Err(e) = write!(handle, "{text}") {
-                    eprintln!("Couldn't write to file: {e}");
-                }
+                let bytes = text.as_bytes();
+                handle.write(&bytes).await?;
             }
             Self::InMemory { output } => {
-                if let Err(e) = write!(output, "{text}") {
-                    eprintln!("Couldn't write to in memory logger, {e}");
-                }
+                write!(output, "{text}")?;
             }
         }
 
@@ -108,20 +112,18 @@ impl LoggerReceiver {
             .map_err(|_| anyhow!("oneshot response sender dropped"))
     }
 
-    pub fn write_line(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    pub async fn write_line(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
         match self {
             Self::Shell => {
                 println!("{text}");
             }
             Self::File { handle } => {
-                if let Err(e) = writeln!(handle, "{text}") {
-                    eprintln!("Couldn't write to file: {e}");
-                }
+                let text = format!("{text}\n");
+                let bytes = text.as_bytes();
+                handle.write(&bytes).await?;
             }
             Self::InMemory { output } => {
-                if let Err(e) = writeln!(output, "{text}") {
-                    eprintln!("Couldn't write to in memory logger, {e}");
-                }
+                writeln!(output, "{text}")?;
             }
         }
 
@@ -130,7 +132,7 @@ impl LoggerReceiver {
             .map_err(|_| anyhow!("oneshot response sender dropped"))
     }
 
-    pub fn info(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    pub async fn info(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
         match self {
             Self::Shell => {
                 let mut stdout = StandardStream::stdout(ColorChoice::Always);
@@ -139,14 +141,11 @@ impl LoggerReceiver {
                 let _ = stdout.set_color(ColorSpec::new().set_fg(None));
             }
             Self::File { handle } => {
-                if let Err(e) = write!(handle, "{text}") {
-                    eprintln!("Couldn't write to file: {e}");
-                }
+                let bytes = text.as_bytes();
+                handle.write(&bytes).await?;
             }
             Self::InMemory { output } => {
-                if let Err(e) = write!(output, "{text}") {
-                    eprintln!("Couldn't write to in memory logger, {e}");
-                }
+                write!(output, "{text}")?;
             }
         }
 
@@ -155,7 +154,7 @@ impl LoggerReceiver {
             .map_err(|_| anyhow!("oneshot response sender dropped"))
     }
 
-    pub fn info_line(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    pub async fn info_line(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
         match self {
             Self::Shell => {
                 let mut stdout = StandardStream::stdout(ColorChoice::Always);
@@ -164,14 +163,12 @@ impl LoggerReceiver {
                 let _ = stdout.set_color(ColorSpec::new().set_fg(None));
             }
             Self::File { handle } => {
-                if let Err(e) = writeln!(handle, "{text}") {
-                    eprintln!("Couldn't write to file: {e}");
-                }
+                let text = format!("{text}\n");
+                let bytes = text.as_bytes();
+                handle.write(&bytes).await?;
             }
             Self::InMemory { output } => {
-                if let Err(e) = writeln!(output, "{text}") {
-                    eprintln!("Coudln't write to in memory logger, {e}");
-                }
+                writeln!(output, "{text}")?;
             }
         }
 
@@ -180,7 +177,7 @@ impl LoggerReceiver {
             .map_err(|_| anyhow!("oneshot response sender dropped"))
     }
 
-    pub fn error(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    pub async fn error(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
         match self {
             Self::Shell => {
                 let mut stderr = StandardStream::stderr(ColorChoice::Always);
@@ -189,14 +186,11 @@ impl LoggerReceiver {
                 let _ = stderr.set_color(ColorSpec::new().set_fg(None));
             }
             Self::File { handle } => {
-                if let Err(e) = write!(handle, "{text}") {
-                    eprintln!("Couldn't write to file: {e}");
-                }
+                let bytes = text.as_bytes();
+                handle.write(&bytes).await?;
             }
             Self::InMemory { output } => {
-                if let Err(e) = write!(output, "{text}") {
-                    eprintln!("Couldn't write to in memory logger, {e}");
-                }
+                write!(output, "{text}")?;
             }
         }
 
@@ -205,7 +199,7 @@ impl LoggerReceiver {
             .map_err(|_| anyhow!("oneshot rsponse sender dropped"))
     }
 
-    pub fn error_line(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    pub async fn error_line(&mut self, text: &str, resp_tx: oneshot::Sender<()>) -> Result<()> {
         match self {
             Self::Shell => {
                 let mut stderr = StandardStream::stderr(ColorChoice::Always);
@@ -214,14 +208,12 @@ impl LoggerReceiver {
                 let _ = stderr.set_color(ColorSpec::new().set_fg(None));
             }
             Self::File { handle } => {
-                if let Err(e) = writeln!(handle, "{text}") {
-                    eprintln!("Couldn't write to file: {e}");
-                }
+                let text = format!("{text}\n");
+                let bytes = text.as_bytes();
+                handle.write(&bytes).await?;
             }
             Self::InMemory { output } => {
-                if let Err(e) = writeln!(output, "{text}") {
-                    eprintln!("Couldn't write to in memory logger, {e}");
-                }
+                writeln!(output, "{text}")?;
             }
         }
 
@@ -230,12 +222,12 @@ impl LoggerReceiver {
             .map_err(|_| anyhow!("oneshot response sender dropped"))
     }
 
-    fn try_retrieve_output(&mut self, resp_tx: oneshot::Sender<String>) -> Result<()> {
+    async fn try_retrieve_output(&mut self, resp_tx: oneshot::Sender<String>) -> Result<()> {
         let output = match self {
             Self::Shell => String::new(),
             Self::File { handle } => {
                 let mut output = String::new();
-                handle.read_to_string(&mut output)?;
+                handle.read_to_string(&mut output).await?;
                 output
             }
             Self::InMemory { output } => output.clone(),
@@ -271,9 +263,9 @@ impl LoggerSender {
         Self { tx }
     }
 
-    pub fn file(config: Arc<BldConfig>, run_id: &str) -> Result<Self> {
+    pub async fn file(config: Arc<BldConfig>, run_id: &str) -> Result<Self> {
         let (tx, rx) = channel(4096);
-        let logger = LoggerReceiver::file(config, run_id)?;
+        let logger = LoggerReceiver::file(config, run_id).await?;
 
         spawn(async move { logger.receive(rx).await });
 

--- a/crates/bld_core/src/messages/login.rs
+++ b/crates/bld_core/src/messages/login.rs
@@ -13,5 +13,5 @@ pub enum LoginClientMessage {
 pub enum LoginServerMessage {
     AuthorizationUrl(String),
     Completed(AuthTokens),
-    Failed { reason: String },
+    Failed(String),
 }

--- a/crates/bld_core/src/platform/container.rs
+++ b/crates/bld_core/src/platform/container.rs
@@ -5,6 +5,7 @@ use bld_config::BldConfig;
 use futures::{StreamExt, TryStreamExt};
 use shiplift::{tty::TtyChunk, ContainerOptions, Docker, Exec, ExecContainerOptions};
 use tar::Archive;
+use tokio::fs::read;
 use tracing::error;
 
 use crate::{
@@ -103,7 +104,7 @@ impl Container {
     pub async fn copy_into(&self, from: &str, to: &str) -> Result<()> {
         let client = self.get_client()?;
         let container = client.containers().get(self.get_id()?);
-        let content = std::fs::read(from)?;
+        let content = read(from).await?;
         container.copy_file_into(to, &content).await?;
         Ok(())
     }

--- a/crates/bld_core/src/platform/mod.rs
+++ b/crates/bld_core/src/platform/mod.rs
@@ -49,14 +49,14 @@ impl TargetPlatform {
 
     pub async fn push(&self, from: &str, to: &str) -> Result<()> {
         match self {
-            Self::Machine { machine, .. } => machine.copy_into(from, to),
+            Self::Machine { machine, .. } => machine.copy_into(from, to).await,
             Self::Container { container, .. } => container.copy_into(from, to).await,
         }
     }
 
     pub async fn get(&self, from: &str, to: &str) -> Result<()> {
         match self {
-            Self::Machine { machine, .. } => machine.copy_from(from, to),
+            Self::Machine { machine, .. } => machine.copy_from(from, to).await,
             Self::Container { container, .. } => container.copy_from(from, to).await,
         }
     }
@@ -83,7 +83,7 @@ impl TargetPlatform {
     pub async fn dispose(&self, in_child_runner: bool) -> Result<()> {
         match self {
             // checking if the runner is a child in order to not cleanup the temp dir for the whole run
-            Self::Machine { machine, .. } if !in_child_runner => machine.dispose(),
+            Self::Machine { machine, .. } if !in_child_runner => machine.dispose().await,
             Self::Machine { .. } => Ok(()),
             Self::Container { container, .. } => container.dispose().await,
         }

--- a/crates/bld_core/src/scanner/mod.rs
+++ b/crates/bld_core/src/scanner/mod.rs
@@ -98,7 +98,7 @@ impl FileScanner {
         Self { tx }
     }
 
-    pub async fn scan(&mut self) -> Result<Vec<String>> {
+    pub async fn scan(&self) -> Result<Vec<String>> {
         let (resp_tx, resp_rx) = oneshot::channel();
         self.tx.send(FileScannerMessage::Next(resp_tx)).await?;
         resp_rx.await.map_err(|e| anyhow!(e))

--- a/crates/bld_core/src/scanner/mod.rs
+++ b/crates/bld_core/src/scanner/mod.rs
@@ -1,43 +1,102 @@
+use actix::spawn;
+use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
+use tokio::{
+    fs::File,
+    io::{AsyncBufReadExt, BufReader},
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        oneshot,
+    },
+};
+use tracing::error;
 
-pub struct FileScanner {
-    path: PathBuf,
-    file_handle: Option<File>,
+enum FileScannerMessage {
+    Next(oneshot::Sender<Vec<String>>),
 }
 
-impl FileScanner {
-    pub fn new(cfg: Arc<BldConfig>, run_id: &str) -> Self {
+struct FileScannerReceiver {
+    path: PathBuf,
+    file_handle: Option<File>,
+    receiver: Receiver<FileScannerMessage>,
+}
+
+impl FileScannerReceiver {
+    pub fn new(
+        config: Arc<BldConfig>,
+        run_id: &str,
+        receiver: Receiver<FileScannerMessage>,
+    ) -> Self {
         Self {
-            path: cfg.log_full_path(run_id),
+            path: config.log_full_path(run_id),
             file_handle: None,
+            receiver,
         }
     }
 
-    fn try_open(&mut self) {
+    pub async fn receive(&mut self) -> Result<()> {
+        while let Some(msg) = self.receiver.recv().await {
+            match msg {
+                FileScannerMessage::Next(resp_tx) => self.next(resp_tx).await?,
+            }
+        }
+        Ok(())
+    }
+
+    async fn try_open(&mut self) {
         if self.file_handle.is_some() {
             return;
         }
         self.file_handle = match self.path.is_file() {
-            true => File::open(&self.path).map(Some).unwrap_or(None),
+            true => File::open(&self.path).await.map(Some).unwrap_or(None),
             false => None,
         };
     }
 
-    pub fn scan(&mut self) -> Vec<String> {
-        self.try_open();
+    async fn next(&mut self, resp_tx: oneshot::Sender<Vec<String>>) -> Result<()> {
+        self.try_open().await;
+
         let mut content: Vec<String> = vec![];
-        if let Some(file_handle) = &self.file_handle {
-            let reader = BufReader::new(file_handle);
-            for (_i, line) in reader.lines().enumerate() {
-                if let Ok(line) = line {
-                    content.push(line);
-                }
-            }
+        let Some(file_handle) = self.file_handle.as_mut() else {
+            resp_tx.send(content).map_err(|_| anyhow!("oneshot response sender dropped"))?;
+            return Ok(());
+        };
+
+        let reader = BufReader::new(file_handle);
+        let mut lines = reader.lines();
+        let mut next = lines.next_line().await?;
+        while let Some(line) = next {
+            content.push(line);
+            next = lines.next_line().await?;
         }
-        content
+
+        resp_tx.send(content).map_err(|_| anyhow!("oneshot response sender dropped"))?;
+        Ok(())
+    }
+}
+
+pub struct FileScanner {
+    tx: Sender<FileScannerMessage>,
+}
+
+impl FileScanner {
+    pub fn new(config: Arc<BldConfig>, run_id: &str) -> Self {
+        let (tx, rx) = channel(4096);
+        let mut receiver = FileScannerReceiver::new(config, run_id, rx);
+
+        spawn(async move {
+            if let Err(e) = receiver.receive().await {
+                error!("{e}");
+            }
+        });
+
+        Self { tx }
+    }
+
+    pub async fn scan(&mut self) -> Result<Vec<String>> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx.send(FileScannerMessage::Next(resp_tx)).await?;
+        resp_rx.await.map_err(|e| anyhow!(e))
     }
 }

--- a/crates/bld_core/src/scanner/mod.rs
+++ b/crates/bld_core/src/scanner/mod.rs
@@ -59,7 +59,9 @@ impl FileScannerReceiver {
 
         let mut content: Vec<String> = vec![];
         let Some(file_handle) = self.file_handle.as_mut() else {
-            resp_tx.send(content).map_err(|_| anyhow!("oneshot response sender dropped"))?;
+            resp_tx
+                .send(content)
+                .map_err(|_| anyhow!("oneshot response sender dropped"))?;
             return Ok(());
         };
 
@@ -71,7 +73,9 @@ impl FileScannerReceiver {
             next = lines.next_line().await?;
         }
 
-        resp_tx.send(content).map_err(|_| anyhow!("oneshot response sender dropped"))?;
+        resp_tx
+            .send(content)
+            .map_err(|_| anyhow!("oneshot response sender dropped"))?;
         Ok(())
     }
 }

--- a/crates/bld_core/src/workers/mod.rs
+++ b/crates/bld_core/src/workers/mod.rs
@@ -1,7 +1,9 @@
+use std::process::ExitStatus;
+
 use anyhow::{anyhow, Result};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
-use std::process::{Child, Command, ExitStatus};
+use tokio::process::{Command, Child};
 
 #[derive(Debug)]
 pub struct PipelineWorker {
@@ -28,11 +30,11 @@ impl PipelineWorker {
     }
 
     pub fn get_pid(&self) -> Option<u32> {
-        self.child.as_ref().map(|c| c.id())
+        self.child.as_ref().map(|c| c.id()).unwrap_or(None)
     }
 
     pub fn has_pid(&self, pid: u32) -> bool {
-        self.child.as_ref().map(|c| c.id() == pid).unwrap_or(false)
+        self.get_pid().map(|id| id == pid).unwrap_or(false)
     }
 
     fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
@@ -51,15 +53,13 @@ impl PipelineWorker {
         self.try_wait().is_ok()
     }
 
-    pub fn cleanup(&mut self) -> Result<ExitStatus> {
+    pub async fn cleanup(&mut self) -> Result<ExitStatus> {
         self.try_wait()
-            .map_err(|_| anyhow!("command is still running. cannot cleanup"))
-            .and_then(|_| {
-                self.child
-                    .as_mut()
-                    .ok_or_else(|| anyhow!("worker has not spawned"))
-                    .and_then(|c| c.wait().map_err(|e| anyhow!(e)))
-            })
+            .map_err(|_| anyhow!("command is still running. cannot cleanup"))?;
+        let child = self.child
+            .as_mut()
+            .ok_or_else(|| anyhow!("worker has not spawned"))?;
+        child.wait().await.map_err(|e| anyhow!(e))
     }
 
     pub fn stop(&mut self) -> Result<()> {

--- a/crates/bld_core/src/workers/mod.rs
+++ b/crates/bld_core/src/workers/mod.rs
@@ -3,7 +3,7 @@ use std::process::ExitStatus;
 use anyhow::{anyhow, Result};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
-use tokio::process::{Command, Child};
+use tokio::process::{Child, Command};
 
 #[derive(Debug)]
 pub struct PipelineWorker {
@@ -56,7 +56,8 @@ impl PipelineWorker {
     pub async fn cleanup(&mut self) -> Result<ExitStatus> {
         self.try_wait()
             .map_err(|_| anyhow!("command is still running. cannot cleanup"))?;
-        let child = self.child
+        let child = self
+            .child
             .as_mut()
             .ok_or_else(|| anyhow!("worker has not spawned"))?;
         child.wait().await.map_err(|e| anyhow!(e))

--- a/crates/bld_runner/src/platform/builder.rs
+++ b/crates/bld_runner/src/platform/builder.rs
@@ -95,7 +95,8 @@ impl<'a> TargetPlatformBuilder<'a> {
                 TargetPlatform::container(Box::new(container))
             }
             None => {
-                let machine = Machine::new(run_id, config, pipeline_environment, environment)?;
+                let machine =
+                    Machine::new(run_id, config, pipeline_environment, environment).await?;
                 TargetPlatform::machine(Box::new(machine))
             }
         }

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -302,6 +302,7 @@ impl Runner {
 
         let (_, framed) = WebSocket::new(&url)?
             .auth(&auth_path)
+            .await
             .request()
             .connect()
             .await

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -196,6 +196,7 @@ impl Job {
 
         let (_, framed) = WebSocket::new(&url)?
             .auth(&auth_path)
+            .await
             .request()
             .connect()
             .await

--- a/crates/bld_server/src/extractors/user.rs
+++ b/crates/bld_server/src/extractors/user.rs
@@ -33,6 +33,7 @@ impl FromRequest for User {
         let config = req.app_data::<Data<BldConfig>>().cloned();
         let client = req.app_data::<Data<Option<CoreClient>>>().cloned();
         let access_token = get_access_token(req);
+        dbg!(&access_token);
 
         async move {
             let config = config.unwrap();

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -119,7 +119,8 @@ impl ExecutePipelineSocket {
                 .into_actor(self)
                 .then(|res, act, ctx| match res {
                     Ok(run_id) => {
-                        act.scanner = Some(FileScanner::new(Arc::clone(&act.config), &run_id).into_arc());
+                        act.scanner =
+                            Some(FileScanner::new(Arc::clone(&act.config), &run_id).into_arc());
                         act.run_id = Some(run_id.to_owned());
                         let message = ExecServerMessage::QueuedRun { run_id };
                         if let Ok(data) = serde_json::to_string(&message) {

--- a/crates/bld_sock/Cargo.toml
+++ b/crates/bld_sock/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.40"
 bld_config = { path = "../bld_config" }
 bld_core = { path = "../bld_core" }
 futures = "0.3.15"
+futures-util = "0.3.15"
 serde = "1.0.126"
 serde_derive = "1.0.126"
 serde_json = "1.0.64"

--- a/crates/bld_supervisor/src/queues/worker_queue.rs
+++ b/crates/bld_supervisor/src/queues/worker_queue.rs
@@ -295,7 +295,7 @@ async fn try_cleanup_process(
 
     let conn = conn.as_ref();
 
-    if let Err(e) = worker.cleanup() {
+    if let Err(e) = worker.cleanup().await {
         error!("error when trying to cleanup the worker process, {e}");
     }
 

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -8,8 +8,8 @@ use actix_web::{
 use actix_web_actors::ws;
 use anyhow::Result;
 use bld_core::{messages::ServerMessages, workers::PipelineWorker};
-use tokio::process::Command;
 use std::env::current_exe;
+use tokio::process::Command;
 use tracing::{debug, error, info};
 
 pub struct ServerSocket {

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -1,14 +1,15 @@
 use crate::queues::WorkerQueueSender;
 use actix::prelude::*;
-use actix_web::rt::spawn;
-use actix_web::web::{Bytes, Data, Payload};
-use actix_web::{Error, HttpRequest, HttpResponse};
+use actix_web::{
+    rt::spawn,
+    web::{Bytes, Data, Payload},
+    Error, HttpRequest, HttpResponse,
+};
 use actix_web_actors::ws;
 use anyhow::Result;
-use bld_core::messages::ServerMessages;
-use bld_core::workers::PipelineWorker;
+use bld_core::{messages::ServerMessages, workers::PipelineWorker};
+use tokio::process::Command;
 use std::env::current_exe;
-use std::process::Command;
 use tracing::{debug, error, info};
 
 pub struct ServerSocket {


### PR DESCRIPTION
In this PR:
- Replaced the use of std::fs with tokio::fs.
- Replaced the use of std::process with tokio::process.
- Fixed issues with async code since most function has to be changed to async from blocking.