### PR TITLE
Panic on bld cron cat

### DIFF
--- a/crates/bld_commands/src/cron/cat.rs
+++ b/crates/bld_commands/src/cron/cat.rs
@@ -35,8 +35,7 @@ impl BldCommand for CronCatCommand {
             let config = BldConfig::load().await?.into_arc();
             let client = HttpClient::new(config, &self.server)?;
             let filters = JobFiltersParams::new(Some(self.id), None, None, None, None);
-            let response =
-                System::new().block_on(async move { client.cron_list(&filters).await })?;
+            let response = client.cron_list(&filters).await?;
 
             if !response.is_empty() {
                 let entry = &response[0];

--- a/crates/bld_runner/src/validator/v2.rs
+++ b/crates/bld_runner/src/validator/v2.rs
@@ -1,14 +1,14 @@
 use crate::{
     pipeline::v2::Pipeline,
     platform::v2::Platform,
-    step::v2::{BuildStep, BuildStepExec}
+    step::v2::{BuildStep, BuildStepExec},
 };
 use anyhow::{bail, Result};
 use bld_config::definitions::{
     KEYWORD_BLD_DIR_V2, KEYWORD_PROJECT_DIR_V2, KEYWORD_RUN_PROPS_ID_V2,
     KEYWORD_RUN_PROPS_START_TIME_V2,
 };
-use bld_config::{BldConfig, SshUserAuth, path};
+use bld_config::{path, BldConfig, SshUserAuth};
 use bld_core::proxies::PipelineFileSystemProxy;
 use bld_utils::fs::IsYaml;
 use cron::Schedule;
@@ -18,7 +18,7 @@ use std::{
     fmt::Write,
     path::PathBuf,
     str::FromStr,
-    sync::Arc
+    sync::Arc,
 };
 
 pub struct PipelineValidator<'a> {


### PR DESCRIPTION
In this PR:
- Removed unnecessary use of System::new() in cron cat subcommand.