### PR TITLE
V0.4/task/windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,6 @@ dependencies = [
  "tracing",
  "uuid",
  "walkdir",
- "windows",
 ]
 
 [[package]]
@@ -2148,7 +2147,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core",
 ]
 
 [[package]]
@@ -4870,31 +4869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.0",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "tracing",
  "uuid",
  "walkdir",
+ "windows",
 ]
 
 [[package]]
@@ -2147,7 +2148,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -4869,12 +4870,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "bld_utils",
  "bollard",
  "futures",
+ "futures-util",
  "rustls 0.20.9",
  "sea-orm",
  "serde",

--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -213,6 +213,7 @@ impl RunAdapter {
 
         debug!("starting run");
         let result = runner.run().await;
+        debug!("finished run");
 
         cmd_signals.stop().await?;
         result

--- a/crates/bld_core/Cargo.toml
+++ b/crates/bld_core/Cargo.toml
@@ -31,9 +31,14 @@ termcolor = "1.1.2"
 tokio = { version = "1.24.2", features = ["full"] }
 tracing = "0.1.36"
 uuid = { version = "1.3.4", features = ["v4"] }
-nix = { version = "0.26.1", features = ["process"] }
 regex = "1.8.1"
 walkdir = "2.3.3"
 openidconnect = "3.1.1"
 rustls = "0.20.7"
 flate2 = "1.0.28"
+
+[target.'cfg(target_family = "unix")'.dependencies]
+nix = { version = "0.26.1", features = ["process"] }
+
+[target.'cfg(target_family = "windows")'.dependencies]
+windows = "0.52.0"

--- a/crates/bld_core/Cargo.toml
+++ b/crates/bld_core/Cargo.toml
@@ -39,6 +39,3 @@ flate2 = "1.0.28"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { version = "0.26.1", features = ["process"] }
-
-[target.'cfg(target_family = "windows")'.dependencies]
-windows = "0.52.0"

--- a/crates/bld_core/src/database/pipeline_run_containers.rs
+++ b/crates/bld_core/src/database/pipeline_run_containers.rs
@@ -67,7 +67,11 @@ pub async fn select_in_invalid_state<C: ConnectionTrait + TransactionTrait>(
                 .add(pipeline_runs::Column::State.eq(PR_STATE_FINISHED))
                 .add(pipeline_runs::Column::State.eq(PR_STATE_FAULTED)),
         )
-        .filter(pipeline_run_containers::Column::State.eq(PRC_STATE_ACTIVE))
+        .filter(
+            Condition::any()
+                .add(pipeline_run_containers::Column::State.eq(PRC_STATE_ACTIVE))
+                .add(pipeline_run_containers::Column::State.eq(PRC_STATE_FAULTED)),
+        )
         .all(conn)
         .await
         .map_err(|e| {
@@ -107,7 +111,6 @@ pub async fn insert<C: ConnectionTrait + TransactionTrait>(
         state: Set(model.state),
         date_created: Set(Utc::now().naive_utc()),
         date_updated: Set(Utc::now().naive_utc()),
-        ..Default::default()
     };
 
     PipelineRunContainersEntity::insert(model)

--- a/crates/bld_core/src/database/pipeline_run_containers.rs
+++ b/crates/bld_core/src/database/pipeline_run_containers.rs
@@ -106,6 +106,7 @@ pub async fn insert<C: ConnectionTrait + TransactionTrait>(
         container_id: Set(model.container_id),
         state: Set(model.state),
         date_created: Set(Utc::now().naive_utc()),
+        date_updated: Set(Utc::now().naive_utc()),
         ..Default::default()
     };
 

--- a/crates/bld_core/src/database/pipeline_runs.rs
+++ b/crates/bld_core/src/database/pipeline_runs.rs
@@ -22,30 +22,6 @@ pub struct InsertPipelineRun {
     pub app_user: String,
 }
 
-pub async fn select_running_by_id<C: ConnectionTrait + TransactionTrait>(
-    conn: &C,
-    run_id: &str,
-) -> Result<PipelineRuns> {
-    debug!("loading pipeline run with id: {run_id} that is in a running state");
-
-    let model = PipelineRunsEntity::find()
-        .filter(pipeline_runs::Column::Id.eq(run_id))
-        .filter(pipeline_runs::Column::State.eq(PR_STATE_RUNNING))
-        .one(conn)
-        .await
-        .map_err(|e| {
-            error!("couldn't load pipeline run due to: {e}");
-            anyhow!(e)
-        })?
-        .ok_or_else(|| {
-            error!("couldn't load pipeline run due to: not found");
-            anyhow!("pipeline run not found")
-        })?;
-
-    debug!("loaded pipeline runs successfully");
-    Ok(model)
-}
-
 pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
     conn: &C,
     pip_id: &str,

--- a/crates/bld_core/src/lib.rs
+++ b/crates/bld_core/src/lib.rs
@@ -10,5 +10,6 @@ pub mod request;
 pub mod requests;
 pub mod responses;
 pub mod scanner;
+pub mod shell;
 pub mod signals;
 pub mod workers;

--- a/crates/bld_core/src/proxies/mod.rs
+++ b/crates/bld_core/src/proxies/mod.rs
@@ -275,9 +275,8 @@ impl PipelineFileSystemProxy {
             bail!("pipeline not found");
         }
 
-        let path = path.display().to_string();
-        let mut args = vec![config.local.editor.as_str(), path.as_str()];
-        let mut editor = get_shell(&mut args)?;
+        let args = format!("{} {}", config.local.editor, path.display());
+        let mut editor = get_shell(&mut vec![args.as_str()])?;
 
         let status = editor.status().await?;
         if !ExitStatus::success(&status) {

--- a/crates/bld_core/src/shell/mod.rs
+++ b/crates/bld_core/src/shell/mod.rs
@@ -1,0 +1,18 @@
+use anyhow::{bail, Result};
+use bld_config::{os_name, OSname};
+use tokio::process::Command;
+
+pub fn get_shell(args: &mut Vec<&str>) -> Result<Command> {
+    let (shell, mut shell_args) = match os_name() {
+        OSname::Windows => ("powershell.exe", vec![]),
+        OSname::Linux => ("bash", vec!["-c"]),
+        OSname::Mac => ("sh", vec!["-c"]),
+        OSname::Unknown => bail!("could not spawn shell"),
+    };
+    shell_args.append(args);
+
+    let mut shell = Command::new(shell);
+    shell.args(shell_args);
+
+    Ok(shell)
+}

--- a/crates/bld_core/src/workers/mod.rs
+++ b/crates/bld_core/src/workers/mod.rs
@@ -4,7 +4,10 @@ use anyhow::{anyhow, Result};
 use tokio::process::{Child, Command};
 
 #[cfg(target_family = "unix")]
-use nix::{sys::signal::{self, Signal}, unistd::Pid};
+use nix::{
+    sys::signal::{self, Signal},
+    unistd::Pid,
+};
 
 #[derive(Debug)]
 pub struct PipelineWorker {
@@ -75,7 +78,10 @@ impl PipelineWorker {
 
     #[cfg(target_family = "windows")]
     pub async fn stop(&mut self) -> Result<()> {
-        let child = self.child.as_mut().ok_or_else(|| anyhow!("worker has not spawned"))?;
+        let child = self
+            .child
+            .as_mut()
+            .ok_or_else(|| anyhow!("worker has not spawned"))?;
         child.kill().await.map_err(|e| anyhow!(e))
     }
 }

--- a/crates/bld_core/src/workers/mod.rs
+++ b/crates/bld_core/src/workers/mod.rs
@@ -78,10 +78,11 @@ impl PipelineWorker {
 
     #[cfg(target_family = "windows")]
     pub async fn stop(&mut self) -> Result<()> {
-        let child = self
-            .child
+        self.child
             .as_mut()
-            .ok_or_else(|| anyhow!("worker has not spawned"))?;
-        child.kill().await.map_err(|e| anyhow!(e))
+            .ok_or_else(|| anyhow!("unable to get instance of worker process"))?
+            .kill()
+            .await?;
+        Ok(())
     }
 }

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -17,7 +17,7 @@ use bld_core::messages::{ExecClientMessage, WorkerMessages};
 use bld_core::platform::TargetPlatform;
 use bld_core::proxies::PipelineFileSystemProxy;
 use bld_core::request::WebSocket;
-use bld_core::signals::{UnixSignalMessage, UnixSignalsReceiver, UnixSignal};
+use bld_core::signals::{UnixSignal, UnixSignalMessage, UnixSignalsReceiver};
 use bld_sock::clients::ExecClient;
 use bld_utils::sync::IntoArc;
 use futures::stream::StreamExt;

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -547,7 +547,7 @@ impl Runner {
         self.logger.write(e.to_string()).await?;
         self.has_faulted = true;
         self.stop().await?;
-        Err(anyhow!(""))
+        bail!("")
     }
 
     pub async fn run(mut self) -> RecursiveFuture {

--- a/crates/bld_supervisor/Cargo.toml
+++ b/crates/bld_supervisor/Cargo.toml
@@ -19,6 +19,7 @@ bld_core = { path = "../bld_core" }
 bld_sock = { path = "../bld_sock" }
 bld_utils = { path = "../bld_utils" }
 futures = "0.3.15"
+futures-util = "0.3.15"
 sea-orm = { version = "0.12.2", features = ["sqlx-sqlite", "sqlx-postgres", "sqlx-mysql", "runtime-tokio-rustls"] }
 serde = "1.0.126"
 serde_derive = "1.0.126"

--- a/crates/bld_supervisor/src/queues/worker_queue.rs
+++ b/crates/bld_supervisor/src/queues/worker_queue.rs
@@ -194,7 +194,7 @@ impl WorkerQueueReceiver {
         }
 
         for entry in stopped.iter_mut() {
-            if let Err(e) = entry.stop() {
+            if let Err(e) = entry.stop().await {
                 error!("error while stopping worker process: {e}");
             }
             if let Err(e) = try_cleanup_process(self.conn.clone(), entry).await {

--- a/crates/bld_supervisor/src/queues/worker_queue.rs
+++ b/crates/bld_supervisor/src/queues/worker_queue.rs
@@ -198,9 +198,8 @@ impl WorkerQueueReceiver {
                 error!("error while stopping worker process: {e}");
             }
 
-            if cfg!(target_family = "windows") {
-                self.set_faulted_worker(entry).await;
-            }
+            #[cfg(target_family = "windows")]
+            self.set_faulted_worker(entry).await;
 
             if let Err(e) = try_cleanup_process(self.conn.clone(), entry).await {
                 error!("error while cleaning up worker process, {e}");

--- a/crates/bld_supervisor/src/queues/worker_queue.rs
+++ b/crates/bld_supervisor/src/queues/worker_queue.rs
@@ -197,10 +197,6 @@ impl WorkerQueueReceiver {
             if let Err(e) = entry.stop().await {
                 error!("error while stopping worker process: {e}");
             }
-
-            #[cfg(target_family = "windows")]
-            self.set_faulted_worker(entry).await;
-
             if let Err(e) = try_cleanup_process(self.conn.clone(), entry).await {
                 error!("error while cleaning up worker process, {e}");
             }
@@ -221,26 +217,6 @@ impl WorkerQueueReceiver {
             .find(|w| w.has_pid(pid))
             .or_else(|| self.backlog.iter().find(|w| w.has_pid(pid)))
             .is_some()
-    }
-
-    #[cfg(target_family = "windows")]
-    async fn set_faulted_worker(&self, worker: &PipelineWorker) {
-        let conn = self.conn.get_ref();
-
-        if let Err(e) =
-            pipeline_runs::update_state(conn, worker.get_run_id(), PR_STATE_FAULTED).await
-        {
-            error!("{e}");
-        }
-
-        if let Err(e) = pipeline_run_containers::update_running_containers_to_faulted(
-            conn,
-            worker.get_run_id()
-        )
-        .await
-        {
-            error!("{e}");
-        }
     }
 }
 
@@ -311,9 +287,9 @@ pub fn worker_queue_channel(
 }
 
 /// This function will call the clean up method for the worker and check
-/// the current state of the run id. If its set as running, the worker did not
-/// complete successfully so it will be set to finished and all of its associated
-/// containers will be set as faulted in order to be cleaned up later.
+/// the current state of the run id. If the state isn't faulted or finished then
+/// the worker did not complete successfully so it will be set to faulted and all
+/// of its associated containers will be set as faulted in order to be cleaned up later.
 async fn try_cleanup_process(
     conn: Data<DatabaseConnection>,
     worker: &mut PipelineWorker,
@@ -327,7 +303,7 @@ async fn try_cleanup_process(
     }
 
     let run_id = worker.get_run_id();
-    let run = pipeline_runs::select_running_by_id(conn, run_id).await?;
+    let run = pipeline_runs::select_by_id(conn, run_id).await?;
 
     if run.state != PR_STATE_FINISHED || run.state != PR_STATE_FAULTED {
         let _ = pipeline_runs::update_state(conn, run_id, PR_STATE_FAULTED).await;


### PR DESCRIPTION
This PR focuses on changes to build Bld in windows using MSVC, specifically:
- Changed the crate used for signal handling and added a check for the target family of the OS for the dependency.
- Fixed an issue with faulted runs in order to properly clean up associated containers.
- Fixed an issue with pipeline run containers insert operation that caused them to not be created. This error was difficult to spot since it was only shown by the worker logs.
- Minor refactorings in uses of the spawn function inside of websockets.