### PR TITLE
V0.4/task/bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "bld"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bld_commands",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "bld_commands"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "bld_config"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "openidconnect",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "bld_core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "bld_http"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "awc",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "bld_migrations"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "bld_models"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "bld_runner"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "bld_server"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "bld_sock"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "bld_supervisor"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "bld_utils"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Kostas Vlachos <kvl_93@outlook.com>"]
 edition = "2021"
 

--- a/crates/bld_commands/Cargo.toml
+++ b/crates/bld_commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_commands"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_config/Cargo.toml
+++ b/crates/bld_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_config"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -1,4 +1,4 @@
-pub const VERSION: &str = "0.3.1";
+pub const VERSION: &str = "0.4.0";
 pub const TOOL_DIR: &str = ".bld";
 pub const PUSH: &str = "push";
 pub const GET: &str = "get";

--- a/crates/bld_core/Cargo.toml
+++ b/crates/bld_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_core"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_http/Cargo.toml
+++ b/crates/bld_http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_http"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_migrations/Cargo.toml
+++ b/crates/bld_migrations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_migrations"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 publish = false
 

--- a/crates/bld_models/Cargo.toml
+++ b/crates/bld_models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_models"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_runner/Cargo.toml
+++ b/crates/bld_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_runner"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_server/Cargo.toml
+++ b/crates/bld_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_server"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_sock/Cargo.toml
+++ b/crates/bld_sock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_sock"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_supervisor/Cargo.toml
+++ b/crates/bld_supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_supervisor"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bld_utils/Cargo.toml
+++ b/crates/bld_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bld_utils"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
### In this PR:
- Bumped the version of all workspace crates to 0.4
- Bumped the version of the bld cli to 0.4