### PR TITLE
V0.4/task/api versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "actix-web",
  "actix-web-actors",
  "anyhow",
+ "awc",
  "bld_config",
  "bld_core",
  "bld_http",

--- a/crates/bld_commands/src/auth/command.rs
+++ b/crates/bld_commands/src/auth/command.rs
@@ -31,7 +31,7 @@ impl AuthCommand {
     async fn login(config: Arc<BldConfig>, server: String) -> Result<()> {
         let server = config.server(&server)?;
         let auth_path = config.auth_full_path(&server.name);
-        let url = format!("{}/ws-login/", server.base_url_ws());
+        let url = format!("{}/v1/ws-login/", server.base_url_ws());
 
         debug!("establishing web socket connection on {}", url);
 

--- a/crates/bld_commands/src/monit/command.rs
+++ b/crates/bld_commands/src/monit/command.rs
@@ -49,7 +49,7 @@ impl MonitCommand {
         let config = BldConfig::load().await?;
         let server = config.server(&self.server)?;
         let auth_path = config.auth_full_path(&server.name);
-        let url = format!("{}/ws-monit/", server.base_url_ws());
+        let url = format!("{}/v1/ws-monit/", server.base_url_ws());
 
         debug!("establishing web socket connection on {}", url);
 

--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -218,7 +218,7 @@ impl RunAdapter {
     async fn run_web_socket(mode: WebSocketRequest) -> Result<()> {
         let server = mode.config.server(&mode.server)?;
         let auth_path = mode.config.auth_full_path(&server.name);
-        let url = format!("{}/ws-exec/", server.base_url_ws());
+        let url = format!("{}/v1/ws-exec/", server.base_url_ws());
         let data = ExecClientMessage::EnqueueRun {
             name: mode.pipeline,
             environment: Some(mode.environment),

--- a/crates/bld_commands/src/worker/command.rs
+++ b/crates/bld_commands/src/worker/command.rs
@@ -130,7 +130,7 @@ async fn connect_to_supervisor(
     config: Arc<BldConfig>,
     mut worker_rx: Receiver<WorkerMessages>,
 ) -> Result<()> {
-    let url = format!("{}/ws-worker/", config.local.supervisor.base_url_ws());
+    let url = format!("{}/v1/ws-worker/", config.local.supervisor.base_url_ws());
 
     debug!("establishing web socket connection on {}", url);
 

--- a/crates/bld_core/src/context/mod.rs
+++ b/crates/bld_core/src/context/mod.rs
@@ -16,7 +16,10 @@ use self::local::{LocalContextBackend, LocalContextMessage};
 use self::server::{ServerContextBackend, ServerContextMessage};
 
 pub enum Context {
-    Server { tx: Sender<ServerContextMessage>, conn: Arc<DatabaseConnection> },
+    Server {
+        tx: Sender<ServerContextMessage>,
+        conn: Arc<DatabaseConnection>,
+    },
     Local(Sender<LocalContextMessage>),
 }
 
@@ -24,7 +27,10 @@ impl Context {
     pub fn server(config: Arc<BldConfig>, pool: Arc<DatabaseConnection>, run_id: &str) -> Self {
         let (tx, rx) = channel(4096);
         ServerContextBackend::new(config, pool.clone(), run_id, rx).receive();
-        Self::Server{ tx, conn: pool.clone() }
+        Self::Server {
+            tx,
+            conn: pool.clone(),
+        }
     }
 
     pub fn local(config: Arc<BldConfig>) -> Self {

--- a/crates/bld_core/src/platform/builder.rs
+++ b/crates/bld_core/src/platform/builder.rs
@@ -97,7 +97,7 @@ impl<'a> PlatformBuilder<'a> {
 
         let platform = match self.options {
             PlatformOptions::Container { image, docker_url } => {
-                let context = PlatformContext::new(&run_id, self.conn);
+                let context = PlatformContext::new(run_id, self.conn);
                 let options = ContainerOptions {
                     config,
                     docker_url,

--- a/crates/bld_http/src/lib.rs
+++ b/crates/bld_http/src/lib.rs
@@ -186,7 +186,7 @@ impl HttpClient {
     }
 
     async fn refresh(&self) -> Result<()> {
-        let url = format!("{}/refresh", self.base_url);
+        let url = format!("{}/v1/refresh", self.base_url);
         let tokens = read_tokens(&self.auth_path).await?;
         let Some(refresh_token) = tokens.refresh_token else {
             error!("no refresh token found");
@@ -208,7 +208,7 @@ impl HttpClient {
     }
 
     async fn check_inner(&self, pipeline: &str) -> Result<()> {
-        let url = format!("{}/check", self.base_url);
+        let url = format!("{}/v1/check", self.base_url);
         let params = PipelineQueryParams::new(pipeline);
         Request::get(&url)
             .query(&params)?
@@ -231,7 +231,7 @@ impl HttpClient {
     }
 
     async fn deps_inner(&self, params: &PipelineQueryParams) -> Result<Vec<String>> {
-        let url = format!("{}/deps", self.base_url);
+        let url = format!("{}/v1/deps", self.base_url);
         Request::get(&url)
             .auth(&self.auth_path)
             .await
@@ -253,7 +253,7 @@ impl HttpClient {
     }
 
     async fn hist_inner(&self, params: &HistQueryParams) -> Result<Vec<HistoryEntry>> {
-        let url = format!("{}/hist", self.base_url);
+        let url = format!("{}/v1/hist", self.base_url);
         Request::get(&url)
             .query(params)?
             .auth(&self.auth_path)
@@ -280,7 +280,7 @@ impl HttpClient {
     }
 
     async fn print_inner(&self, params: &PipelineQueryParams) -> Result<String> {
-        let url = format!("{}/print", self.base_url);
+        let url = format!("{}/v1/print", self.base_url);
         Request::get(&url)
             .auth(&self.auth_path)
             .await
@@ -302,7 +302,7 @@ impl HttpClient {
     }
 
     async fn list_inner(&self) -> Result<String> {
-        let url = format!("{}/list", self.base_url);
+        let url = format!("{}/v1/list", self.base_url);
         Request::get(&url).auth(&self.auth_path).await.send().await
     }
 
@@ -318,7 +318,7 @@ impl HttpClient {
     }
 
     async fn pull_inner(&self, params: &PipelineQueryParams) -> Result<PullResponse> {
-        let url = format!("{}/pull", self.base_url);
+        let url = format!("{}/v1/pull", self.base_url);
         Request::get(&url)
             .auth(&self.auth_path)
             .await
@@ -340,7 +340,7 @@ impl HttpClient {
     }
 
     async fn push_inner(&self, json: &PushInfo) -> Result<()> {
-        let url = format!("{}/push", self.base_url);
+        let url = format!("{}/v1/push", self.base_url);
         Request::post(&url)
             .auth(&self.auth_path)
             .await
@@ -365,7 +365,7 @@ impl HttpClient {
     }
 
     async fn remove_inner(&self, params: &PipelineQueryParams) -> Result<()> {
-        let url = format!("{}/remove", self.base_url);
+        let url = format!("{}/v1/remove", self.base_url);
         Request::delete(&url)
             .auth(&self.auth_path)
             .await
@@ -388,7 +388,7 @@ impl HttpClient {
     }
 
     async fn run_inner(&self, json: &ExecClientMessage) -> Result<()> {
-        let url = format!("{}/run", self.base_url);
+        let url = format!("{}/v1/run", self.base_url);
         Request::post(&url)
             .auth(&self.auth_path)
             .await
@@ -419,7 +419,7 @@ impl HttpClient {
     }
 
     async fn stop_inner(&self, json: &String) -> Result<()> {
-        let url = format!("{}/stop", self.base_url);
+        let url = format!("{}/v1/stop", self.base_url);
         Request::post(&url)
             .auth(&self.auth_path)
             .await
@@ -441,7 +441,7 @@ impl HttpClient {
     }
 
     async fn cron_list_inner(&self, filters: &JobFiltersParams) -> Result<Vec<CronJobResponse>> {
-        let url = format!("{}/cron", self.base_url);
+        let url = format!("{}/v1/cron", self.base_url);
         Request::get(&url)
             .auth(&self.auth_path)
             .await
@@ -462,7 +462,7 @@ impl HttpClient {
     }
 
     async fn cron_add_inner(&self, body: &AddJobRequest) -> Result<()> {
-        let url = format!("{}/cron", self.base_url);
+        let url = format!("{}/v1/cron", self.base_url);
         Request::post(&url)
             .auth(&self.auth_path)
             .await
@@ -483,7 +483,7 @@ impl HttpClient {
     }
 
     async fn cron_update_inner(&self, body: &UpdateJobRequest) -> Result<()> {
-        let url = format!("{}/cron", self.base_url);
+        let url = format!("{}/v1/cron", self.base_url);
         Request::patch(&url)
             .auth(&self.auth_path)
             .await
@@ -504,7 +504,7 @@ impl HttpClient {
     }
 
     async fn cron_remove_inner(&self, id: &str) -> Result<()> {
-        let url = format!("{}/cron/{id}", self.base_url);
+        let url = format!("{}/v1/cron/{id}", self.base_url);
         Request::delete(&url)
             .auth(&self.auth_path)
             .await
@@ -525,7 +525,7 @@ impl HttpClient {
     }
 
     async fn copy_inner(&self, data: &PipelinePathRequest) -> Result<()> {
-        let url = format!("{}/copy", self.base_url);
+        let url = format!("{}/v1/copy", self.base_url);
         Request::post(&url)
             .auth(&self.auth_path)
             .await
@@ -547,7 +547,7 @@ impl HttpClient {
     }
 
     async fn mv_inner(&self, data: &PipelinePathRequest) -> Result<()> {
-        let url = format!("{}/move", self.base_url);
+        let url = format!("{}/v1/move", self.base_url);
         Request::patch(&url)
             .auth(&self.auth_path)
             .await

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -290,7 +290,7 @@ impl Runner {
             .map(|(key, value)| (key.to_owned(), self.apply_context(value)))
             .collect();
 
-        let url = format!("{}/ws-exec/", server.base_url_ws());
+        let url = format!("{}/v1/ws-exec/", server.base_url_ws());
 
         debug!(
             "establishing web socket connection with server {}",

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -190,7 +190,7 @@ impl Job {
         let variables = details.variables.clone();
         let environment = details.environment.clone();
 
-        let url = format!("{}/ws-exec/", server.base_url_ws());
+        let url = format!("{}/v1/ws-exec/", server.base_url_ws());
 
         debug!(
             "establishing web socket connection with server {}",

--- a/crates/bld_server/Cargo.toml
+++ b/crates/bld_server/Cargo.toml
@@ -11,6 +11,7 @@ actix-codec = "0.5.0"
 actix-http = "3.0.4"
 actix-web = { version = "4.0.1", features = ["rustls"] }
 actix-web-actors = "4.1.0"
+awc = { version = "3.0.0", features = ["rustls"] }
 anyhow = "1.0.40"
 bld_config = { path = "../bld_config" }
 bld_core = { path = "../bld_core" }

--- a/crates/bld_server/src/endpoints/auth.rs
+++ b/crates/bld_server/src/endpoints/auth.rs
@@ -16,7 +16,7 @@ const AUTH_REDIRECT_SUCCESS: &str =
     "Login completed, you can close this browser tab and go back to your terminal.";
 const AUTH_REDIRECT_FAILED: &str = "An error occured while completing the login process.";
 
-#[get("/auth/redirect")]
+#[get("/v1/auth/redirect")]
 pub async fn redirect(info: Query<AuthRedirectParams>, logins: Data<Logins>) -> impl Responder {
     info!("Reached handler for /authRedirect route");
     let code = info.code.to_owned();
@@ -30,7 +30,7 @@ pub async fn redirect(info: Query<AuthRedirectParams>, logins: Data<Logins>) -> 
     }
 }
 
-#[get("/auth/refresh")]
+#[get("/v1/auth/refresh")]
 pub async fn refresh(
     info: Query<RefreshTokenParams>,
     client: Data<Option<CoreClient>>,

--- a/crates/bld_server/src/endpoints/check.rs
+++ b/crates/bld_server/src/endpoints/check.rs
@@ -10,7 +10,7 @@ use bld_models::dtos::PipelineQueryParams;
 use bld_runner::{Load, Yaml};
 use tracing::info;
 
-#[get("/check")]
+#[get("/v1/check")]
 pub async fn get(
     _user: User,
     config: Data<BldConfig>,

--- a/crates/bld_server/src/endpoints/copy.rs
+++ b/crates/bld_server/src/endpoints/copy.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 use crate::extractors::User;
 
-#[post("/copy")]
+#[post("/v1/copy")]
 pub async fn post(
     _user: User,
     fs: Data<FileSystem>,

--- a/crates/bld_server/src/endpoints/cron.rs
+++ b/crates/bld_server/src/endpoints/cron.rs
@@ -8,7 +8,7 @@ use tracing::info;
 
 use crate::{cron::CronScheduler, extractors::User};
 
-#[get("/cron")]
+#[get("/v1/cron")]
 pub async fn get(
     _: User,
     cron: Data<CronScheduler>,
@@ -21,7 +21,7 @@ pub async fn get(
     }
 }
 
-#[post("/cron")]
+#[post("/v1/cron")]
 pub async fn post(_: User, cron: Data<CronScheduler>, body: Json<AddJobRequest>) -> impl Responder {
     info!("Reached handler for POST /cron route");
     match cron.add(&body).await {
@@ -30,7 +30,7 @@ pub async fn post(_: User, cron: Data<CronScheduler>, body: Json<AddJobRequest>)
     }
 }
 
-#[patch("/cron")]
+#[patch("/v1/cron")]
 pub async fn patch(
     _: User,
     cron: Data<CronScheduler>,
@@ -43,7 +43,7 @@ pub async fn patch(
     }
 }
 
-#[delete("/cron/{cron_job_id}")]
+#[delete("/v1/cron/{cron_job_id}")]
 pub async fn delete(_: User, cron: Data<CronScheduler>, path: Path<String>) -> impl Responder {
     info!("Reached handler for DELETE /cron route");
     let cron_job_id = path.into_inner();

--- a/crates/bld_server/src/endpoints/deps.rs
+++ b/crates/bld_server/src/endpoints/deps.rs
@@ -13,7 +13,7 @@ use bld_models::dtos::PipelineQueryParams;
 use bld_runner::VersionedPipeline;
 use tracing::info;
 
-#[get("/deps")]
+#[get("/v1/deps")]
 pub async fn get(
     _user: User,
     config: Data<BldConfig>,

--- a/crates/bld_server/src/endpoints/hist.rs
+++ b/crates/bld_server/src/endpoints/hist.rs
@@ -8,7 +8,7 @@ use bld_models::{
 use sea_orm::DatabaseConnection;
 use tracing::info;
 
-#[get("/hist")]
+#[get("/v1/hist")]
 pub async fn get(
     _user: User,
     conn: Data<DatabaseConnection>,

--- a/crates/bld_server/src/endpoints/list.rs
+++ b/crates/bld_server/src/endpoints/list.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use bld_core::fs::FileSystem;
 use tracing::info;
 
-#[get("/list")]
+#[get("/v1/list")]
 pub async fn get(_: User, fs: Data<FileSystem>) -> HttpResponse {
     info!("Reached handler for /list route");
     match find_pipelines(fs.get_ref()).await {

--- a/crates/bld_server/src/endpoints/move.rs
+++ b/crates/bld_server/src/endpoints/move.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 use crate::extractors::User;
 
-#[patch("/move")]
+#[patch("/v1/move")]
 pub async fn patch(
     _user: User,
     fs: Data<FileSystem>,

--- a/crates/bld_server/src/endpoints/print.rs
+++ b/crates/bld_server/src/endpoints/print.rs
@@ -5,7 +5,7 @@ use bld_core::fs::FileSystem;
 use bld_models::dtos::PipelineQueryParams;
 use tracing::info;
 
-#[get("/print")]
+#[get("/v1/print")]
 pub async fn get(
     _: User,
     fs: Data<FileSystem>,

--- a/crates/bld_server/src/endpoints/pull.rs
+++ b/crates/bld_server/src/endpoints/pull.rs
@@ -5,7 +5,7 @@ use bld_core::fs::FileSystem;
 use bld_models::dtos::{PipelineQueryParams, PullResponse};
 use tracing::info;
 
-#[get("/pull")]
+#[get("/v1/pull")]
 pub async fn get(
     _: User,
     fs: Data<FileSystem>,

--- a/crates/bld_server/src/endpoints/push.rs
+++ b/crates/bld_server/src/endpoints/push.rs
@@ -8,7 +8,7 @@ use bld_models::dtos::PushInfo;
 use bld_runner::{Load, VersionedPipeline, Yaml};
 use tracing::{error, info};
 
-#[post("/push")]
+#[post("/v1/push")]
 pub async fn post(
     _: User,
     fs: Data<FileSystem>,

--- a/crates/bld_server/src/endpoints/remove.rs
+++ b/crates/bld_server/src/endpoints/remove.rs
@@ -7,7 +7,7 @@ use bld_core::fs::FileSystem;
 use bld_models::dtos::PipelineQueryParams;
 use tracing::info;
 
-#[delete("/remove")]
+#[delete("/v1/remove")]
 pub async fn delete(
     _: User,
     fs: Data<FileSystem>,

--- a/crates/bld_server/src/endpoints/run.rs
+++ b/crates/bld_server/src/endpoints/run.rs
@@ -14,7 +14,7 @@ use bld_models::dtos::ExecClientMessage;
 use sea_orm::DatabaseConnection;
 use tracing::info;
 
-#[post("/run")]
+#[post("/v1/run")]
 pub async fn post(
     user: User,
     fs: Data<FileSystem>,

--- a/crates/bld_server/src/endpoints/stop.rs
+++ b/crates/bld_server/src/endpoints/stop.rs
@@ -4,7 +4,7 @@ use actix_web::web::{Data, Json};
 use actix_web::{post, HttpResponse, Responder};
 use tracing::info;
 
-#[post("/stop")]
+#[post("/v1/stop")]
 pub async fn post(
     _: User,
     req: Json<String>,

--- a/crates/bld_server/src/server.rs
+++ b/crates/bld_server/src/server.rs
@@ -70,9 +70,9 @@ pub async fn start(config: BldConfig, host: String, port: i64) -> Result<()> {
             .service(cron::post)
             .service(cron::patch)
             .service(cron::delete)
-            .service(resource("/ws-exec/").route(get().to(exec::ws)))
-            .service(resource("/ws-monit/").route(get().to(monit::ws)))
-            .service(resource("/ws-login/").route(get().to(login::ws)))
+            .service(resource("/v1/ws-exec/").route(get().to(exec::ws)))
+            .service(resource("/v1/ws-monit/").route(get().to(monit::ws)))
+            .service(resource("/v1/ws-login/").route(get().to(login::ws)))
     });
 
     let address = format!("{host}:{port}");

--- a/crates/bld_server/src/supervisor/channel.rs
+++ b/crates/bld_server/src/supervisor/channel.rs
@@ -47,8 +47,8 @@ async fn try_ws_connection(url: &str) -> Result<Framed<BoxedSocket, Codec>> {
 }
 
 struct SupervisorMessageReceiver {
-config: Arc<BldConfig>,
-rx: Receiver<ServerMessages>,
+    config: Arc<BldConfig>,
+    rx: Receiver<ServerMessages>,
     child: Option<Child>,
     last_message: Option<ServerMessages>,
 }

--- a/crates/bld_server/src/supervisor/channel.rs
+++ b/crates/bld_server/src/supervisor/channel.rs
@@ -28,7 +28,7 @@ async fn try_ws_connection(url: &str) -> Result<Framed<BoxedSocket, Codec>> {
     for _ in 0..10 {
         debug!("establishing web socket connection on {}", url);
 
-        let Ok((_, framed)) = WebSocket::new(&url)?
+        let Ok((_, framed)) = WebSocket::new(url)?
             .request()
             .connect()
             .await

--- a/crates/bld_server/src/supervisor/channel.rs
+++ b/crates/bld_server/src/supervisor/channel.rs
@@ -1,6 +1,9 @@
 use actix::{io::SinkWrite, Actor, StreamHandler};
+use actix_codec::Framed;
+use actix_http::ws::Codec;
 use actix_web::rt::spawn;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
+use awc::BoxedSocket;
 use bld_config::BldConfig;
 use bld_http::WebSocket;
 use bld_models::dtos::ServerMessages;
@@ -15,9 +18,37 @@ use tokio::{
 };
 use tracing::{debug, error};
 
+const INITIAL_DELAY: u64 = 500;
+const RETRY_DELAY: u64 = 2000;
+
+async fn try_ws_connection(url: &str) -> Result<Framed<BoxedSocket, Codec>> {
+    // small wait for the supervisor
+    sleep(Duration::from_millis(INITIAL_DELAY)).await;
+
+    for _ in 0..10 {
+        debug!("establishing web socket connection on {}", url);
+
+        let Ok((_, framed)) = WebSocket::new(&url)?
+            .request()
+            .connect()
+            .await
+            .map_err(|e| {
+                error!("connection to supervisor web socket failed due to {e}, retrying in {RETRY_DELAY}ms");
+                anyhow!(e.to_string())
+            }) else {
+                sleep(Duration::from_millis(RETRY_DELAY)).await;
+                continue;
+            };
+
+        return Ok(framed);
+    }
+
+    bail!("unable to establish connection to supervisor websocket");
+}
+
 struct SupervisorMessageReceiver {
-    config: Arc<BldConfig>,
-    rx: Receiver<ServerMessages>,
+config: Arc<BldConfig>,
+rx: Receiver<ServerMessages>,
     child: Option<Child>,
     last_message: Option<ServerMessages>,
 }
@@ -33,29 +64,15 @@ impl SupervisorMessageReceiver {
     }
 
     pub async fn receive(mut self) -> Result<()> {
+        let supervisor = &self.config.local.supervisor;
+        let url = format!("{}/v1/ws-server/", supervisor.base_url_ws());
+
         'retry_loop: loop {
             if let Err(e) = self.spawn_inner() {
                 error!("{e}");
                 break 'retry_loop;
             }
-
-            // small wait for the supervisor
-            sleep(Duration::from_millis(300)).await;
-
-            let supervisor = &self.config.local.supervisor;
-            let url = format!("{}/ws-server/", supervisor.base_url_ws());
-
-            debug!("establishing web socket connection on {}", url);
-
-            let (_, framed) = WebSocket::new(&url)?
-                .request()
-                .connect()
-                .await
-                .map_err(|e| {
-                    error!("{e}");
-                    anyhow!(e.to_string())
-                })?;
-
+            let framed = try_ws_connection(&url).await?;
             let (sink, stream) = framed.split();
             let address = EnqueueClient::create(|ctx| {
                 EnqueueClient::add_stream(stream, ctx);

--- a/crates/bld_supervisor/src/supervisor.rs
+++ b/crates/bld_supervisor/src/supervisor.rs
@@ -32,8 +32,8 @@ pub async fn start(config: BldConfig) -> Result<()> {
             .app_data(config_clone.clone())
             .app_data(conn.clone())
             .app_data(worker_queue_sender.clone())
-            .service(resource("/ws-server/").route(get().to(ws_server_socket)))
-            .service(resource("/ws-worker/").route(get().to(ws_worker_socket)))
+            .service(resource("/v1/ws-server/").route(get().to(ws_server_socket)))
+            .service(resource("/v1/ws-worker/").route(get().to(ws_worker_socket)))
     });
 
     server = match &config.local.supervisor.tls {


### PR DESCRIPTION
# In this PR:
- Changed the server api endpoints to be under a version 1.
- Changed the server web socket endpoints to be under a version 1.
- Changed the logic of connecting to the supervisor web socket in order to have retries with delays.