### PR TITLE
V0.4/refactor/UI components

### DIFF
--- a/crates/bld_ui/src/components/badge.rs
+++ b/crates/bld_ui/src/components/badge.rs
@@ -1,7 +1,7 @@
 use leptos::*;
 
 #[component]
-pub fn Badge(#[prop(optional)] class: String, children: Children) -> impl IntoView {
+pub fn Badge(#[prop(into, optional)] class: String, children: Children) -> impl IntoView {
     let class =
         format!("whitespace-nowrap rounded-full bg-indigo-700 px-3 py-1 text-indigo-100 {class}");
     view! {

--- a/crates/bld_ui/src/components/button_group.rs
+++ b/crates/bld_ui/src/components/button_group.rs
@@ -1,40 +1,25 @@
 use leptos::*;
 
-#[derive(Debug, Clone)]
-pub struct ButtonGroupItem {
-    pub id: String,
-    pub label: String,
+#[component]
+pub fn ButtonGroup(children: Children) -> impl IntoView {
+    view! {
+        <div class="inline-flex rounded-lg border border-gray-800 p-1 bg-slate-900">
+            {children()}
+        </div>
+    }
 }
 
 #[component]
-pub fn ButtonGroup(
-    #[prop(into)] items: Signal<Vec<ButtonGroupItem>>,
-    #[prop(into)] selected: RwSignal<String>,
+pub fn ButtonGroupItem(
+    #[prop(into, optional)] is_selected: Option<Signal<bool>>,
+    children: Children
 ) -> impl IntoView {
+    let class = move || if is_selected.as_ref().map(|x| x.get()).unwrap_or(false) {
+        "inline-block rounded-md px-4 py-2 text-sm text-gray-200 shadow-sm focus:relative bg-slate-800"
+    } else {
+        "inline-block rounded-md px-4 py-2 text-sm text-gray-400 hover:text-gray-200 focus:relative"
+    };
     view! {
-        <div class="inline-flex rounded-lg border border-gray-800 p-1 bg-slate-900">
-            {move || items
-                .get()
-                .into_iter()
-                .map(|x| if x.id == selected.get() {
-                    view! {
-                        <button
-                            class="inline-block rounded-md px-4 py-2 text-sm text-gray-200 shadow-sm focus:relative bg-slate-800"
-                            on:click=move |_e| selected.set(x.id.clone())>
-                            {x.label}
-                        </button>
-                    }.into_view()
-                } else {
-                    view! {
-                        <button
-                            class="inline-block rounded-md px-4 py-2 text-sm text-gray-400 hover:text-gray-200 focus:relative"
-                            on:click=move |_e| selected.set(x.id.clone())>
-                            {x.label}
-                        </button>
-                    }.into_view()
-                })
-                .collect::<Vec<_>>()
-            }
-        </div>
+        <button class=class>{children()}</button>
     }
 }

--- a/crates/bld_ui/src/components/button_group.rs
+++ b/crates/bld_ui/src/components/button_group.rs
@@ -11,10 +11,10 @@ pub fn ButtonGroup(children: Children) -> impl IntoView {
 
 #[component]
 pub fn ButtonGroupItem(
-    #[prop(into, optional)] is_selected: Option<Signal<bool>>,
+    #[prop(into, optional)] is_selected: Signal<bool>,
     children: Children
 ) -> impl IntoView {
-    let class = move || if is_selected.as_ref().map(|x| x.get()).unwrap_or(false) {
+    let class = move || if is_selected.get() {
         "inline-block rounded-md px-4 py-2 text-sm text-gray-200 shadow-sm focus:relative bg-slate-800"
     } else {
         "inline-block rounded-md px-4 py-2 text-sm text-gray-400 hover:text-gray-200 focus:relative"

--- a/crates/bld_ui/src/components/button_group.rs
+++ b/crates/bld_ui/src/components/button_group.rs
@@ -12,12 +12,14 @@ pub fn ButtonGroup(children: Children) -> impl IntoView {
 #[component]
 pub fn ButtonGroupItem(
     #[prop(into, optional)] is_selected: Signal<bool>,
-    children: Children
+    children: Children,
 ) -> impl IntoView {
-    let class = move || if is_selected.get() {
-        "inline-block rounded-md px-4 py-2 text-sm text-gray-200 shadow-sm focus:relative bg-slate-800"
-    } else {
-        "inline-block rounded-md px-4 py-2 text-sm text-gray-400 hover:text-gray-200 focus:relative"
+    let class = move || {
+        if is_selected.get() {
+            "inline-block rounded-md px-4 py-2 text-sm text-gray-200 shadow-sm focus:relative bg-slate-800"
+        } else {
+            "inline-block rounded-md px-4 py-2 text-sm text-gray-400 hover:text-gray-200 focus:relative"
+        }
     };
     view! {
         <button class=class>{children()}</button>

--- a/crates/bld_ui/src/components/list.rs
+++ b/crates/bld_ui/src/components/list.rs
@@ -1,40 +1,37 @@
 use leptos::*;
 
-#[derive(Debug, Clone, Default)]
-pub struct ListItem {
-    pub id: String,
-    pub icon: String,
-    pub title: String,
-    pub sub_title: Option<String>,
-    pub content: Option<View>,
-    pub stat: String,
+#[component]
+pub fn List(children: Children) -> impl IntoView {
+    view! {
+        <div class="flex flex-col gap-y-4 pr-2">
+            {children()}
+        </div>
+    }
 }
 
 #[component]
-pub fn List(#[prop(into)] items: Signal<Vec<ListItem>>) -> impl IntoView {
+pub fn ComplexListItem(
+    #[prop(into)] icon: Signal<String>,
+    #[prop(into)] title: Signal<String>,
+    #[prop(into, optional)] sub_title: Signal<String>,
+    #[prop(into, optional)] stat: Signal<String>,
+) -> impl IntoView {
     view! {
-        <div class="flex flex-col gap-y-4 pr-2">
-            <For each=move || items.get() key=|state| state.id.clone() let:child>
-                <div class="flex justify-items-stretch items-center">
-                    <div class="text-5xl text-indigo-500">
-                        <i class={child.icon} />
-                    </div>
-                    <div class="flex flex-col ml-4 grow">
-                        <div>
-                            {child.title}
-                        </div>
-                        <div class="text-sm text-gray-400">
-                            {child.sub_title}
-                        </div>
-                        <div>
-                            {child.content}
-                        </div>
-                    </div>
-                    <div class="text-xl">
-                        {child.stat}
-                    </div>
+        <div class="flex justify-items-stretch items-center">
+            <div class="text-5xl text-indigo-500">
+                <i class=icon.get() />
+            </div>
+            <div class="flex flex-col ml-4 grow">
+                <div>
+                    {title.get()}
                 </div>
-            </For>
+                <div class="text-sm text-gray-400">
+                    {sub_title.get()}
+                </div>
+            </div>
+            <div class="text-xl">
+                {stat.get()}
+            </div>
         </div>
     }
 }

--- a/crates/bld_ui/src/components/list.rs
+++ b/crates/bld_ui/src/components/list.rs
@@ -1,9 +1,13 @@
 use leptos::*;
 
 #[component]
-pub fn List(children: Children) -> impl IntoView {
+pub fn List(
+    #[prop(into, optional)] class: String,
+    children: Children
+) -> impl IntoView {
+    let class = format!("flex flex-col gap-y-4 pr-2 overflow-y-auto {class}");
     view! {
-        <div class="flex flex-col gap-y-4 pr-2">
+        <div class=class>
             {children()}
         </div>
     }
@@ -15,9 +19,11 @@ pub fn ComplexListItem(
     #[prop(into)] title: Signal<String>,
     #[prop(into, optional)] sub_title: Signal<String>,
     #[prop(into, optional)] stat: Signal<String>,
+    #[prop(into, optional)] class: String
 ) -> impl IntoView {
+    let class = format!("flex justify-items-stretch items-center {class}");
     view! {
-        <div class="flex justify-items-stretch items-center">
+        <div class=class>
             <div class="text-5xl text-indigo-500">
                 <i class=icon.get() />
             </div>

--- a/crates/bld_ui/src/components/sidebar.rs
+++ b/crates/bld_ui/src/components/sidebar.rs
@@ -2,7 +2,7 @@ use crate::components::button::Button;
 use leptos::*;
 use leptos_router::A;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct SidebarItem {
     pub icon: String,
     pub text: String,
@@ -19,25 +19,27 @@ pub fn SidebarTop() -> impl IntoView {
 }
 
 #[component]
-pub fn SidebarItemInstance(#[prop()] item: SidebarItem) -> impl IntoView {
+pub fn SidebarItemInstance(#[prop(into)] item: Signal<SidebarItem>) -> impl IntoView {
     view! {
-        <A class="py-4 px-8 hover:bg-slate-600 hover:cursor-pointer flex items-center" href=item.url>
+        <A class="py-4 px-8 hover:bg-slate-600 hover:cursor-pointer flex items-center" href=item.get().url>
             <div class="text-2xl text-indigo-500">
-                <i class=item.icon />
+                <i class={item.get().icon} />
             </div>
-            <div class="ml-4">{item.text}</div>
+            <div class="ml-4">{item.get().text}</div>
         </A>
     }
 }
 
 #[component]
-pub fn SidebarContent(#[prop()] items: Vec<SidebarItem>) -> impl IntoView {
+pub fn SidebarContent(#[prop(into)] items: Signal<Vec<SidebarItem>>) -> impl IntoView {
     view! {
         <div class="flex flex-col divide-y divide-slate-600">
-            {items
-                .into_iter()
-                .map(|i| view!{ <SidebarItemInstance item=i /> })
-                .collect_view()}
+            <For
+                each=move || items.get().into_iter().enumerate()
+                key=move |(i, _)| *i
+                let:child>
+                <SidebarItemInstance item=move || child.1.clone() />
+            </For>
         </div>
     }
 }
@@ -58,7 +60,7 @@ pub fn SidebarBottom() -> impl IntoView {
 }
 
 #[component]
-pub fn Sidebar(#[prop()] items: Vec<SidebarItem>) -> impl IntoView {
+pub fn Sidebar(#[prop(into)] items: Signal<Vec<SidebarItem>>) -> impl IntoView {
     view! {
         <div class="bg-slate-700 w-64 shadow-md flex flex-col divide-y divide-slate-600">
             <SidebarTop />

--- a/crates/bld_ui/src/components/sidebar.rs
+++ b/crates/bld_ui/src/components/sidebar.rs
@@ -2,13 +2,6 @@ use crate::components::button::Button;
 use leptos::*;
 use leptos_router::A;
 
-#[derive(Clone, Default)]
-pub struct SidebarItem {
-    pub icon: String,
-    pub text: String,
-    pub url: String,
-}
-
 #[component]
 pub fn SidebarTop() -> impl IntoView {
     view! {
@@ -19,28 +12,18 @@ pub fn SidebarTop() -> impl IntoView {
 }
 
 #[component]
-pub fn SidebarItemInstance(#[prop(into)] item: Signal<SidebarItem>) -> impl IntoView {
+pub fn SidebarItem(
+    #[prop(into)] icon: String,
+    #[prop(into)] text: String,
+    #[prop(into)] url: String,
+) -> impl IntoView {
     view! {
-        <A class="py-4 px-8 hover:bg-slate-600 hover:cursor-pointer flex items-center" href=item.get().url>
+        <A class="py-4 px-8 hover:bg-slate-600 hover:cursor-pointer flex items-center" href=url>
             <div class="text-2xl text-indigo-500">
-                <i class={item.get().icon} />
+                <i class={icon} />
             </div>
-            <div class="ml-4">{item.get().text}</div>
+            <div class="ml-4">{text}</div>
         </A>
-    }
-}
-
-#[component]
-pub fn SidebarContent(#[prop(into)] items: Signal<Vec<SidebarItem>>) -> impl IntoView {
-    view! {
-        <div class="flex flex-col divide-y divide-slate-600">
-            <For
-                each=move || items.get().into_iter().enumerate()
-                key=move |(i, _)| *i
-                let:child>
-                <SidebarItemInstance item=move || child.1.clone() />
-            </For>
-        </div>
     }
 }
 
@@ -60,12 +43,12 @@ pub fn SidebarBottom() -> impl IntoView {
 }
 
 #[component]
-pub fn Sidebar(#[prop(into)] items: Signal<Vec<SidebarItem>>) -> impl IntoView {
+pub fn Sidebar(children: Children) -> impl IntoView {
     view! {
         <div class="bg-slate-700 w-64 shadow-md flex flex-col divide-y divide-slate-600">
             <SidebarTop />
-            <div class="grow">
-                <SidebarContent items=items />
+            <div class="grow flex flex-col divide-y divide-slate-600">
+                {children()}
             </div>
             <SidebarBottom />
         </div>

--- a/crates/bld_ui/src/components/tabs.rs
+++ b/crates/bld_ui/src/components/tabs.rs
@@ -1,42 +1,30 @@
 use leptos::*;
 
-#[derive(Debug, Clone)]
-pub struct TabItem {
-    pub id: String,
-    pub label: String,
+#[component]
+pub fn Tabs(children: Children) -> impl IntoView {
+    view! {
+        <div class="flex flex-col">
+            <div class="hidden sm:block">
+                <nav class="flex gap-6" aria-label="Tabs">
+                    {children()}
+                </nav>
+            </div>
+        </div>
+    }
 }
 
 #[component]
-pub fn Tabs(
-    #[prop(into)] items: Signal<Vec<TabItem>>,
-    #[prop(into)] selected: RwSignal<String>,
-) -> impl IntoView {
+pub fn Tab(#[prop(into)] is_selected: Signal<bool>, children: Children) -> impl IntoView {
+    let class = move || {
+        if is_selected.get() {
+            "shrink-0 rounded-lg px-4 py-2 text-sm font-medium text-gray-200 bg-slate-800"
+        } else {
+            "shrink-0 rounded-lg px-4 py-2 text-sm font-medium text-gray-400 hover:text-gray-200"
+        }
+    };
     view! {
-        <div class="hidden sm:block">
-            <nav class="flex gap-6" aria-label="Tabs">
-                {move || items
-                    .get()
-                    .into_iter()
-                    .map(|x| if x.id == selected.get() {
-                        view! {
-                            <button
-                                class="shrink-0 rounded-lg px-4 py-2 text-sm font-medium text-gray-200 bg-slate-800"
-                                on:click=move |_e| selected.set(x.id.clone())>
-                                {x.label}
-                            </button>
-                        }.into_view()
-                    } else {
-                        view! {
-                            <button
-                                class="shrink-0 rounded-lg px-4 py-2 text-sm font-medium text-gray-400 hover:text-gray-200"
-                                on:click=move |_e| selected.set(x.id.clone())>
-                                {x.label}
-                            </button>
-                        }.into_view()
-                    })
-                    .collect::<Vec<_>>()
-                }
-            </nav>
-        </div>
+        <button class=class>
+            {children()}
+        </button>
     }
 }

--- a/crates/bld_ui/src/context.rs
+++ b/crates/bld_ui/src/context.rs
@@ -29,10 +29,6 @@ impl PipelineSelectedView {
 pub struct RefreshCronJobs(pub RwSignal<()>);
 
 impl RefreshCronJobs {
-    pub fn get(&self) -> () {
-        self.0.get()
-    }
-
     pub fn set(&self) {
         self.0.set(());
     }
@@ -42,10 +38,6 @@ impl RefreshCronJobs {
 pub struct RefreshHistory(pub RwSignal<()>);
 
 impl RefreshHistory {
-    pub fn get(&self) -> () {
-        self.0.get()
-    }
-
     pub fn set(&self) {
         self.0.set(());
     }

--- a/crates/bld_ui/src/context.rs
+++ b/crates/bld_ui/src/context.rs
@@ -9,7 +9,7 @@ pub struct AppDialogContent(pub RwSignal<Option<View>>);
 #[derive(Copy, Clone)]
 pub enum PipelineView {
     UI,
-    RawFile
+    RawFile,
 }
 
 #[derive(Copy, Clone)]

--- a/crates/bld_ui/src/context.rs
+++ b/crates/bld_ui/src/context.rs
@@ -42,3 +42,16 @@ impl RefreshHistory {
         self.0.set(());
     }
 }
+
+#[derive(Copy, Clone)]
+pub struct RefreshPipelines(pub RwSignal<()>);
+
+impl RefreshPipelines {
+    pub fn get(&self) {
+        self.0.get();
+    }
+
+    pub fn set(&self) {
+        self.0.set(());
+    }
+}

--- a/crates/bld_ui/src/context.rs
+++ b/crates/bld_ui/src/context.rs
@@ -28,6 +28,25 @@ impl PipelineSelectedView {
 #[derive(Copy, Clone)]
 pub struct RefreshCronJobs(pub RwSignal<()>);
 
+impl RefreshCronJobs {
+    pub fn get(&self) -> () {
+        self.0.get()
+    }
+
+    pub fn set(&self) {
+        self.0.set(());
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct RefreshHistory(pub RwSignal<()>);
 
+impl RefreshHistory {
+    pub fn get(&self) -> () {
+        self.0.get()
+    }
+
+    pub fn set(&self) {
+        self.0.set(());
+    }
+}

--- a/crates/bld_ui/src/context.rs
+++ b/crates/bld_ui/src/context.rs
@@ -1,13 +1,33 @@
 use leptos::{html::Dialog, *};
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct AppDialog(pub NodeRef<Dialog>);
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct AppDialogContent(pub RwSignal<Option<View>>);
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
+pub enum PipelineView {
+    UI,
+    RawFile
+}
+
+#[derive(Copy, Clone)]
+pub struct PipelineSelectedView(pub RwSignal<PipelineView>);
+
+impl PipelineSelectedView {
+    pub fn get(&self) -> PipelineView {
+        self.0.get()
+    }
+
+    pub fn set(&self, view: PipelineView) {
+        self.0.set(view);
+    }
+}
+
+#[derive(Copy, Clone)]
 pub struct RefreshCronJobs(pub RwSignal<()>);
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct RefreshHistory(pub RwSignal<()>);
+

--- a/crates/bld_ui/src/pages/home/dashboard/most_runs.rs
+++ b/crates/bld_ui/src/pages/home/dashboard/most_runs.rs
@@ -1,83 +1,57 @@
 use crate::components::card::Card;
-use crate::components::list::{List, ListItem};
+use crate::components::list::{ComplexListItem, List};
 use leptos::*;
 
 #[component]
 pub fn DashboardMostRunsPerUser() -> impl IntoView {
-    let (data, _set_data) = create_signal(vec![
-        ListItem {
-            id: "0".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "John Johnson".to_string(),
-            sub_title: Some("john@someemail.com".to_string()),
-            content: None,
-            stat: "65 runs".to_string(),
-        },
-        ListItem {
-            id: "1".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "Wade Willson".to_string(),
-            sub_title: Some("wade@someemail.com".to_string()),
-            content: None,
-            stat: "60 runs".to_string(),
-        },
-        ListItem {
-            id: "2".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "Peter Parker".to_string(),
-            sub_title: Some("peter@someemail.com".to_string()),
-            content: None,
-            stat: "49 runs".to_string(),
-        },
-        ListItem {
-            id: "3".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "Charles Xavier".to_string(),
-            sub_title: Some("charles@someemail.com".to_string()),
-            content: None,
-            stat: "40 runs".to_string(),
-        },
-        ListItem {
-            id: "4".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "Bruce Wayne".to_string(),
-            sub_title: Some("bruse@someemail.com".to_string()),
-            content: None,
-            stat: "35 runs".to_string(),
-        },
-        ListItem {
-            id: "5".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "Clark Kent".to_string(),
-            sub_title: Some("clark@someemail.com".to_string()),
-            content: None,
-            stat: "28 runs".to_string(),
-        },
-        ListItem {
-            id: "6".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "Lois Lane".to_string(),
-            sub_title: Some("lois@someemail.com".to_string()),
-            content: None,
-            stat: "24 runs".to_string(),
-        },
-        ListItem {
-            id: "7".to_string(),
-            icon: "iconoir-user-circle".to_string(),
-            title: "Barbara Gordon".to_string(),
-            sub_title: Some("barbara@someemail.com".to_string()),
-            content: None,
-            stat: "16 runs".to_string(),
-        },
-    ]);
-
     view! {
         <Card>
             <div class="flex flex-col px-8 py-12">
                 <div class="text-2xl">"Most runs"</div>
                 <div class="text-gray-400 mb-8">"Users with most runs in the last month"</div>
                 <div class="h-96 overflow-y-auto">
-                    <List items=data />
+                    <List>
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "John Johnson".to_string()
+                            sub_title=move || "john@someemail.com".to_string()
+                            stat=move || "65 runs".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "Wade Willson".to_string()
+                            sub_title=move || "wade@someemail.com".to_string()
+                            stat=move || "60 runs".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "Peter Parker".to_string()
+                            sub_title=move || "peter@someemail.com".to_string()
+                            stat=move || "49 runs".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "Charles Xavier".to_string()
+                            sub_title=move || "charles@someemail.com".to_string()
+                            stat= move || "40 runs".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "Bruce Wayne".to_string()
+                            sub_title=move || "bruse@someemail.com".to_string()
+                            stat= move || "35 runs".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "Clark Kent".to_string()
+                            sub_title=move || "clark@someemail.com".to_string()
+                            stat=move || "28 runs".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "Lois Lane".to_string()
+                            sub_title=move || "lois@someemail.com".to_string()
+                            stat=move || "24 runs".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-user-circle".to_string()
+                            title=move || "Barbara Gordon".to_string()
+                            sub_title=move || "barbara@someemail.com".to_string()
+                            stat=move || "16 runs".to_string() />
+                    </List>
                 </div>
             </div>
         </Card>

--- a/crates/bld_ui/src/pages/home/dashboard/pipelines.rs
+++ b/crates/bld_ui/src/pages/home/dashboard/pipelines.rs
@@ -1,51 +1,33 @@
 use crate::components::card::Card;
-use crate::components::list::{List, ListItem};
+use crate::components::list::{ComplexListItem, List};
 use leptos::*;
 
 #[component]
 pub fn DashboardPipelines() -> impl IntoView {
-    let (data, _set_data) = create_signal(vec![
-        ListItem {
-            id: "0".to_string(),
-            icon: "iconoir-tools".to_string(),
-            title: "web-app/ci.yaml".to_string(),
-            sub_title: None,
-            content: None,
-            stat: "success 80% | failure 20%".to_string(),
-        },
-        ListItem {
-            id: "1".to_string(),
-            icon: "iconoir-tools".to_string(),
-            title: "web-app/pr.yaml".to_string(),
-            sub_title: None,
-            content: None,
-            stat: "success 76% | failure 24%".to_string(),
-        },
-        ListItem {
-            id: "2".to_string(),
-            icon: "iconoir-tools".to_string(),
-            title: "web-app/vault-task.yaml".to_string(),
-            sub_title: None,
-            content: None,
-            stat: "success 100% | failure 0%".to_string(),
-        },
-        ListItem {
-            id: "3".to_string(),
-            icon: "iconoir-tools".to_string(),
-            title: "redis/refresh.yaml".to_string(),
-            sub_title: None,
-            content: None,
-            stat: "success 100% | failure 0%".to_string(),
-        },
-    ]);
-
     view! {
         <Card>
             <div class="flex flex-col px-8 py-12">
                 <div class="text-2xl">"Pipelines success/failure rate"</div>
                 <div class="text-gray-400 mb-8">"Pipeline runs for the last month with a success/failure rate"</div>
                 <div class="max-h-[600px] overflow-y-auto">
-                    <List items=data />
+                    <List>
+                        <ComplexListItem
+                            icon=move || "iconoir-tools".to_string()
+                            title=move || "web-app/ci.yaml".to_string()
+                            stat=move || "success 80% | failure 20%".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-tools".to_string()
+                            title=move || "web-app/pr.yaml".to_string()
+                            stat=move || "success 80% | failure 20%".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-tools".to_string()
+                            title=move || "web-app/vault-task.yaml".to_string()
+                            stat=move || "success 100% | failure 0%".to_string() />
+                        <ComplexListItem
+                            icon=move || "iconoir-tools".to_string()
+                            title=move || "web-app/refresh.yaml".to_string()
+                            stat=move || "success 100% | failure 0%".to_string() />
+                    </List>
                 </div>
             </div>
         </Card>

--- a/crates/bld_ui/src/pages/home/history/table.rs
+++ b/crates/bld_ui/src/pages/home/history/table.rs
@@ -28,7 +28,7 @@ async fn get_hist(params: &HistQueryParams) -> Result<Vec<HistoryEntry>> {
 }
 
 #[component]
-fn HistoryEntryState(#[prop(into)] state: String) -> impl IntoView {
+pub fn HistoryEntryState(#[prop(into)] state: String) -> impl IntoView {
     let (icon, label, class) = match state.as_str() {
         "initial" => ("iconoir-running", "Intial", "bg-yellow-600"),
         "queued" => ("iconoir-clock", "Queued", ""),
@@ -39,7 +39,7 @@ fn HistoryEntryState(#[prop(into)] state: String) -> impl IntoView {
             "bg-emerable-600",
         ),
         "faulted" => ("iconoir-minus-circle", "Faulted", "bg-red-600"),
-        _ => return view! {}.into_view(),
+        _ => ("", "Unknown", "bg-black"),
     };
 
     let icon = format!("{icon} mr-2");
@@ -53,7 +53,6 @@ fn HistoryEntryState(#[prop(into)] state: String) -> impl IntoView {
             </Badge>
         </div>
     }
-    .into_view()
 }
 
 #[component]

--- a/crates/bld_ui/src/pages/home/history/table.rs
+++ b/crates/bld_ui/src/pages/home/history/table.rs
@@ -33,11 +33,7 @@ pub fn HistoryEntryState(#[prop(into)] state: String) -> impl IntoView {
         "initial" => ("iconoir-running", "Intial", "bg-yellow-600"),
         "queued" => ("iconoir-clock", "Queued", ""),
         "running" => ("iconoir-running", "Running", ""),
-        "finished" => (
-            "iconoir-check-circle",
-            "Finished",
-            "bg-emerable-600",
-        ),
+        "finished" => ("iconoir-check-circle", "Finished", "bg-emerable-600"),
         "faulted" => ("iconoir-minus-circle", "Faulted", "bg-red-600"),
         _ => ("", "Unknown", "bg-black"),
     };

--- a/crates/bld_ui/src/pages/home/history/table.rs
+++ b/crates/bld_ui/src/pages/home/history/table.rs
@@ -30,15 +30,15 @@ async fn get_hist(params: &HistQueryParams) -> Result<Vec<HistoryEntry>> {
 #[component]
 fn HistoryEntryState(#[prop(into)] state: String) -> impl IntoView {
     let (icon, label, class) = match state.as_str() {
-        "initial" => ("iconoir-running", "Intial", "bg-yellow-600".to_string()),
-        "queued" => ("iconoir-clock", "Queued", String::new()),
-        "running" => ("iconoir-running", "Running", String::new()),
+        "initial" => ("iconoir-running", "Intial", "bg-yellow-600"),
+        "queued" => ("iconoir-clock", "Queued", ""),
+        "running" => ("iconoir-running", "Running", ""),
         "finished" => (
             "iconoir-check-circle",
             "Finished",
-            "bg-emerable-600".to_string(),
+            "bg-emerable-600",
         ),
-        "faulted" => ("iconoir-minus-circle", "Faulted", "bg-red-600".to_string()),
+        "faulted" => ("iconoir-minus-circle", "Faulted", "bg-red-600"),
         _ => return view! {}.into_view(),
     };
 

--- a/crates/bld_ui/src/pages/home/mod.rs
+++ b/crates/bld_ui/src/pages/home/mod.rs
@@ -14,43 +14,29 @@ use crate::components::sidebar::{Sidebar, SidebarItem};
 use leptos::*;
 use leptos_router::Outlet;
 
-fn get_nav_items() -> Vec<SidebarItem> {
-    vec![
-        SidebarItem {
-            icon: "iconoir-presentation".to_string(),
-            text: "Dashboard".to_string(),
-            url: "/".to_string(),
-            ..Default::default()
-        },
-        SidebarItem {
-            icon: "iconoir-book".to_string(),
-            text: "History".to_string(),
-            url: "/history".to_string(),
-            ..Default::default()
-        },
-        SidebarItem {
-            icon: "iconoir-wrench".to_string(),
-            text: "Pipelines".to_string(),
-            url: "/pipelines".to_string(),
-            ..Default::default()
-        },
-        SidebarItem {
-            icon: "iconoir-clock-rotate-right".to_string(),
-            text: "Cron jobs".to_string(),
-            url: "/cron".to_string(),
-            ..Default::default()
-        },
-    ]
-}
-
 #[component]
 pub fn Home() -> impl IntoView {
-    let nav_items = create_rw_signal(get_nav_items());
-
     view! {
         <div class="size-full flex">
             <div class="grow-0 flex self-stretch">
-                <Sidebar items=move || nav_items.get() />
+                <Sidebar>
+                    <SidebarItem
+                        icon="iconoir-presentation"
+                        text="Dashboard"
+                        url="/" />
+                    <SidebarItem
+                        icon="iconoir-book"
+                        text="History"
+                        url="/history" />
+                    <SidebarItem
+                        icon="iconoir-wrench"
+                        text="Pipelines"
+                        url="/pipelines" />
+                    <SidebarItem
+                        icon="iconoir-clock-rotate-right"
+                        text="Cron jobs"
+                        url="/cron" />
+                </Sidebar>
             </div>
             <div class="grow overflow-auto">
                 <div class="m-12">

--- a/crates/bld_ui/src/pages/home/mod.rs
+++ b/crates/bld_ui/src/pages/home/mod.rs
@@ -45,12 +45,12 @@ fn get_nav_items() -> Vec<SidebarItem> {
 
 #[component]
 pub fn Home() -> impl IntoView {
-    let nav_items = get_nav_items();
+    let nav_items = create_rw_signal(get_nav_items());
 
     view! {
         <div class="size-full flex">
             <div class="grow-0 flex self-stretch">
-                <Sidebar items=nav_items />
+                <Sidebar items=move || nav_items.get() />
             </div>
             <div class="grow overflow-auto">
                 <div class="m-12">

--- a/crates/bld_ui/src/pages/home/monit.rs
+++ b/crates/bld_ui/src/pages/home/monit.rs
@@ -54,13 +54,13 @@ pub fn Monit() -> impl IntoView {
 
     view! {
         <Card>
-            <div class="flex flex-col px-8 py-12">
+            <div class="flex flex-col px-8 py-12 gap-4">
                 <div class="flex mb-8 gap-x-4">
-                    <div class="grow text-2xl mb-4 ">
-                        "Monitoring pipeline run"
-                    </div>
-                    <div class="flex-shrink">
-                        <Badge><span class="font-bold">"Id: "</span>{id()}</Badge>
+                    <div class="grow flex flex-col">
+                        <div class="text-2xl">"Monitoring pipeline run"</div>
+                        <div class="text-gray-400">
+                            "Currently monitoring pipeline run with id: "{id()}
+                        </div>
                     </div>
                     <div class="flex-shrink">
                         <Badge><span class="font-bold">"Socket state: "</span>{socket_state()}</Badge>

--- a/crates/bld_ui/src/pages/home/pipelines/mod.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/mod.rs
@@ -3,7 +3,7 @@ mod run;
 mod table;
 mod v2;
 
-use crate::components::{button::Button, card::Card};
+use crate::{components::{button::Button, card::Card}, context::RefreshPipelines};
 use leptos::*;
 use table::PipelinesTable;
 
@@ -12,7 +12,7 @@ pub use run::{variables::RunPipelineVariables, RunPipeline};
 
 #[component]
 pub fn Pipelines() -> impl IntoView {
-    let refresh = create_rw_signal(());
+    let refresh = RefreshPipelines(create_rw_signal(()));
 
     provide_context(refresh);
 
@@ -30,7 +30,7 @@ pub fn Pipelines() -> impl IntoView {
                             </div>
                         </div>
                         <div class="w-40 flex items-end">
-                            <Button on:click=move |_| refresh.set(())>
+                            <Button on:click=move |_| refresh.set()>
                                 "Refresh"
                             </Button>
                         </div>

--- a/crates/bld_ui/src/pages/home/pipelines/mod.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/mod.rs
@@ -3,7 +3,10 @@ mod run;
 mod table;
 mod v2;
 
-use crate::{components::{button::Button, card::Card}, context::RefreshPipelines};
+use crate::{
+    components::{button::Button, card::Card},
+    context::RefreshPipelines,
+};
 use leptos::*;
 use table::PipelinesTable;
 

--- a/crates/bld_ui/src/pages/home/pipelines/table.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/table.rs
@@ -1,7 +1,10 @@
-use crate::{components::{
-    link::Link,
-    table::{Body, Cell, Header, Headers, Row, Table},
-}, context::RefreshPipelines};
+use crate::{
+    components::{
+        link::Link,
+        table::{Body, Cell, Header, Headers, Row, Table},
+    },
+    context::RefreshPipelines,
+};
 use anyhow::Result;
 use bld_models::dtos::ListResponse;
 use leptos::{leptos_dom::logging, *};

--- a/crates/bld_ui/src/pages/home/pipelines/table.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/table.rs
@@ -1,7 +1,7 @@
-use crate::components::{
+use crate::{components::{
     link::Link,
     table::{Body, Cell, Header, Headers, Row, Table},
-};
+}, context::RefreshPipelines};
 use anyhow::Result;
 use bld_models::dtos::ListResponse;
 use leptos::{leptos_dom::logging, *};
@@ -26,7 +26,7 @@ async fn get_pipelines() -> Result<Vec<ListResponse>> {
 #[component]
 pub fn PipelinesTable() -> impl IntoView {
     let (data, set_data) = create_signal(vec![]);
-    let refresh = use_context::<RwSignal<()>>();
+    let refresh = use_context::<RefreshPipelines>();
 
     let list_res = create_resource(
         move || set_data,

--- a/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
@@ -1,9 +1,9 @@
-use crate::components::{
+use crate::{components::{
     badge::Badge,
     button_group::{ButtonGroup, ButtonGroupItem},
     card::Card,
     link::LinkButton,
-};
+}, context::{PipelineSelectedView, PipelineView}};
 use bld_runner::pipeline::v2::Pipeline;
 use leptos::*;
 
@@ -11,13 +11,13 @@ use leptos::*;
 pub fn PipelineDetailsV2(
     #[prop(into)] id: Signal<Option<String>>,
     #[prop(into)] name: Signal<Option<String>>,
-    #[prop(into)] pipeline: Signal<Pipeline>,
-    #[prop(into)] selected_group_item: RwSignal<String>,
+    #[prop(into)] pipeline: Signal<Pipeline>
 ) -> impl IntoView {
     let pipeline_name = move || pipeline.get().name;
     let cron = move || pipeline.get().cron.map(|x| format!("Cron: {}", x));
     let runs_on = move || format!("Runs on: {}", pipeline.get().runs_on);
     let dispose = move || format!("Dispose: {}", pipeline.get().dispose);
+    let selected_view = use_context::<PipelineSelectedView>();
 
     view! {
         <Card>
@@ -44,14 +44,18 @@ pub fn PipelineDetailsV2(
                     <div class="flex-shrink">
                         <ButtonGroup>
                             <ButtonGroupItem
-                                is_selected=move || selected_group_item.get() == "view"
-                                on:click=move |_| selected_group_item.set("view".to_string())>
+                                is_selected=move || selected_view.map(|x| matches!(x.get(), PipelineView::UI)).unwrap_or_default()
+                                on:click=move |_| {
+                                    let _ = selected_view.map(|x| x.set(PipelineView::UI));
+                                }>
                                 "View"
                             </ButtonGroupItem>
                             <ButtonGroupItem
-                                is_selected=move || selected_group_item.get() == "rawfile"
-                                on:click=move |_| selected_group_item.set("rawfile".to_string())>
-                                "Raw file"
+                                is_selected=move || selected_view.map(|x| matches!(x.get(), PipelineView::RawFile)).unwrap_or_default()
+                                on:click=move |_| {
+                                    let _ = selected_view.map(|x| x.set(PipelineView::RawFile));
+                                }>
+                                "View"
                             </ButtonGroupItem>
                         </ButtonGroup>
                     </div>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
@@ -1,9 +1,12 @@
-use crate::{components::{
-    badge::Badge,
-    button_group::{ButtonGroup, ButtonGroupItem},
-    card::Card,
-    link::LinkButton,
-}, context::{PipelineSelectedView, PipelineView}};
+use crate::{
+    components::{
+        badge::Badge,
+        button_group::{ButtonGroup, ButtonGroupItem},
+        card::Card,
+        link::LinkButton,
+    },
+    context::{PipelineSelectedView, PipelineView},
+};
 use bld_runner::pipeline::v2::Pipeline;
 use leptos::*;
 
@@ -11,7 +14,7 @@ use leptos::*;
 pub fn PipelineDetailsV2(
     #[prop(into)] id: Signal<Option<String>>,
     #[prop(into)] name: Signal<Option<String>>,
-    #[prop(into)] pipeline: Signal<Pipeline>
+    #[prop(into)] pipeline: Signal<Pipeline>,
 ) -> impl IntoView {
     let pipeline_name = move || pipeline.get().name;
     let cron = move || pipeline.get().cron.map(|x| format!("Cron: {}", x));

--- a/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
@@ -55,7 +55,7 @@ pub fn PipelineDetailsV2(
                                 on:click=move |_| {
                                     let _ = selected_view.map(|x| x.set(PipelineView::RawFile));
                                 }>
-                                "View"
+                                "Raw file"
                             </ButtonGroupItem>
                         </ButtonGroup>
                     </div>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
@@ -14,19 +14,6 @@ pub fn PipelineDetailsV2(
     #[prop(into)] pipeline: Signal<Pipeline>,
     #[prop(into)] selected_group_item: RwSignal<String>,
 ) -> impl IntoView {
-    let group = Signal::from(|| {
-        vec![
-            ButtonGroupItem {
-                id: "view".to_string(),
-                label: "View".to_string(),
-            },
-            ButtonGroupItem {
-                id: "rawfile".to_string(),
-                label: "Raw file".to_string(),
-            },
-        ]
-    });
-
     let pipeline_name = move || pipeline.get().name;
     let cron = move || pipeline.get().cron.map(|x| format!("Cron: {}", x));
     let runs_on = move || format!("Runs on: {}", pipeline.get().runs_on);
@@ -55,7 +42,18 @@ pub fn PipelineDetailsV2(
                 </div>
                 <div class="flex items-center gap-x-4">
                     <div class="flex-shrink">
-                        <ButtonGroup items=group selected=selected_group_item />
+                        <ButtonGroup>
+                            <ButtonGroupItem
+                                is_selected=move || selected_group_item.get() == "view"
+                                on:click=move |_| selected_group_item.set("view".to_string())>
+                                "View"
+                            </ButtonGroupItem>
+                            <ButtonGroupItem
+                                is_selected=move || selected_group_item.get() == "rawfile"
+                                on:click=move |_| selected_group_item.set("rawfile".to_string())>
+                                "Raw file"
+                            </ButtonGroupItem>
+                        </ButtonGroup>
                     </div>
                     <Show
                         when=move || id.get().is_some() && name.get().is_some()

--- a/crates/bld_ui/src/pages/home/pipelines/v2/external.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/external.rs
@@ -18,7 +18,7 @@ pub fn PipelineExternalV2(#[prop(into)] external: Signal<Vec<External>>) -> impl
 
     view! {
         <Card>
-            <div class="flex flex-col px-8 py-12 gap-y-4 min-h-96 max-h-[600]px">
+            <div class="flex flex-col px-8 py-12 gap-y-4 min-h-96 max-h-[600px]">
                 <div class="flex flex-col">
                     <div class="text-xl">
                         "External"
@@ -39,7 +39,7 @@ pub fn PipelineExternalV2(#[prop(into)] external: Signal<Vec<External>>) -> impl
                             each=move || external().into_iter().enumerate()
                             key=|(i, _)| *i
                             let:child>
-                            <pre class="text-sm text-gray-200">
+                            <pre class="text-sm text-gray-200 p-4 rounded-lg bg-slate-800">
                                 {child.1}
                             </pre>
                         </For>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/external.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/external.rs
@@ -1,8 +1,4 @@
-use crate::components::{
-    badge::Badge,
-    card::Card,
-    list::{List, ListItem},
-};
+use crate::components::{badge::Badge, card::Card, list::List};
 use bld_runner::external::v2::External;
 use leptos::{leptos_dom::logging, *};
 
@@ -13,22 +9,11 @@ pub fn PipelineExternalV2(#[prop(into)] external: Signal<Vec<External>>) -> impl
             .get()
             .into_iter()
             .map(|x| {
-                let mut item = ListItem::default();
-                item.icon = "iconoir-minus".to_string();
-                let content = serde_yaml::to_string(&x)
+                serde_yaml::to_string(&x)
                     .map_err(|e| logging::console_error(&format!("{:?}", e)))
-                    .unwrap_or_default();
-                item.content = Some(
-                    view! {
-                        <pre class="text-sm text-gray-200">
-                            {content}
-                        </pre>
-                    }
-                    .into_view(),
-                );
-                item
+                    .unwrap_or_default()
             })
-            .collect::<Vec<ListItem>>()
+            .collect::<Vec<String>>()
     };
 
     view! {
@@ -49,7 +34,16 @@ pub fn PipelineExternalV2(#[prop(into)] external: Signal<Vec<External>>) -> impl
                             <Badge>"No external pipelines configured."</Badge>
                         </div>
                     }>
-                    <List items=external />
+                    <List>
+                        <For
+                            each=move || external().into_iter().enumerate()
+                            key=|(i, _)| *i
+                            let:child>
+                            <pre class="text-sm text-gray-200">
+                                {child.1}
+                            </pre>
+                        </For>
+                    </List>
                 </Show>
             </div>
         </Card>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/hist_and_cron.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/hist_and_cron.rs
@@ -4,7 +4,7 @@ use crate::{
         card::Card,
         tabs::{Tab, Tabs},
     },
-    context::{RefreshHistory, RefreshCronJobs},
+    context::{RefreshCronJobs, RefreshHistory},
     pages::home::cron::CronJobsTable,
     pages::home::history::table::HistoryTable,
 };

--- a/crates/bld_ui/src/pages/home/pipelines/v2/jobs.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/jobs.rs
@@ -1,7 +1,7 @@
 use crate::components::{
     badge::Badge,
     card::Card,
-    list::{List, ListItem},
+    list::List,
     tabs::{Tab, Tabs},
 };
 use bld_runner::step::v2::BuildStep;
@@ -20,25 +20,14 @@ pub fn PipelineJobsV2(
                     k,
                     v.into_iter()
                         .map(|x| {
-                            let mut item = ListItem::default();
-                            item.icon = "iconoir-minus".to_string();
-                            let content = serde_yaml::to_string(&x)
+                            serde_yaml::to_string(&x)
                                 .map_err(|e| logging::console_error(&format!("{:?}", e)))
-                                .unwrap_or_default();
-                            item.content = Some(
-                                view! {
-                                    <pre class="text-sm text-gray-200">
-                                        {content}
-                                    </pre>
-                                }
-                                .into_view(),
-                            );
-                            item
+                                .unwrap_or_default()
                         })
-                        .collect::<Vec<ListItem>>(),
+                        .collect::<Vec<String>>(),
                 )
             })
-            .collect::<HashMap<String, Vec<ListItem>>>()
+            .collect::<HashMap<String, Vec<String>>>()
     };
 
     let selected_tab = create_rw_signal(String::default());
@@ -80,7 +69,16 @@ pub fn PipelineJobsV2(
                             </Tab>
                         </For>
                     </Tabs>
-                    <List items=items />
+                    <List>
+                        <For
+                            each=move || items().into_iter().enumerate()
+                            key=|(i, _)| *i
+                            let:child>
+                            <pre class="text-sm text-gray-200">
+                                {child.1}
+                            </pre>
+                        </For>
+                    </List>
                 </Show>
             </div>
         </Card>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/jobs.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/jobs.rs
@@ -34,11 +34,16 @@ pub fn PipelineJobsV2(
     selected_tab
         .update(|x: &mut String| *x = jobs().keys().next().map(|x| x.clone()).unwrap_or_default());
 
-    let items = move || jobs().get(&selected_tab.get()).cloned().unwrap_or_default();
+    let items = move || {
+        logging::console_log("Refreshing job items");
+        let data = jobs().get(&selected_tab.get()).cloned().unwrap_or_default();
+        logging::console_log(&format!("{:?}", data));
+        data
+    };
 
     view! {
         <Card>
-            <div class="flex flex-col px-8 py-12 gap-y-4 min-h-96 max-h-[500]px">
+            <div class="flex flex-col px-8 py-12 gap-y-4 min-h-96 max-h-[600px]">
                 <div class="flex flex-col">
                     <div class="text-xl">
                         "Jobs"
@@ -74,7 +79,7 @@ pub fn PipelineJobsV2(
                             each=move || items().into_iter().enumerate()
                             key=|(i, _)| *i
                             let:child>
-                            <pre class="text-sm text-gray-200">
+                            <pre class="text-sm text-gray-200 p-4 rounded-lg bg-slate-800">
                                 {child.1}
                             </pre>
                         </For>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/jobs.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/jobs.rs
@@ -2,7 +2,7 @@ use crate::components::{
     badge::Badge,
     card::Card,
     list::{List, ListItem},
-    tabs::{TabItem, Tabs},
+    tabs::{Tab, Tabs},
 };
 use bld_runner::step::v2::BuildStep;
 use leptos::{leptos_dom::logging, *};
@@ -42,16 +42,6 @@ pub fn PipelineJobsV2(
     };
 
     let selected_tab = create_rw_signal(String::default());
-    let tabs = move || {
-        jobs()
-            .keys()
-            .map(|k| TabItem {
-                id: k.clone(),
-                label: k.clone(),
-            })
-            .collect::<Vec<TabItem>>()
-    };
-
     selected_tab
         .update(|x: &mut String| *x = jobs().keys().next().map(|x| x.clone()).unwrap_or_default());
 
@@ -69,13 +59,27 @@ pub fn PipelineJobsV2(
                     </div>
                 </div>
                 <Show
-                    when=move || !tabs().is_empty()
+                    when=move || !jobs().is_empty()
                     fallback= || view! {
                         <div class="grid justify-items-center">
                             <Badge>"No jobs configured."</Badge>
                         </div>
                     }>
-                    <Tabs items=tabs selected=selected_tab />
+                    <Tabs>
+                        <For
+                            each=move || jobs()
+                                .into_keys()
+                                .enumerate()
+                                .map(|(i, x)| (i, x.clone(), x.clone(), x))
+                            key=|(i, _, _, _)| *i
+                            let:child>
+                            <Tab
+                                is_selected=move || selected_tab.get() == *child.1
+                                on:click=move |_| selected_tab.set(child.2.to_owned())>
+                                {child.3}
+                            </Tab>
+                        </For>
+                    </Tabs>
                     <List items=items />
                 </Show>
             </div>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/mod.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/mod.rs
@@ -5,7 +5,7 @@ mod hist_and_cron;
 mod jobs;
 mod variables;
 
-use crate::components::card::Card;
+use crate::{components::card::Card, context::{RefreshCronJobs, RefreshHistory}};
 use bld_runner::pipeline::versioned::VersionedPipeline;
 use leptos::{leptos_dom::logging, *};
 
@@ -37,6 +37,8 @@ pub fn PipelineV2(
     };
 
     let selected_group_item = create_rw_signal("view".to_string());
+    provide_context(RefreshHistory(create_rw_signal(())));
+    provide_context(RefreshCronJobs(create_rw_signal(())));
 
     view! {
         <Show

--- a/crates/bld_ui/src/pages/home/pipelines/v2/mod.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/mod.rs
@@ -7,7 +7,7 @@ mod variables;
 
 use crate::{
     components::card::Card,
-    context::{RefreshCronJobs, RefreshHistory},
+    context::{PipelineSelectedView, PipelineView, RefreshCronJobs, RefreshHistory},
 };
 use bld_runner::pipeline::versioned::VersionedPipeline;
 use leptos::{leptos_dom::logging, *};
@@ -23,6 +23,8 @@ pub fn PipelineV2(
     #[prop(into)] name: Signal<Option<String>>,
     #[prop(into)] pipeline: Signal<Option<VersionedPipeline>>,
 ) -> impl IntoView {
+    let selected_view = PipelineSelectedView(create_rw_signal(PipelineView::UI));
+
     let raw = move || {
         pipeline.get().map(|x| {
             serde_yaml::to_string(&x)
@@ -39,9 +41,9 @@ pub fn PipelineV2(
         }
     };
 
-    let selected_group_item = create_rw_signal("view".to_string());
     provide_context(RefreshHistory(create_rw_signal(())));
     provide_context(RefreshCronJobs(create_rw_signal(())));
+    provide_context(selected_view);
 
     view! {
         <Show
@@ -51,10 +53,9 @@ pub fn PipelineV2(
                 <PipelineDetailsV2
                     id=id
                     name=name
-                    pipeline=move || pipeline().unwrap()
-                    selected_group_item=selected_group_item />
+                    pipeline=move || pipeline().unwrap() />
                 <Show
-                    when=move || selected_group_item.get() == "view"
+                    when=move || matches!(selected_view.get(), PipelineView::UI)
                     fallback=|| view! {}>
                     <div class="grid grid-cols-2 gap-8">
                         <PipelineJobsV2 jobs=move || pipeline().unwrap().jobs />
@@ -69,7 +70,7 @@ pub fn PipelineV2(
                     <PipelineHistAndCronV2 name=move || name.get() />
                 </Show>
                 <Show
-                    when=move || selected_group_item.get() == "rawfile"
+                    when=move || matches!(selected_view.get(), PipelineView::RawFile)
                     fallback=|| view! {}>
                     <Card>
                         <div class="px-8 py-12">

--- a/crates/bld_ui/src/pages/home/pipelines/v2/mod.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/mod.rs
@@ -5,7 +5,10 @@ mod hist_and_cron;
 mod jobs;
 mod variables;
 
-use crate::{components::card::Card, context::{RefreshCronJobs, RefreshHistory}};
+use crate::{
+    components::card::Card,
+    context::{RefreshCronJobs, RefreshHistory},
+};
 use bld_runner::pipeline::versioned::VersionedPipeline;
 use leptos::{leptos_dom::logging, *};
 

--- a/crates/bld_ui/src/pages/home/pipelines/v2/variables.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/variables.rs
@@ -2,7 +2,7 @@ use crate::components::{
     badge::Badge,
     card::Card,
     table::{Body, Cell, Header, Headers, Row, Table},
-    tabs::{TabItem, Tabs},
+    tabs::{Tab, Tabs},
 };
 use leptos::*;
 use std::collections::HashMap;
@@ -35,18 +35,7 @@ pub fn PipelineVariablesV2(
     #[prop(into)] variables: Signal<HashMap<String, String>>,
     #[prop(into)] environment: Signal<HashMap<String, String>>,
 ) -> impl IntoView {
-    let (tabs, _set_tabs) = create_signal(vec![
-        TabItem {
-            id: "variables".to_string(),
-            label: "Variables".to_string(),
-        },
-        TabItem {
-            id: "environment".to_string(),
-            label: "Environment".to_string(),
-        },
-    ]);
     let selected_tab = create_rw_signal("variables".to_string());
-
     view! {
         <Card>
             <div class="flex flex-col px-8 py-12 gap-y-4 min-h-96 max-h-[600px]">
@@ -56,7 +45,18 @@ pub fn PipelineVariablesV2(
                 <div class="text-gray-400">
                     "The configured variables and environment variables for this pipeline."
                 </div>
-                <Tabs items=tabs selected=selected_tab />
+                <Tabs>
+                    <Tab
+                        is_selected=move || selected_tab.get() == "variables"
+                        on:click=move |_| selected_tab.set("variables".to_string())>
+                        "Variables"
+                    </Tab>
+                    <Tab
+                        is_selected=move || selected_tab.get() == "environment"
+                        on:click=move |_| selected_tab.set("environment".to_string())>
+                        "Environment"
+                    </Tab>
+                </Tabs>
                 <Show
                     when=move || selected_tab.get() == "variables" && !variables.get().is_empty()
                     fallback=|| view! {}>

--- a/crates/bld_ui/src/pages/home/pipelines/v2/variables.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/variables.rs
@@ -7,6 +7,12 @@ use crate::components::{
 use leptos::*;
 use std::collections::HashMap;
 
+#[derive(Copy, Clone)]
+enum TabType {
+    Variables,
+    Environment,
+}
+
 #[component]
 fn VariablesTable(#[prop(into)] data: Signal<HashMap<String, String>>) -> impl IntoView {
     view! {
@@ -35,7 +41,12 @@ pub fn PipelineVariablesV2(
     #[prop(into)] variables: Signal<HashMap<String, String>>,
     #[prop(into)] environment: Signal<HashMap<String, String>>,
 ) -> impl IntoView {
-    let selected_tab = create_rw_signal("variables".to_string());
+    let selected_tab = create_rw_signal(TabType::Variables);
+    let view_is_variables = move || matches!(selected_tab.get(), TabType::Variables);
+    let view_is_environment = move || matches!(selected_tab.get(), TabType::Environment);
+    let set_view_to_variables = move || selected_tab.set(TabType::Variables);
+    let set_view_to_environment = move || selected_tab.set(TabType::Environment);
+
     view! {
         <Card>
             <div class="flex flex-col px-8 py-12 gap-y-4 min-h-96 max-h-[600px]">
@@ -47,35 +58,35 @@ pub fn PipelineVariablesV2(
                 </div>
                 <Tabs>
                     <Tab
-                        is_selected=move || selected_tab.get() == "variables"
-                        on:click=move |_| selected_tab.set("variables".to_string())>
+                        is_selected=move || view_is_variables()
+                        on:click=move |_| set_view_to_variables()>
                         "Variables"
                     </Tab>
                     <Tab
-                        is_selected=move || selected_tab.get() == "environment"
-                        on:click=move |_| selected_tab.set("environment".to_string())>
+                        is_selected=move || view_is_environment()
+                        on:click=move |_| set_view_to_environment()>
                         "Environment"
                     </Tab>
                 </Tabs>
                 <Show
-                    when=move || selected_tab.get() == "variables" && !variables.get().is_empty()
+                    when=move || view_is_variables()  && !variables.get().is_empty()
                     fallback=|| view! {}>
                     <VariablesTable data=variables />
                 </Show>
                 <Show
-                    when=move || selected_tab.get() == "variables" && variables.get().is_empty()
+                    when=move || view_is_variables() && variables.get().is_empty()
                     fallback=|| view! {}>
                     <div class="grid justify-items-center">
                         <Badge>"No variables configured."</Badge>
                     </div>
                 </Show>
                 <Show
-                    when=move || selected_tab.get() == "environment" && !environment.get().is_empty()
+                    when=move || view_is_environment() && !environment.get().is_empty()
                     fallback=|| view! {}>
                     <VariablesTable data=environment />
                 </Show>
                 <Show
-                    when=move || selected_tab.get() == "environment" && environment.get().is_empty()
+                    when=move || view_is_environment() && environment.get().is_empty()
                     fallback=|| view! {}>
                     <div class="grid justify-items-center">
                         <Badge>"No environment variables configured."</Badge>


### PR DESCRIPTION
### In this PR:
- Refactor almost all components to use children in order to remove the use of `.into_view()`.
- Added new context types.
- Refactored pages to properly use the components and solves some minor issues.