### PR TITLE
V0.4/task/bundle bld UI into server

### DIFF
--- a/.bld/pipelines/build.yaml
+++ b/.bld/pipelines/build.yaml
@@ -20,6 +20,12 @@ jobs:
       exec:
         - trunk build --release
 
+    - name: Move ui dist to bld_server
+      working_dir: ./bld
+      exec:
+        - mkdir crates/bld_server/static_files
+        - cp -r crates/bld_ui/dist/* crates/bld_server/static_files/
+
     - name: Cargo build for musl target
       working_dir: ./bld
       exec:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.vimspector.json
 /dist
 /crates/bld_ui/dist
+/crates/bld_server/static_files
 /.bld/**/*
 !/.bld/config.yaml
 !/.bld/pipelines

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,7 +1016,9 @@ dependencies = [
  "chrono",
  "futures",
  "futures-util",
+ "mime_guess",
  "openidconnect",
+ "rust-embed",
  "rustls 0.20.9",
  "sea-orm",
  "serde",
@@ -3153,6 +3155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,6 +4174,41 @@ dependencies = [
  "syn 2.0.71",
  "syn_derive",
  "thiserror",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+dependencies = [
+ "actix-web",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.71",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -5715,6 +5762,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ $ cargo build --release
 $ ./target/release/bld --version
 ```
 
-> IMPORTANT! The bld_server crate requires for a `static_files` directory to exist in its project structure and if it doesn't build error will appear since it tries to embed all of its files to the resulting binary. There is a `build.rs` file for the project that creates the directory but if you encounter any issues, create the directory manually.
+> The bld_server crate requires for a `static_files` directory to exist in its project structure and if it doesn't build error will appear since it tries to embed all of its files to the resulting binary. There is a `build.rs` file for the project that creates the directory but if you encounter any issues, create the directory manually.
 
 Bld also has a UI for its server that you can build it by running the below command
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,8 @@ $ cargo build --release
 $ ./target/release/bld --version
 ```
 
+> IMPORTANT! The bld_server crate requires for a `static_files` directory to exist in its project structure and if it doesn't build error will appear since it tries to embed all of its files to the resulting binary. There is a `build.rs` file for the project that creates the directory but if you encounter any issues, create the directory manually.
+
 Bld also has a UI for its server that you can build it by running the below command
 ```bash
 $ cd crates/bld_ui

--- a/crates/bld_server/Cargo.toml
+++ b/crates/bld_server/Cargo.toml
@@ -34,3 +34,5 @@ uuid = { version = "1.3.4", features = ["v4"] }
 rustls = "0.20.7"
 openidconnect = "3.1.1"
 actix-cors = "0.7.0"
+rust-embed = { version = "8.5.0", features = ["actix-web"] }
+mime_guess = "=2.0.5"

--- a/crates/bld_server/build.rs
+++ b/crates/bld_server/build.rs
@@ -1,0 +1,11 @@
+use std::{fs::create_dir, io::Error, path::PathBuf};
+
+fn main() -> Result<(), Error> {
+    let path = PathBuf::from("static_files");
+
+    if !path.exists() {
+        create_dir(&path)?;
+    }
+
+    Ok(())
+}

--- a/crates/bld_server/src/server.rs
+++ b/crates/bld_server/src/server.rs
@@ -59,7 +59,6 @@ pub async fn start(config: BldConfig, host: String, port: i64) -> Result<()> {
             .app_data(cron.clone())
             .wrap(middleware::Logger::default())
             .wrap(cors)
-            .service(home::get)
             .service(auth::available)
             .service(auth::redirect)
             .service(auth::refresh)
@@ -84,6 +83,8 @@ pub async fn start(config: BldConfig, host: String, port: i64) -> Result<()> {
             .service(resource("/v1/ws-exec/").route(get().to(exec::ws)))
             .service(resource("/v1/ws-monit/").route(get().to(monit::ws)))
             .service(resource("/v1/ws-login/").route(get().to(login::ws)))
+            .service(home::index)
+            .service(home::fallback)
     });
 
     let address = format!("{host}:{port}");


### PR DESCRIPTION
### In this PR
- Added dependencies to `rust-embed` and `mime_guess` in order to include static files to the bld_server crate.
- Updated the build pipeline to move the dist files from the `bld_ui` crate to the static_files directory of the `bld_server` crate.
- Added a new`build.rs` to create an empty `static_files` directory in order to prevent errors when building the project. 
- Updated Readme.md