### PR TITLE
V0.4/bugfix/runs flagged as faulted

### DIFF
--- a/crates/bld_core/src/context/local.rs
+++ b/crates/bld_core/src/context/local.rs
@@ -14,7 +14,7 @@ pub enum LocalContextMessage {
     RemoveRemoteRun(String),
     AddPlatform(Arc<Platform>),
     RemovePlatform(String),
-    DoCleanup(oneshot::Sender<()>),
+    RunFaulted(oneshot::Sender<()>),
 }
 
 pub struct LocalContextBackend {
@@ -62,13 +62,13 @@ impl LocalContextBackend {
                     self.platforms.retain(|p| !p.is(&platform_id));
                 }
 
-                LocalContextMessage::DoCleanup(resp_tx) => self.do_cleanup(resp_tx).await?,
+                LocalContextMessage::RunFaulted(resp_tx) => self.run_faulted(resp_tx).await?,
             }
         }
         Ok(())
     }
 
-    async fn do_cleanup(&mut self, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    async fn run_faulted(&mut self, resp_tx: oneshot::Sender<()>) -> Result<()> {
         for run in self.remote_runs.iter() {
             let _ = self
                 .cleanup_remote_run(run)

--- a/crates/bld_core/src/context/mod.rs
+++ b/crates/bld_core/src/context/mod.rs
@@ -181,16 +181,16 @@ impl Context {
             .map_err(|e| anyhow!("{e}"))
     }
 
-    pub async fn cleanup(&self) -> Result<()> {
+    pub async fn run_faulted(&self) -> Result<()> {
         let (resp_tx, resp_rx) = oneshot::channel();
 
         match self {
             Self::Server { tx, .. } => tx
-                .send(ServerContextMessage::DoCleanup(resp_tx))
+                .send(ServerContextMessage::RunFaulted(resp_tx))
                 .await
                 .map_err(|e| anyhow!(e))?,
             Self::Local(tx) => tx
-                .send(LocalContextMessage::DoCleanup(resp_tx))
+                .send(LocalContextMessage::RunFaulted(resp_tx))
                 .await
                 .map_err(|e| anyhow!(e))?,
         }

--- a/crates/bld_core/src/context/server.rs
+++ b/crates/bld_core/src/context/server.rs
@@ -32,7 +32,7 @@ pub enum ServerContextMessage {
     SetContainerAsRemoved(String),
     SetContainerAsFaulted(String),
     KeepAliveContainer(String),
-    DoCleanup(oneshot::Sender<()>),
+    RunFaulted(oneshot::Sender<()>),
 }
 
 pub struct ServerContextBackend {
@@ -142,7 +142,7 @@ impl ServerContextBackend {
                     .await?;
                 }
 
-                ServerContextMessage::DoCleanup(resp_tx) => self.do_cleanup(resp_tx).await?,
+                ServerContextMessage::RunFaulted(resp_tx) => self.run_faulted(resp_tx).await?,
             }
         }
         Ok(())
@@ -173,7 +173,7 @@ impl ServerContextBackend {
         Ok(())
     }
 
-    async fn do_cleanup(&mut self, resp_tx: oneshot::Sender<()>) -> Result<()> {
+    async fn run_faulted(&mut self, resp_tx: oneshot::Sender<()>) -> Result<()> {
         self.update_pipeline_state(&self.run_id, PR_STATE_FAULTED)
             .await?;
 

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -424,7 +424,7 @@ impl Runner {
                                 )
                                 .await?;
 
-                            context.cleanup().await?;
+                            context.run_faulted().await?;
 
                             break resp_tx
                                 .send(())

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -607,7 +607,7 @@ impl Runner {
                                 )
                                 .await?;
 
-                            context.cleanup().await?;
+                            context.run_faulted().await?;
 
                             break resp_tx
                                 .send(())

--- a/crates/bld_supervisor/src/queues/worker_queue.rs
+++ b/crates/bld_supervisor/src/queues/worker_queue.rs
@@ -299,7 +299,7 @@ async fn try_cleanup_process(conn: Data<DatabaseConnection>, worker: &mut Worker
     let run_id = worker.get_run_id();
     let run = pipeline_runs::select_by_id(conn, run_id).await?;
 
-    if run.state != PR_STATE_FINISHED || run.state != PR_STATE_FAULTED {
+    if run.state != PR_STATE_FINISHED && run.state != PR_STATE_FAULTED {
         let _ = pipeline_runs::update_state(conn, run_id, PR_STATE_FAULTED).await;
     }
 


### PR DESCRIPTION
### In this PR
- Fixed a boolean expression that caused all pipelines to be set as faulted.
- Minor refactoring on a function and enum names.