### PR TITLE
V0.4/task/container private repo options

### DIFF
--- a/.bld/dockerfiles/Dockerfile
+++ b/.bld/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78-bookworm
+FROM rust:1.81-bookworm
 
 ARG OPENSSL_VERSION=1.1.1m
 

--- a/crates/bld_commands/src/pull/command.rs
+++ b/crates/bld_commands/src/pull/command.rs
@@ -55,9 +55,8 @@ impl PullCommand {
             let mut deps = client
                 .deps(&self.pipeline)
                 .await
-                .map(|deps| {
+                .inspect(|_| {
                     println!("Done.");
-                    deps
                 })
                 .map_err(|e| {
                     println!("Error. {e}");
@@ -73,9 +72,8 @@ impl PullCommand {
             let data = client
                 .pull(pipeline)
                 .await
-                .map(|data| {
+                .inspect(|_| {
                     println!("Done.");
-                    data
                 })
                 .map_err(|err| {
                     println!("Error. {err}");

--- a/crates/bld_commands/src/push/command.rs
+++ b/crates/bld_commands/src/push/command.rs
@@ -59,9 +59,8 @@ impl PushCommand {
                 self.pipeline.to_owned(),
             )
             .await
-            .map(|pips| {
+            .inspect(|_| {
                 println!("Done.");
-                pips
             })
             .map_err(|e| {
                 println!("Error. {e}");
@@ -79,7 +78,7 @@ impl PushCommand {
             client
                 .push(&name, &content)
                 .await
-                .map(|_| println!("Done."))
+                .inspect(|_| println!("Done."))
                 .map_err(|e| {
                     println!("Error. {e}");
                     anyhow!("")

--- a/crates/bld_config/src/docker.rs
+++ b/crates/bld_config/src/docker.rs
@@ -68,3 +68,20 @@ impl Default for DockerUrl {
         Self::Single(definitions::LOCAL_DOCKER_URL.to_owned())
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryConfig {
+    pub url: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+impl RegistryConfig {
+    pub fn new(url: String) -> Self {
+        Self {
+            url,
+            username: None,
+            password: None,
+        }
+    }
+}

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -155,6 +155,10 @@ impl BldConfig {
             .ok_or_else(|| anyhow!("ssh configuration with name '{name}' wasn't found"))
     }
 
+    pub fn registry(&self, _name: &str) -> Option<&str> {
+        None
+    }
+
     pub async fn openid_core_client(&self) -> Result<Option<CoreClient>> {
         if let Some(auth) = &self.local.server.auth {
             auth.core_client(&self.local.server.base_url_http())

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -155,8 +155,8 @@ impl BldConfig {
             .ok_or_else(|| anyhow!("ssh configuration with name '{name}' wasn't found"))
     }
 
-    pub fn registry(&self, _name: &str) -> Option<&str> {
-        None
+    pub fn registry(&self, name: &str) -> Option<&RegistryConfig> {
+        self.local.registries.get(name)
     }
 
     pub async fn openid_core_client(&self) -> Result<Option<CoreClient>> {

--- a/crates/bld_config/src/local.rs
+++ b/crates/bld_config/src/local.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     definitions, ssh::SshConfig, BldLocalServerConfig, BldLocalSupervisorConfig, DockerUrl,
+    RegistryConfig,
 };
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +25,9 @@ pub struct BldLocalConfig {
 
     #[serde(default)]
     pub ssh: HashMap<String, SshConfig>,
+
+    #[serde(default)]
+    pub registries: HashMap<String, RegistryConfig>,
 }
 
 impl BldLocalConfig {
@@ -113,6 +117,7 @@ impl Default for BldLocalConfig {
             docker_url: Default::default(),
             editor: Self::default_editor(),
             ssh: Default::default(),
+            registries: Default::default(),
         }
     }
 }

--- a/crates/bld_core/src/platform/image.rs
+++ b/crates/bld_core/src/platform/image.rs
@@ -28,16 +28,12 @@ impl<'a> PullImage<'a> {
             ..Default::default()
         };
 
-        let credentials = if let Some(registry) = self.registry {
-            Some(DockerCredentials {
-                username: registry.username.as_ref().map(|x| x.to_owned()),
-                password: registry.password.as_ref().map(|x| x.to_owned()),
-                serveraddress: Some(registry.url.to_owned()),
-                ..Default::default()
-            })
-        } else {
-            None
-        };
+        let credentials = self.registry.map(|registry| DockerCredentials {
+            username: registry.username.as_ref().map(|x| x.to_owned()),
+            password: registry.password.as_ref().map(|x| x.to_owned()),
+            serveraddress: Some(registry.url.to_owned()),
+            ..Default::default()
+        });
 
         let mut stream = client.create_image(Some(opts), None, credentials);
 

--- a/crates/bld_models/src/queries/cron_job_environment_variables.rs
+++ b/crates/bld_models/src/queries/cron_job_environment_variables.rs
@@ -41,9 +41,8 @@ pub async fn select_by_cron_job_id<C: ConnectionTrait + TransactionTrait>(
         .filter(cron_job_environment_variables::Column::CronJobId.eq(cev_cron_job_id))
         .all(conn)
         .await
-        .map(|cev| {
+        .inspect(|_| {
             debug!("loaded cron job environment variables successfully");
-            cev
         })
         .map_err(|e| {
             error!("couldn't load cron job environment variables due to {e}");

--- a/crates/bld_models/src/queries/cron_job_variables.rs
+++ b/crates/bld_models/src/queries/cron_job_variables.rs
@@ -38,9 +38,8 @@ pub async fn select_by_cron_job_id<C: ConnectionTrait + TransactionTrait>(
         .filter(cron_job_variables::Column::CronJobId.eq(cv_cron_job_id))
         .all(conn)
         .await
-        .map(|cev| {
+        .inspect(|_| {
             debug!("loaded cron job variables successfully");
-            cev
         })
         .map_err(|e| {
             error!("couldn't load cron job variables due to {e}");

--- a/crates/bld_models/src/queries/cron_jobs.rs
+++ b/crates/bld_models/src/queries/cron_jobs.rs
@@ -36,9 +36,8 @@ pub async fn select_all<C: ConnectionTrait + TransactionTrait>(conn: &C) -> Resu
     CronJobEntity::find()
         .all(conn)
         .await
-        .map(|c| {
+        .inspect(|_| {
             debug!("loaded all cron jobs successfully");
-            c
         })
         .map_err(|e| {
             error!("couln't load cron jobs due to {e}");
@@ -64,9 +63,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load cron job due to not found");
             anyhow!("cron job not found")
         })
-        .map(|cj| {
+        .inspect(|_| {
             debug!("loaded cron job successfully");
-            cj
         })
 }
 
@@ -91,9 +89,8 @@ pub async fn select_default_by_pipeline<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load cron job due to not found");
             anyhow!("cron job not found")
         })
-        .map(|cj| {
+        .inspect(|_| {
             debug!("loading cron job successfully");
-            cj
         })
 }
 
@@ -106,9 +103,8 @@ pub async fn select_by_pipeline<C: ConnectionTrait + TransactionTrait>(
         .filter(cron_jobs::Column::PipelineId.eq(cj_pipeline_id))
         .all(conn)
         .await
-        .map(|cj| {
+        .inspect(|_| {
             debug!("loading cron job successfully");
-            cj
         })
         .map_err(|e| {
             error!("couldn't load cron job due to {e}");
@@ -145,9 +141,8 @@ pub async fn select_with_filters<C: ConnectionTrait + TransactionTrait>(
                 error!("couldn't load pipeline due to not found");
                 anyhow!("pipeline not found")
             })
-            .map(|model| {
+            .inspect(|_| {
                 debug!("loaded pipeline with name {flt_pipeline} successfully");
-                model
             })?;
         find = find.filter(cron_jobs::Column::PipelineId.eq(pipeline.id));
     }
@@ -164,9 +159,8 @@ pub async fn select_with_filters<C: ConnectionTrait + TransactionTrait>(
 
     find.all(conn)
         .await
-        .map(|jobs| {
+        .inspect(|_| {
             debug!("loaded cron jobs successfully!");
-            jobs
         })
         .map_err(|e| {
             error!("unable to load cron jobs due to {e}");

--- a/crates/bld_models/src/queries/ha_client_serial_responses.rs
+++ b/crates/bld_models/src/queries/ha_client_serial_responses.rs
@@ -49,9 +49,8 @@ pub async fn select_last<C: ConnectionTrait + TransactionTrait>(
             error!("couldn'y load high availability client serial respone due to: not found");
             anyhow!("high availability client serial response not found")
         })
-        .map(|csr| {
+        .inspect(|_| {
             debug!("loaded high availability client serial response successfully");
-            csr
         })
 }
 
@@ -80,9 +79,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability client serial response due to: not found");
             anyhow!("high availability client serial response not found")
         })
-        .map(|csr| {
+        .inspect(|_| {
             debug!("loaded high availability client serial response successfully");
-            csr
         })
 }
 

--- a/crates/bld_models/src/queries/ha_client_status.rs
+++ b/crates/bld_models/src/queries/ha_client_status.rs
@@ -49,9 +49,8 @@ pub async fn select_last<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability client status due to: not found");
             anyhow!("high availability client status not found")
         })
-        .map(|cs| {
+        .inspect(|_| {
             debug!("loaded high availability client status successfully");
-            cs
         })
 }
 
@@ -80,9 +79,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability client status due to: not found");
             anyhow!("high availability client status not found")
         })
-        .map(|cs| {
+        .inspect(|_| {
             debug!("loaded high availability client status successfully");
-            cs
         })
 }
 

--- a/crates/bld_models/src/queries/ha_hard_state.rs
+++ b/crates/bld_models/src/queries/ha_hard_state.rs
@@ -46,9 +46,8 @@ pub async fn select_first<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load the first high availability hard state due to: not found");
             anyhow!("high availability hard state not found")
         })
-        .map(|ha| {
+        .inspect(|_| {
             debug!("loaded the first high availability hard state successfully");
-            ha
         })
 }
 
@@ -70,9 +69,8 @@ pub async fn select_last<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability hard state due to: not found");
             anyhow!("high availability hard state not found")
         })
-        .map(|hs| {
+        .inspect(|_| {
             debug!("loaded high availability hard state successfully");
-            hs
         })
 }
 
@@ -95,9 +93,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability hard state due to: not found");
             anyhow!("high availability hard state not found")
         })
-        .map(|hs| {
+        .inspect(|_| {
             debug!("loaded high availability hard state successfully");
-            hs
         })
 }
 

--- a/crates/bld_models/src/queries/ha_log.rs
+++ b/crates/bld_models/src/queries/ha_log.rs
@@ -53,9 +53,8 @@ pub async fn select_last<C: ConnectionTrait + TransactionTrait>(conn: &C) -> Res
             error!("couldn't load high availability log due to: not found");
             anyhow!("high availability log not found")
         })
-        .map(|l| {
+        .inspect(|_| {
             debug!("loaded high availability log successfully");
-            l
         })
 }
 
@@ -70,9 +69,8 @@ pub async fn select_last_rows<C: ConnectionTrait + TransactionTrait>(
         .limit(rows)
         .all(conn)
         .await
-        .map(|l| {
+        .inspect(|_| {
             debug!("loaded high availability logs successfully");
-            l
         })
         .map_err(|e| {
             error!("could not load high availability logs due to: {}", e);
@@ -99,9 +97,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability log due to: not found");
             anyhow!("high availability log not found")
         })
-        .map(|l| {
+        .inspect(|_| {
             debug!("loaded high availability log successfully");
-            l
         })
 }
 
@@ -119,9 +116,8 @@ pub async fn select_between_ids<C: ConnectionTrait + TransactionTrait>(
         .filter(high_availability_log::Column::Id.lte(lg_end_id))
         .all(conn)
         .await
-        .map(|l| {
+        .inspect(|_| {
             debug!("loaded high availability logs successfully");
-            l
         })
         .map_err(|e| {
             error!("could not load high availability logs due to: {}", e);
@@ -153,9 +149,8 @@ pub async fn select_by_payload_type<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability log due to: not found");
             anyhow!("high availability log not found")
         })
-        .map(|l| {
+        .inspect(|_| {
             debug!("load high availability log model entries successfully");
-            l
         })
 }
 
@@ -178,9 +173,8 @@ pub async fn select_first_by_date_created_desc<C: ConnectionTrait + TransactionT
             error!("couldn't load high availability log due to: not found");
             anyhow!("high availability log not found")
         })
-        .map(|l| {
+        .inspect(|_| {
             debug!("loaded first high availability log successfully");
-            l
         })
 }
 
@@ -208,9 +202,8 @@ pub async fn select_config_greater_than_id<C: ConnectionTrait + TransactionTrait
             error!("couldn't load high availability log due to: not found");
             anyhow!("high availability log not found")
         })
-        .map(|l| {
+        .inspect(|_| {
             debug!("loaded high availability logs successfully");
-            l
         })
 }
 

--- a/crates/bld_models/src/queries/ha_members.rs
+++ b/crates/bld_models/src/queries/ha_members.rs
@@ -42,12 +42,11 @@ pub async fn select<C: ConnectionTrait + TransactionTrait>(
         .filter(high_availability_snapshot::Column::Id.eq(sn_id))
         .all(conn)
         .await
-        .map(|m| {
+        .inspect(|_| {
             debug!(
                 "loaded high availability members of snapshot with id: {} successfully",
                 sn_id
             );
-            m
         })
         .map_err(|e| {
             error!("could not load high availability members due to: {}", e);
@@ -65,9 +64,8 @@ pub async fn select_last_rows<C: ConnectionTrait + TransactionTrait>(
         .limit(rows)
         .all(conn)
         .await
-        .map(|m| {
+        .inspect(|_| {
             debug!("loaded high availability members successfully");
-            m
         })
         .map_err(|e| {
             error!("could not load high availability members due to: {}", e);

--- a/crates/bld_models/src/queries/ha_members_after_consensus.rs
+++ b/crates/bld_models/src/queries/ha_members_after_consensus.rs
@@ -45,12 +45,11 @@ pub async fn select<C: ConnectionTrait + TransactionTrait>(
         .filter(high_availability_snapshot::Column::Id.eq(sn_id))
         .all(conn)
         .await
-        .map(|mc| {
+        .inspect(|_| {
             debug!(
                 "loaded high availability members after consensus of snapshot: {} successfully",
                 sn_id
             );
-            mc
         })
         .map_err(|e| {
             error!(
@@ -74,9 +73,8 @@ pub async fn select_last_rows<C: ConnectionTrait + TransactionTrait>(
         .limit(rows)
         .all(conn)
         .await
-        .map(|mc| {
+        .inspect(|_| {
             debug!("loaded high availability members after consensus successfully");
-            mc
         })
         .map_err(|e| {
             error!(

--- a/crates/bld_models/src/queries/ha_snapshot.rs
+++ b/crates/bld_models/src/queries/ha_snapshot.rs
@@ -44,9 +44,8 @@ pub async fn select_last<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability snapshot due to: not found");
             anyhow!("high availability snapshot not found")
         })
-        .map(|sn| {
+        .inspect(|_| {
             debug!("loaded high availability snapshot successfully");
-            sn
         })
 }
 

--- a/crates/bld_models/src/queries/ha_state_machine.rs
+++ b/crates/bld_models/src/queries/ha_state_machine.rs
@@ -33,9 +33,8 @@ pub async fn select_first<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability state machine due to: not found");
             anyhow!("high availability state machine not found")
         })
-        .map(|sm| {
+        .inspect(|_| {
             debug!("loaded high availability state machine successfully");
-            sm
         })
 }
 
@@ -61,9 +60,8 @@ pub async fn select_last<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability state machine due to: not found");
             anyhow!("high availability state machine not found")
         })
-        .map(|sm| {
+        .inspect(|_| {
             debug!("loaded high availability state machine successfully");
-            sm
         })
 }
 
@@ -89,9 +87,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load high availability state machine due to: not found");
             anyhow!("high availability state machine not found")
         })
-        .map(|sm| {
+        .inspect(|_| {
             debug!("loaded high availability state machine successfully");
-            sm
         })
 }
 

--- a/crates/bld_models/src/queries/login_attempts.rs
+++ b/crates/bld_models/src/queries/login_attempts.rs
@@ -66,9 +66,8 @@ pub async fn select_by_csrf_token(
             error!("couldn't load login attempt due to not found");
             anyhow!("login attempt not found")
         })
-        .map(|p| {
+        .inspect(|_| {
             debug!("loaded login attempt successfully");
-            p
         })
 }
 

--- a/crates/bld_models/src/queries/pipeline.rs
+++ b/crates/bld_models/src/queries/pipeline.rs
@@ -23,9 +23,8 @@ pub async fn select_all<C: ConnectionTrait + TransactionTrait>(conn: &C) -> Resu
         .order_by_asc(pipeline::Column::Name)
         .all(conn)
         .await
-        .map(|p| {
+        .inspect(|_| {
             debug!("loaded all pipelines successfully");
-            p
         })
         .map_err(|e| {
             error!("couldn't load pipelines due to {e}");
@@ -43,9 +42,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
     let model = PipelineEntity::find_by_id(pip_id)
         .one(conn)
         .await
-        .map(|p| {
+        .inspect(|_| {
             debug!("loaded pipeline successfully");
-            p
         })
         .map_err(|e| {
             error!("could not load pipeline due to {e}");
@@ -78,9 +76,8 @@ pub async fn select_by_name<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load pipeline due to not found");
             anyhow!("pipeline not found")
         })
-        .map(|p| {
+        .inspect(|_| {
             debug!("loaded pipeline successfully");
-            p
         })
 }
 

--- a/crates/bld_models/src/queries/pipeline_run_containers.rs
+++ b/crates/bld_models/src/queries/pipeline_run_containers.rs
@@ -46,9 +46,8 @@ pub async fn select_by_id<C: ConnectionTrait + TransactionTrait>(
             error!("couldn't load pipeline run container. Not found");
             anyhow!("pipeline run container not found")
         })
-        .map(|prc| {
+        .inspect(|_| {
             debug!("loaded pipeline run container successfully");
-            prc
         })
 }
 
@@ -83,9 +82,8 @@ pub async fn select_in_invalid_state<C: ConnectionTrait + TransactionTrait>(
         .filter(pipeline_run_containers::Column::Id.eq(PRC_STATE_FAULTED))
         .all(conn)
         .await
-        .map(|prc| {
+        .inspect(|_| {
             debug!("loaded faulted pipeline run containers successfully");
-            prc
         })
         .map_err(|e| {
             error!("could not load pipeline run containers, {e}");

--- a/crates/bld_runner/src/lib.rs
+++ b/crates/bld_runner/src/lib.rs
@@ -3,6 +3,7 @@ pub mod external;
 pub mod pipeline;
 pub mod runs_on;
 pub mod step;
+pub mod registry;
 
 #[cfg(feature = "all")]
 mod runner;

--- a/crates/bld_runner/src/lib.rs
+++ b/crates/bld_runner/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod artifacts;
 pub mod external;
 pub mod pipeline;
+pub mod registry;
 pub mod runs_on;
 pub mod step;
-pub mod registry;
 
 #[cfg(feature = "all")]
 mod runner;

--- a/crates/bld_runner/src/registry/mod.rs
+++ b/crates/bld_runner/src/registry/mod.rs
@@ -1,0 +1,1 @@
+pub mod v2;

--- a/crates/bld_runner/src/registry/v2.rs
+++ b/crates/bld_runner/src/registry/v2.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::token_context::v2::PipelineContext;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Registry {
+    UrlOrConfigKey(String),
+    Full {
+        url: String,
+        username: String,
+        password: String,
+    },
+}
+
+impl Registry {
+    pub async fn apply_tokens<'a>(&mut self, context: &PipelineContext<'a>) -> Result<()> {
+        match self {
+            Registry::UrlOrConfigKey(url) => {
+                *url = context.transform(url.to_owned()).await?;
+            }
+            Registry::Full {
+                url,
+                username,
+                password,
+            } => {
+                *url = context.transform(url.to_owned()).await?;
+                *username = context.transform(username.to_owned()).await?;
+                *password = context.transform(password.to_owned()).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/bld_runner/src/registry/v2.rs
+++ b/crates/bld_runner/src/registry/v2.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bld_config::RegistryConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::token_context::v2::PipelineContext;
@@ -6,28 +7,24 @@ use crate::token_context::v2::PipelineContext;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Registry {
-    UrlOrConfigKey(String),
-    Full {
-        url: String,
-        username: String,
-        password: String,
-    },
+    FromConfig(String),
+    Full(RegistryConfig),
 }
 
 impl Registry {
     pub async fn apply_tokens<'a>(&mut self, context: &PipelineContext<'a>) -> Result<()> {
         match self {
-            Registry::UrlOrConfigKey(url) => {
+            Registry::FromConfig(url) => {
                 *url = context.transform(url.to_owned()).await?;
             }
-            Registry::Full {
-                url,
-                username,
-                password,
-            } => {
-                *url = context.transform(url.to_owned()).await?;
-                *username = context.transform(username.to_owned()).await?;
-                *password = context.transform(password.to_owned()).await?;
+            Registry::Full(ref mut config) => {
+                config.url = context.transform(config.url.to_owned()).await?;
+                if let Some(ref mut username) = config.username {
+                    config.username = Some(context.transform(username.to_owned()).await?);
+                }
+                if let Some(ref mut password) = config.password {
+                    config.password = Some(context.transform(password.to_owned()).await?);
+                }
             }
         }
         Ok(())

--- a/crates/bld_runner/src/registry/v2.rs
+++ b/crates/bld_runner/src/registry/v2.rs
@@ -12,6 +12,7 @@ pub enum Registry {
 }
 
 impl Registry {
+    #[cfg(feature = "all")]
     pub async fn apply_tokens<'a>(&mut self, context: &PipelineContext<'a>) -> Result<()> {
         match self {
             Registry::FromConfig(url) => {

--- a/crates/bld_runner/src/registry/v2.rs
+++ b/crates/bld_runner/src/registry/v2.rs
@@ -1,7 +1,10 @@
-use anyhow::Result;
 use bld_config::RegistryConfig;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "all")]
+use anyhow::Result;
+
+#[cfg(feature = "all")]
 use crate::token_context::v2::PipelineContext;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -321,6 +321,7 @@ impl Runner {
                 image,
                 pull,
                 docker_url,
+                ..
             } => {
                 let image = if pull.unwrap_or_default() {
                     Image::pull(image)

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -327,7 +327,7 @@ impl Runner {
                 let image = if pull.unwrap_or_default() {
                     match registry.as_ref() {
                         Some(Registry::FromConfig(value)) => {
-                            Image::pull(image, self.config.registry(&value))
+                            Image::pull(image, self.config.registry(value))
                         }
                         Some(Registry::Full(config)) => Image::pull(image, Some(config)),
                         None => Image::pull(image, None),

--- a/crates/bld_runner/src/runs_on/v2.rs
+++ b/crates/bld_runner/src/runs_on/v2.rs
@@ -48,7 +48,7 @@ impl Display for RunsOn {
 }
 
 impl RunsOn {
-    pub fn registry<'a>(&'a self) -> Option<&'a str> {
+    pub fn registry(&self) -> Option<&str> {
         match self {
             RunsOn::Pull {
                 registry: Some(Registry::FromConfig(config)),
@@ -62,7 +62,7 @@ impl RunsOn {
         }
     }
 
-    pub fn registry_username<'a>(&'a self) -> Option<&'a str> {
+    pub fn registry_username(&self) -> Option<&str> {
         match self {
             RunsOn::Pull {
                 registry: Some(Registry::Full(config)),

--- a/crates/bld_runner/src/runs_on/v2.rs
+++ b/crates/bld_runner/src/runs_on/v2.rs
@@ -1,7 +1,7 @@
+use crate::registry::v2::Registry;
 use bld_config::SshConfig;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
-use crate::registry::v2::Registry;
 
 #[cfg(feature = "all")]
 use anyhow::Result;
@@ -52,7 +52,10 @@ impl RunsOn {
     pub async fn apply_tokens<'a>(&mut self, context: &PipelineContext<'a>) -> Result<()> {
         match self {
             RunsOn::Pull {
-                image, registry, docker_url, ..
+                image,
+                registry,
+                docker_url,
+                ..
             } => {
                 *image = context.transform(image.to_owned()).await?;
                 if let Some(docker_url) = docker_url {

--- a/crates/bld_runner/src/runs_on/v2.rs
+++ b/crates/bld_runner/src/runs_on/v2.rs
@@ -47,8 +47,32 @@ impl Display for RunsOn {
     }
 }
 
-#[cfg(feature = "all")]
 impl RunsOn {
+    pub fn registry<'a>(&'a self) -> Option<&'a str> {
+        match self {
+            RunsOn::Pull {
+                registry: Some(Registry::FromConfig(config)),
+                ..
+            } => Some(config),
+            RunsOn::Pull {
+                registry: Some(Registry::Full(config)),
+                ..
+            } => Some(&config.url),
+            _ => None,
+        }
+    }
+
+    pub fn registry_username<'a>(&'a self) -> Option<&'a str> {
+        match self {
+            RunsOn::Pull {
+                registry: Some(Registry::Full(config)),
+                ..
+            } => config.username.as_deref(),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "all")]
     pub async fn apply_tokens<'a>(&mut self, context: &PipelineContext<'a>) -> Result<()> {
         match self {
             RunsOn::Pull {

--- a/crates/bld_server/src/supervisor/channel.rs
+++ b/crates/bld_server/src/supervisor/channel.rs
@@ -79,9 +79,8 @@ impl SupervisorMessageReceiver {
                 EnqueueClient::new(SinkWrite::new(sink, ctx))
             });
 
-            address.send(ServerMessages::Ack).await.map_err(|e| {
+            address.send(ServerMessages::Ack).await.inspect_err(|e| {
                 error!("failed to send Ack to supervisor, {e}");
-                e
             })?;
 
             if let Some(msg) = self.last_message {

--- a/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/v2/details.rs
@@ -17,6 +17,15 @@ pub fn PipelineDetailsV2(
     let cron = move || pipeline.with(|p| p.cron.as_ref().map(|x| format!("Cron: {x}")));
     let runs_on = move || pipeline.with(|p| format!("Runs on: {}", p.runs_on));
     let dispose = move || pipeline.with(|p| format!("Dispose: {}", p.dispose));
+    let registry =
+        move || pipeline.with(|p| p.runs_on.registry().map(|x| format!("Registry: {x}")));
+    let username = move || {
+        pipeline.with(|p| {
+            p.runs_on
+                .registry_username()
+                .map(|x| format!("Username: {x}"))
+        })
+    };
 
     view! {
         <Card>
@@ -29,6 +38,12 @@ pub fn PipelineDetailsV2(
                     <div class="flex gap-x-2">
                         <Badge>"Version: 2"</Badge>
                         <Badge>{move || runs_on()}</Badge>
+                        <Show when=move || registry().is_some() fallback=|| view! {}>
+                            <Badge>{move || registry()}</Badge>
+                        </Show>
+                        <Show when=move || username().is_some() fallback=|| view! {}>
+                            <Badge>{move || username()}</Badge>
+                        </Show>
                         <Show when=move || cron().is_some() fallback=|| view! {}>
                             <Badge>{move || cron().unwrap()}</Badge>
                         </Show>


### PR DESCRIPTION
### In this PR:
- Added new field in the BldConfig for docker registries that supports url, username and password.
- Added new optional configuration in the runs_on section of a pipeline in order to define a registry configuration with url, username and password or use a key to lookup a registry from the bld configuration.
- Added support for expressions in all variants of a registry section in a pipeline.
- Made changes to the platform in order to pull an image from a registry based on the provided configuration.