### PR TITLE
260 enable codegen units

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ debug = true
 lto = true
 opt-level = 3
 debug = false
+codegen-units = 1
 
 [dependencies]
 anyhow = "1.0.93"


### PR DESCRIPTION
### In this PR:
- Set `codegen-units=1` in the project `Cargo.toml` file