### PR TITLE
284 add not equals operator to expressions

### DIFF
--- a/crates/bld_runner/grammar/expr_v3.pest
+++ b/crates/bld_runner/grammar/expr_v3.pest
@@ -2,6 +2,7 @@
 // Defining operators
 //
 EqualsOperator = @{ " "* ~ "==" ~ " "* }
+NotEqualsOperator = @{ " "* ~ "!=" ~ " "* }
 GreaterOperator = @{ " "* ~ ">" ~ " "* }
 GreaterEqualsOperator = @{ " "* ~ ">=" ~ " "* }
 LessOperator = @{ " "* ~ "<" ~ " "* }
@@ -11,6 +12,7 @@ OrOperator = @{ " "* ~ "||" ~ " "* }
 
 Operator = {
     EqualsOperator
+    | NotEqualsOperator
     | GreaterOperator
     | GreaterEqualsOperator
     | LessOperator
@@ -52,12 +54,13 @@ Symbol = { Boolean | Number | String | Object }
 // Defining expressions
 //
 Equals = { Symbol ~ EqualsOperator ~ Symbol }
+NotEquals = { Symbol ~ NotEqualsOperator ~ Symbol }
 Greater = { Symbol ~ GreaterOperator ~ Symbol }
 GreaterEquals = { Symbol ~ GreaterEqualsOperator ~ Symbol }
 Less = { Symbol ~ LessOperator ~ Symbol }
 LessEquals = { Symbol ~ LessEqualsOperator ~ Symbol }
 
-ExpressionInner = { Equals | Greater | GreaterEquals | Less | LessEquals | Symbol }
+ExpressionInner = { Equals | NotEquals | Greater | GreaterEquals | Less | LessEquals | Symbol }
 Expression = { ("(" ~ " "* ~ ExpressionInner ~ " "* ~ ")") | ExpressionInner }
 
 LogicalExpression = {  Expression ~ ((AndOperator | OrOperator) ~ Expression)+ }

--- a/crates/bld_runner/src/expr/v3/parser.rs
+++ b/crates/bld_runner/src/expr/v3/parser.rs
@@ -30,6 +30,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_not_equals_operator_success() {
+        let data = ["!=", " !=", "!= ", " != "];
+        for op in data {
+            let Ok(pairs) = ExprParser::parse(Rule::NotEqualsOperator, op) else {
+                panic!("unable to parse NotEqualsOperator");
+            };
+            for pair in pairs {
+                let Rule::NotEqualsOperator = pair.as_rule() else {
+                    panic!("parsed value is not a NotEqualsOperator rule");
+                };
+                assert_eq!(pair.as_span().as_str(), op);
+            }
+        }
+    }
+
+    #[test]
     fn parse_greater_operator_success() {
         let data = [">", " >", "> ", " > "];
         for op in data {
@@ -318,6 +334,41 @@ mod tests {
         ];
         for op in data {
             let pair = ExprParser::parse(Rule::Equals, op);
+            assert!(pair.is_ok());
+        }
+    }
+
+    #[test]
+    fn parse_not_equals_success() {
+        let data = [
+            "100 != 150.12",
+            "100 != -150.12",
+            "-100 != -150.12",
+            "-100 != 150.12",
+            "100!= 150.12",
+            "100 !=-150.12",
+            "-100!=-150.12",
+            "100 != true",
+            "true!= true",
+            "true !=false",
+            "false!=false",
+            "\"hello\" != 100",
+            "\"hello\" != -100",
+            "\"hello\" != true",
+            "\"hello\" != false",
+            "\"hello\" != customer.name.length",
+            "\"hello\" != customer().name().length()",
+            "\"hello\" != customer().name23_23().length()",
+            "\"hello\" != \"hello world\"",
+            "100 != \"hello\"",
+            "-100 != \"hello\"",
+            "true != \"hello\"",
+            "false != \"hello\"",
+            "customer.name.length != \"hello\"",
+            "\"hello world\" != \"hello\"",
+        ];
+        for op in data {
+            let pair = ExprParser::parse(Rule::NotEquals, op);
             assert!(pair.is_ok());
         }
     }
@@ -660,7 +711,7 @@ mod tests {
 
     #[test]
     fn parse_composite_logical_expression_success() {
-        let data = ["100 == 200 && true == false || (\"hello world\" > \"world\")"];
+        let data = ["100 == 200 && true == false || (\"hello world\" > \"world\") || 100 != 200"];
         for expr in data {
             let Ok(pairs) = ExprParser::parse(Rule::LogicalExpression, expr) else {
                 panic!("unable to parse LogicalExpression rule");
@@ -682,6 +733,7 @@ mod tests {
                                 let body_inner = body.next().unwrap();
                                 assert!(
                                     body_inner.as_rule() == Rule::Equals
+                                        || body_inner.as_rule() == Rule::NotEquals
                                         || body_inner.as_rule() == Rule::Greater
                                         || body_inner.as_rule() == Rule::GreaterEquals
                                         || body_inner.as_rule() == Rule::Less

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -52,6 +52,13 @@ impl<'a, 'b> ExprValue<'a> {
         Ok(ExprValue::<'b>::Boolean(value))
     }
 
+    pub fn try_not_eq(&self, other: &'a Self) -> Result<ExprValue<'b>> {
+        let ExprValue::Boolean(value) = self.try_eq(other)? else {
+            bail!("non boolean type is an invalid comparison result");
+        };
+        Ok(ExprValue::<'b>::Boolean(!value))
+    }
+
     pub fn try_ord(&self, other: &'a Self) -> Result<ExprValue<'b>> {
         let value = match (self, other) {
             (Self::Number(l), Self::Number(r)) => l > r,


### PR DESCRIPTION
### In this PR:
- Added new rules for the NotEquals operator in the .pest file.
- Added new tests for the not equals operator in the expression parser.
- Added expression evaluation for the not equals operator and added tests.