### PR TITLE
255 pipeline and action steps should support outputs

### DIFF
--- a/.bld/config.yaml
+++ b/.bld/config.yaml
@@ -1,3 +1,3 @@
 local:
-  docker_url: unix://var/run/docker.sock
+  docker_url: unix://var/run/user/1000/podman/podman.sock
   editor: nvim

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "cron",
  "futures",
  "futures-util",
+ "mockall",
  "pest",
  "pest_derive",
  "regex",
@@ -1757,6 +1758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +1990,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "funty"
@@ -3308,6 +3321,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,6 +3905,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -5615,6 +5680,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -19,6 +19,8 @@ pub const KEYWORD_PROJECT_DIR_V3: &str = "bld_project_dir";
 pub const KEYWORD_RUN_PROPS_ID_V3: &str = "bld_run_id";
 pub const KEYWORD_RUN_PROPS_START_TIME_V3: &str = "bld_start_time";
 
+pub const BLD_OUTPUTS_ENV_VAR_V3: &str = "BLD_OUTPUTS";
+
 pub const TOOL_DEFAULT_PIPELINE: &str = "default";
 pub const TOOL_DEFAULT_PIPELINE_FILE: &str = "default.yaml";
 pub const TOOL_DEFAULT_CONFIG: &str = "config";

--- a/crates/bld_core/src/platform/container.rs
+++ b/crates/bld_core/src/platform/container.rs
@@ -99,7 +99,7 @@ impl Container {
             client,
             context: options.context,
             env,
-            outputs_dir: path!["/tmp/outputs"],
+            outputs_dir: path!["tmp", "outputs"],
         };
 
         instance

--- a/crates/bld_core/src/platform/container.rs
+++ b/crates/bld_core/src/platform/container.rs
@@ -148,7 +148,7 @@ impl Container {
         logger: Arc<Logger>,
         working_dir: &Option<String>,
         input: &str,
-    ) -> Result<()> {
+    ) -> Result<HashMap<String, String>> {
         let input = working_dir
             .as_ref()
             .map(|wd| format!("cd {wd} && {input}"))
@@ -168,7 +168,7 @@ impl Container {
         let exec_stream = self.client.start_exec(&exec.id, None).await?;
 
         let StartExecResults::Attached { mut output, .. } = exec_stream else {
-            return Ok(());
+            return Ok(HashMap::new());
         };
 
         while let Some(result) = output.next().await {
@@ -196,7 +196,7 @@ impl Container {
             bail!("command finished with exit code: {exit_code}");
         }
 
-        Ok(())
+        Ok(HashMap::new())
     }
 
     pub async fn keep_alive(&self) -> Result<()> {

--- a/crates/bld_core/src/platform/container.rs
+++ b/crates/bld_core/src/platform/container.rs
@@ -1,7 +1,8 @@
 use std::{collections::HashMap, path::Path, path::PathBuf, sync::Arc};
 
 use anyhow::{Result, anyhow, bail};
-use bld_config::{BldConfig, path};
+use bld_config::{BldConfig, definitions::BLD_OUTPUTS_ENV_VAR_V3, path};
+use bld_utils::variables::parse_variables_iter;
 use bollard::{
     Docker,
     container::{
@@ -36,6 +37,7 @@ pub struct Container {
     pub client: Docker,
     pub context: PlatformContext,
     pub env: Vec<String>,
+    pub outputs_dir: PathBuf,
 }
 
 impl Container {
@@ -90,14 +92,25 @@ impl Container {
 
         options.context.add(&id).await?;
 
-        Ok(Self {
+        let instance = Self {
             id,
             name,
             config: Some(options.config),
             client,
             context: options.context,
             env,
-        })
+            outputs_dir: path!["/tmp/outputs"],
+        };
+
+        instance
+            .run_internal_cmd(vec![
+                "mkdir",
+                "-p",
+                &instance.outputs_dir.display().to_string(),
+            ])
+            .await?;
+
+        Ok(instance)
     }
 
     pub async fn copy_from(&self, from: &str, to: &str) -> Result<()> {
@@ -143,19 +156,80 @@ impl Container {
         Ok(())
     }
 
+    async fn run_internal_cmd(&self, cmd: Vec<&str>) -> Result<String> {
+        debug!("running internal container command");
+        let options = CreateExecOptions {
+            cmd: Some(cmd),
+            attach_stdout: Some(true),
+            attach_stderr: Some(true),
+            ..Default::default()
+        };
+
+        let exec = self.client.create_exec(&self.name, options).await?;
+        let exec_stream = self.client.start_exec(&exec.id, None).await?;
+
+        let StartExecResults::Attached { mut output, .. } = exec_stream else {
+            debug!("unable to attach stdout for internal container command");
+            bail!("unable to communicate with container");
+        };
+
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        while let Some(result) = output.next().await {
+            let Ok(output) = result else {
+                continue;
+            };
+            match output {
+                LogOutput::StdIn { .. } | LogOutput::Console { .. } => {
+                    continue;
+                }
+                LogOutput::StdOut { message } => {
+                    let chunk_str = String::from_utf8(message.into())?;
+                    stdout.push_str(&chunk_str);
+                }
+                LogOutput::StdErr { message } => {
+                    let chunk_str = String::from_utf8(message.into())?;
+                    stderr.push_str(&chunk_str);
+                }
+            };
+        }
+
+        let inspect = self.client.inspect_exec(&exec.id).await?;
+        let Some(exit_code) = inspect.exit_code else {
+            bail!("unable to confirm exit code for creating outputs file");
+        };
+
+        if exit_code != 0 {
+            debug!("failed to run internal container command due to {stderr}");
+            bail!("command finished with exit code: {exit_code}");
+        }
+
+        debug!("successfully run internal container command");
+        Ok(stdout)
+    }
+
     pub async fn sh(
         &self,
         logger: Arc<Logger>,
         working_dir: &Option<String>,
         input: &str,
     ) -> Result<HashMap<String, String>> {
+        let outputs_path = path![&self.outputs_dir, Uuid::new_v4().to_string()]
+            .display()
+            .to_string();
+
+        // self.run_internal_cmd(vec!["touch", &outputs_path]).await?;
+
         let input = working_dir
             .as_ref()
             .map(|wd| format!("cd {wd} && {input}"))
             .or_else(|| Some(input.to_string()))
             .unwrap();
 
-        let env = self.env.iter().map(String::as_str).collect();
+        let outputs_env = format!("{BLD_OUTPUTS_ENV_VAR_V3}={}", outputs_path);
+        let mut env: Vec<&str> = self.env.iter().map(String::as_str).collect();
+        env.push(&outputs_env);
+
         let options = CreateExecOptions {
             cmd: Some(vec!["bash", "-c", &input]),
             env: Some(env),
@@ -196,7 +270,15 @@ impl Container {
             bail!("command finished with exit code: {exit_code}");
         }
 
-        Ok(HashMap::new())
+        // Ignoring errors here but logging them since many steps don't create outputs and thus
+        // the outputs files might not even exist
+        let outputs = self
+            .run_internal_cmd(vec!["cat", &outputs_path])
+            .await
+            .unwrap_or_default();
+        let outputs = parse_variables_iter(outputs.lines());
+
+        Ok(outputs)
     }
 
     pub async fn keep_alive(&self) -> Result<()> {

--- a/crates/bld_core/src/platform/machine.rs
+++ b/crates/bld_core/src/platform/machine.rs
@@ -9,7 +9,7 @@ use std::{
     process::ExitStatus,
     sync::Arc,
 };
-use tokio::fs::{File, copy, create_dir_all, read_to_string, remove_dir_all};
+use tokio::fs::{copy, create_dir_all, read_to_string, remove_dir_all};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -73,7 +73,7 @@ impl Machine {
     ) -> Result<HashMap<String, String>> {
         let id = Uuid::new_v4();
         let outputs_file = path![&self.tmp_dir, id.to_string()];
-        File::create(&outputs_file).await?;
+        // File::create(&outputs_file).await?;
         debug!("creating new outputs file {}", outputs_file.display());
 
         let current_dir = working_dir.as_ref().unwrap_or(&self.tmp_dir).to_string();
@@ -108,7 +108,7 @@ impl Machine {
         let output_content = read_to_string(&outputs_file).await?;
         let outputs = parse_variables_iter(output_content.lines());
 
-        if outputs.len() > 0 {
+        if outputs.is_empty() {
             debug!("the executed command created {} outputs", outputs.len());
         }
 

--- a/crates/bld_core/src/platform/machine.rs
+++ b/crates/bld_core/src/platform/machine.rs
@@ -1,7 +1,8 @@
 use crate::logger::Logger;
 use anyhow::{Result, bail};
-use bld_config::{BldConfig, path};
-use bld_utils::shell::get_shell;
+use bld_config::{definitions::BLD_OUTPUTS_ENV_VAR_V3, path, BldConfig};
+use bld_utils::{shell::get_shell, variables::parse_variables_iter};
+use uuid::Uuid;
 use std::{
     collections::HashMap,
     fmt::Write,
@@ -9,7 +10,8 @@ use std::{
     process::ExitStatus,
     sync::Arc,
 };
-use tokio::fs::{copy, create_dir_all, remove_dir_all};
+use tokio::fs::{copy, create_dir_all, read_to_string, remove_dir_all, File};
+use tracing::debug;
 
 pub struct Machine {
     tmp_dir: String,
@@ -68,7 +70,12 @@ impl Machine {
         logger: Arc<Logger>,
         working_dir: &Option<String>,
         input: &str,
-    ) -> Result<()> {
+    ) -> Result<HashMap<String, String>> {
+        let id = Uuid::new_v4();
+        let outputs_file = path![&self.tmp_dir, id.to_string()];
+        File::create(&outputs_file).await?;
+        debug!("creating new outputs file {}", outputs_file.display());
+
         let current_dir = working_dir.as_ref().unwrap_or(&self.tmp_dir).to_string();
         let current_dir = if Path::new(&current_dir).is_relative() {
             path![&self.tmp_dir, current_dir].display().to_string()
@@ -78,26 +85,34 @@ impl Machine {
 
         let mut shell = get_shell(&mut vec![input])?;
         shell.envs(&self.env);
+        shell.env(BLD_OUTPUTS_ENV_VAR_V3, &outputs_file);
         shell.current_dir(current_dir);
 
         let process = shell.output().await?;
-        let mut output = String::new();
+        let mut shell_output = String::new();
 
         if !process.stderr.is_empty() {
-            writeln!(output, "{}", String::from_utf8_lossy(&process.stderr))?;
+            writeln!(shell_output, "{}", String::from_utf8_lossy(&process.stderr))?;
         }
 
         if !process.stdout.is_empty() {
-            writeln!(output, "{}", String::from_utf8_lossy(&process.stdout))?;
+            writeln!(shell_output, "{}", String::from_utf8_lossy(&process.stdout))?;
         }
 
-        logger.write(output).await?;
+        logger.write(shell_output).await?;
 
         if !ExitStatus::success(&process.status) {
             bail!("command finished with {}", process.status);
         }
 
-        Ok(())
+        let output_content = read_to_string(&outputs_file).await?;
+        let outputs = parse_variables_iter(output_content.lines());
+
+        if outputs.len() > 0 {
+            debug!("the executed command created {} outputs", outputs.len());
+        }
+
+        Ok(outputs)
     }
 
     pub async fn dispose(&self) -> Result<()> {

--- a/crates/bld_core/src/platform/machine.rs
+++ b/crates/bld_core/src/platform/machine.rs
@@ -1,8 +1,7 @@
 use crate::logger::Logger;
 use anyhow::{Result, bail};
-use bld_config::{definitions::BLD_OUTPUTS_ENV_VAR_V3, path, BldConfig};
+use bld_config::{BldConfig, definitions::BLD_OUTPUTS_ENV_VAR_V3, path};
 use bld_utils::{shell::get_shell, variables::parse_variables_iter};
-use uuid::Uuid;
 use std::{
     collections::HashMap,
     fmt::Write,
@@ -10,8 +9,9 @@ use std::{
     process::ExitStatus,
     sync::Arc,
 };
-use tokio::fs::{copy, create_dir_all, read_to_string, remove_dir_all, File};
+use tokio::fs::{File, copy, create_dir_all, read_to_string, remove_dir_all};
 use tracing::debug;
+use uuid::Uuid;
 
 pub struct Machine {
     tmp_dir: String,

--- a/crates/bld_core/src/platform/mod.rs
+++ b/crates/bld_core/src/platform/mod.rs
@@ -6,7 +6,7 @@ mod image;
 mod machine;
 mod ssh;
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 pub use container::*;
 pub use context::*;
@@ -40,7 +40,7 @@ pub enum PlatformMessage {
         logger: Arc<Logger>,
         working_dir: Option<String>,
         command: String,
-        resp_tx: oneshot::Sender<Result<()>>,
+        resp_tx: oneshot::Sender<Result<HashMap<String, String>>>,
     },
     Dispose {
         resp_tx: oneshot::Sender<Result<()>>,
@@ -120,7 +120,7 @@ impl PlatformBackend {
         logger: Arc<Logger>,
         working_dir: Option<String>,
         command: String,
-    ) -> Result<()> {
+    ) -> Result<HashMap<String, String>> {
         self.ssh.sh(logger, &working_dir, &command).await
     }
 
@@ -230,7 +230,7 @@ impl Platform {
         logger: Arc<Logger>,
         working_dir: &Option<String>,
         command: &str,
-    ) -> Result<()> {
+    ) -> Result<HashMap<String, String>> {
         match &self.inner {
             PlatformType::Machine(machine) => machine.sh(logger, working_dir, command).await,
             PlatformType::Container(container) => container.sh(logger, working_dir, command).await,
@@ -247,7 +247,7 @@ impl Platform {
 
                 resp_rx.await?
             }
-            PlatformType::Mock => Ok(()),
+            PlatformType::Mock => Ok(HashMap::new()),
         }
     }
 

--- a/crates/bld_core/src/platform/ssh.rs
+++ b/crates/bld_core/src/platform/ssh.rs
@@ -320,7 +320,7 @@ impl Ssh {
         logger: Arc<Logger>,
         working_dir: &Option<String>,
         input: &str,
-    ) -> Result<()> {
+    ) -> Result<HashMap<String, String>> {
         let mut command = String::new();
         if let Some(wd) = working_dir {
             command.push_str(&format!("cd {wd} && "));
@@ -355,7 +355,7 @@ impl Ssh {
 
         channel.close().await?;
 
-        Ok(())
+        Ok(HashMap::new())
     }
 
     pub async fn dispose(&mut self) -> Result<()> {

--- a/crates/bld_core/src/platform/ssh.rs
+++ b/crates/bld_core/src/platform/ssh.rs
@@ -4,8 +4,8 @@ use std::{
 
 use anyhow::{Result, anyhow, bail};
 use async_ssh2_lite::{AsyncSession, AsyncSftp, TokioTcpStream};
-use bld_config::{BldConfig, path};
-use bld_utils::sync::IntoArc;
+use bld_config::{BldConfig, definitions::BLD_OUTPUTS_ENV_VAR_V3, path};
+use bld_utils::{sync::IntoArc, variables::parse_variables_iter};
 use futures_util::{
     AsyncReadExt as FuturesUtilAsyncReadExt, AsyncWriteExt as FuturesUtilAsyncWriteExt,
 };
@@ -14,6 +14,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 use tracing::{debug, error};
+use uuid::Uuid;
 use walkdir::WalkDir;
 
 use crate::logger::Logger;
@@ -72,6 +73,7 @@ impl<'a> SshExecutionOptions<'a> {
 pub struct Ssh {
     session: AsyncSession<TokioTcpStream>,
     env: HashMap<String, String>,
+    outputs_dir: PathBuf,
 }
 
 impl Ssh {
@@ -86,9 +88,18 @@ impl Ssh {
         let mut instance = Self {
             session,
             env: HashMap::new(),
+            outputs_dir: path!["tmp", "bld_outputs"],
         };
         instance.set_auth(connect.user, &connect.auth).await?;
         instance.set_env(execution.pipeline_env, execution.env);
+
+        instance
+            .run_internal_cmd(vec![
+                "mkdir",
+                "-p",
+                &instance.outputs_dir.display().to_string(),
+            ])
+            .await?;
 
         Ok(instance)
     }
@@ -315,6 +326,34 @@ impl Ssh {
         Ok(())
     }
 
+    async fn run_internal_cmd(&self, cmd: Vec<&str>) -> Result<String> {
+        debug!("running internal ssh command");
+        let mut channel = self.session.channel_session().await?;
+
+        channel.exec(&cmd.join(" ")).await?;
+
+        let mut output = String::new();
+
+        let mut stdout = String::new();
+        FuturesUtilAsyncReadExt::read_to_string(&mut channel, &mut stdout).await?;
+        output.push_str(&stdout);
+
+        let mut stderr = String::new();
+        let mut channel_stderr = channel.stderr();
+        FuturesUtilAsyncReadExt::read_to_string(&mut channel_stderr, &mut stderr).await?;
+        output.push_str(&stderr);
+
+        let exit_status = channel.exit_status()?;
+        if exit_status != 0 {
+            debug!("failed to run internal ssh command due to {stderr}");
+            bail!("command finished with status {exit_status}");
+        }
+
+        channel.close().await?;
+
+        Ok(stdout)
+    }
+
     pub async fn sh(
         &self,
         logger: Arc<Logger>,
@@ -329,9 +368,16 @@ impl Ssh {
 
         let mut channel = self.session.channel_session().await?;
 
+        let outputs_file = path![&self.outputs_dir, Uuid::new_v4().to_string()]
+            .display()
+            .to_string();
+
         for (k, v) in self.env.iter() {
             channel.setenv(k, v).await?;
         }
+        channel
+            .setenv(BLD_OUTPUTS_ENV_VAR_V3, &outputs_file)
+            .await?;
 
         channel.exec(&command).await?;
 
@@ -355,10 +401,19 @@ impl Ssh {
 
         channel.close().await?;
 
-        Ok(HashMap::new())
+        let outputs = self
+            .run_internal_cmd(vec!["cat", &outputs_file])
+            .await
+            .unwrap_or_default();
+        let outputs = parse_variables_iter(outputs.lines());
+
+        Ok(outputs)
     }
 
     pub async fn dispose(&mut self) -> Result<()> {
+        let _ = self
+            .run_internal_cmd(vec!["rm", "-r", &self.outputs_dir.display().to_string()])
+            .await;
         self.session.disconnect(None, "", None).await?;
         Ok(())
     }

--- a/crates/bld_runner/Cargo.toml
+++ b/crates/bld_runner/Cargo.toml
@@ -59,3 +59,4 @@ regex = { version = "1.11.1", optional = true }
 cron = { version = "0.13.0", optional = true }
 pest = { version = "2.7.15", optional = true }
 pest_derive = { version = "2.7.15", optional = true }
+mockall = "0.13.1"

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -136,7 +136,7 @@ impl<'a> EvalObject<'a> for Action {
             }
 
             "steps" => {
-                let Some(step_id) = object_parts.next() else {
+                let Some(step_id) = object_parts.peek() else {
                     bail!("expected id for step in expression");
                 };
 

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -107,7 +107,7 @@ impl Dependencies for Action {
 impl<'a> EvalObject<'a> for Action {
     fn eval_object<RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>(
         &'a self,
-        path: &mut Peekable<Pairs<'_, Rule>>,
+        path: &mut Peekable<Pairs<'a, Rule>>,
         rctx: &'a RCtx,
         wctx: &'a WCtx,
     ) -> Result<ExprValue<'a>> {

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -136,7 +136,7 @@ impl<'a> EvalObject<'a> for Action {
             }
 
             "steps" => {
-                let Some(step_id) = object_parts.peek() else {
+                let Some(step_id) = object_parts.next() else {
                     bail!("expected id for step in expression");
                 };
 

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -1,5 +1,5 @@
-use super::traits::{ReadonlyRuntimeExprContext, WritableRuntimeExprContext};
-use anyhow::{Result, anyhow, bail};
+use super::traits::ReadonlyRuntimeExprContext;
+use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use std::{collections::HashMap, sync::Arc};
 
@@ -59,32 +59,5 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
 
     fn get_run_start_time(&'a self) -> &'a str {
         &self.run_start_time
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct CommonWritableRuntimeExprContext {
-    pub outputs: HashMap<String, HashMap<String, String>>,
-}
-
-impl WritableRuntimeExprContext for CommonWritableRuntimeExprContext {
-    fn get_output(&self, id: &str, name: &str) -> Result<&str> {
-        let Some(map) = self.outputs.get(id) else {
-            bail!("id {id} has no outputs");
-        };
-        map.get(name)
-            .map(|x| x.as_str())
-            .ok_or_else(|| anyhow!("output '{name}' not found"))
-    }
-
-    fn set_output(&mut self, id: String, name: String, value: String) -> Result<()> {
-        if let Some(outputs) = self.outputs.get_mut(&id) {
-            let _ = outputs.insert(name, value);
-        } else {
-            let mut map = HashMap::new();
-            map.insert(name, value);
-            let _ = self.outputs.insert(id, map);
-        }
-        Ok(())
     }
 }

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -32,7 +32,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
 impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>
     EvalExpr<'a> for CommonExprExecutor<'a, T, RCtx, WCtx>
 {
-    fn eval_cmp(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_cmp(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         if !matches!(
             expr.as_rule(),
             Rule::Equals
@@ -91,7 +91,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         }
     }
 
-    fn eval_symbol(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_symbol(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         let Rule::Symbol = expr.as_rule() else {
             bail!("expected symbol rule, found {:?}", expr.as_rule());
         };
@@ -112,7 +112,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         }
     }
 
-    fn eval_expr(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         let Rule::Expression = expr.as_rule() else {
             bail!("expected expression rule, found {:?}", expr.as_rule());
         };
@@ -146,7 +146,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         }
     }
 
-    fn eval_logical_expr(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_logical_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         let Rule::LogicalExpression = expr.as_rule() else {
             bail!(
                 "expected logical expression rule, found {:?}",

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -229,10 +229,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
 #[cfg(test)]
 mod tests {
     use crate::{
-        expr::v3::{
-            context::{CommonReadonlyRuntimeExprContext, CommonWritableRuntimeExprContext},
-            traits::ExprText,
-        },
+        expr::v3::{context::CommonReadonlyRuntimeExprContext, traits::ExprText},
         inputs::v3::Input,
         pipeline::v3::Pipeline,
     };

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -155,6 +155,8 @@ pub trait ReadonlyRuntimeExprContext<'a> {
 
 #[automock]
 pub trait WritableRuntimeExprContext {
+    #[allow(clippy::needless_lifetimes)]
+    fn get_exec_id<'a>(&'a self) -> Option<&'a str>;
     fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<&'a str>;
     fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
     fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -153,23 +153,23 @@ pub trait ReadonlyRuntimeExprContext<'a> {
 }
 
 pub trait WritableRuntimeExprContext {
-    fn get_output(&self, name: &str) -> Result<&str>;
-    fn set_output(&mut self, name: String, value: String) -> Result<()>;
+    fn get_output(&self, id: &str, name: &str) -> Result<&str>;
+    fn set_output(&mut self, id: String, name: String, value: String) -> Result<()>;
 }
 
 pub trait EvalObject<'a> {
     fn eval_object<RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>(
         &'a self,
-        path: &mut Peekable<Pairs<'_, Rule>>,
+        path: &mut Peekable<Pairs<'a, Rule>>,
         rctx: &'a RCtx,
         wctx: &'a WCtx,
     ) -> Result<ExprValue<'a>>;
 }
 
 pub trait EvalExpr<'a> {
-    fn eval_cmp(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>>;
-    fn eval_symbol(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>>;
-    fn eval_expr(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>>;
-    fn eval_logical_expr(&'a self, expr: Pair<'_, Rule>) -> Result<ExprValue<'a>>;
+    fn eval_cmp(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
+    fn eval_symbol(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
+    fn eval_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
+    fn eval_logical_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
     fn eval(&'a self, expr: &'a str) -> Result<ExprValue<'a>>;
 }

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -3,6 +3,7 @@
 use std::{fmt::Display, iter::Peekable};
 
 use anyhow::{Result, bail};
+use mockall::automock;
 use pest::iterators::{Pair, Pairs};
 
 use super::parser::Rule;
@@ -152,9 +153,10 @@ pub trait ReadonlyRuntimeExprContext<'a> {
     fn get_run_start_time(&'a self) -> &'a str;
 }
 
+#[automock]
 pub trait WritableRuntimeExprContext {
-    fn get_output(&self, id: &str, name: &str) -> Result<&str>;
-    fn set_output(&mut self, id: String, name: String, value: String) -> Result<()>;
+    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<&'a str>;
+    fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
 }
 
 pub trait EvalObject<'a> {

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{fmt::Display, iter::Peekable};
+use std::{collections::HashMap, fmt::Display, iter::Peekable};
 
 use anyhow::{Result, bail};
 use mockall::automock;
@@ -157,6 +157,7 @@ pub trait ReadonlyRuntimeExprContext<'a> {
 pub trait WritableRuntimeExprContext {
     fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<&'a str>;
     fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
+    fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;
 }
 
 pub trait EvalObject<'a> {

--- a/crates/bld_runner/src/external/v3.rs
+++ b/crates/bld_runner/src/external/v3.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use uuid::Uuid;
 
 #[cfg(feature = "all")]
 use crate::{
@@ -15,6 +16,8 @@ use tracing::debug;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct External {
+    #[serde(default = "External::default_id")]
+    pub id: String,
     pub name: Option<String>,
     pub server: Option<String>,
     pub uses: String,
@@ -27,6 +30,10 @@ pub struct External {
 }
 
 impl External {
+    fn default_id() -> String {
+        Uuid::new_v4().to_string()
+    }
+
     pub fn is(&self, value: &str) -> bool {
         self.name.as_ref().map(|n| n == value).unwrap_or_default() || self.uses == value
     }

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -185,20 +185,17 @@ impl<'a> EvalObject<'a> for Pipeline {
                     .map(|x| ExprValue::Text(ExprText::Ref(x)))
             }
 
-            "jobs" => {
-                let Some(job_name) = object_parts.next() else {
-                    bail!("expected name for job in expression");
-                };
-
-                let Some(job) = self.jobs.get(job_name.as_span().as_str()) else {
-                    bail!("job with name {job_name} not defined");
-                };
-
+            "steps" => {
                 let Some(step_id) = object_parts.next() else {
                     bail!("expected id for step in expression");
                 };
 
                 let step_id = step_id.as_span().as_str();
+
+                let Some(job) = wctx.get_exec_id().and_then(|id| self.jobs.get(id)) else {
+                    bail!("unable to find executing job id");
+                };
+
                 let Some(step) = job.iter().find(|x| x.is(step_id)) else {
                     bail!("step with id {step_id} not defined");
                 };

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -194,7 +194,7 @@ impl<'a> EvalObject<'a> for Pipeline {
                     bail!("job with name {job_name} not defined");
                 };
 
-                let Some(step_id) = object_parts.next() else {
+                let Some(step_id) = object_parts.peek() else {
                     bail!("expected id for step in expression");
                 };
 

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -194,7 +194,7 @@ impl<'a> EvalObject<'a> for Pipeline {
                     bail!("job with name {job_name} not defined");
                 };
 
-                let Some(step_id) = object_parts.peek() else {
+                let Some(step_id) = object_parts.next() else {
                     bail!("expected id for step in expression");
                 };
 

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -103,10 +103,7 @@ impl ActionRunner {
         let action = self.action.clone();
         for step in &action.steps {
             match step {
-                Step::SingleSh(sh) => self.shell(&None, sh).await?,
-
                 Step::ComplexSh(complex) => self.complex_shell(complex).await?,
-
                 Step::ExternalFile(_external) => {
                     unimplemented!()
                 }

--- a/crates/bld_runner/src/runner/v3/mod.rs
+++ b/crates/bld_runner/src/runner/v3/mod.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 pub use pipeline::*;
 
 pub enum FileRunner {
-    Action(ActionRunner),
-    Pipeline(PipelineRunner),
+    Action(Box<ActionRunner>),
+    Pipeline(Box<PipelineRunner>),
 }
 
 impl FileRunner {

--- a/crates/bld_runner/src/runner/v3/mod.rs
+++ b/crates/bld_runner/src/runner/v3/mod.rs
@@ -2,6 +2,7 @@ mod action;
 mod common;
 mod job;
 mod pipeline;
+mod state;
 
 pub use action::*;
 use anyhow::Result;

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -55,11 +55,19 @@ impl WritableRuntimeExprContext for StepState {
         let _ = self.outputs.insert(name, value);
         Ok(())
     }
+
+    fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()> {
+        if self.id != id {
+            bail!("target id {id} is inaccessible");
+        }
+        self.outputs = outputs;
+        Ok(())
+    }
 }
 
 #[derive(Default)]
 pub struct JobState {
-    id: String,
+    _id: String,
     state: State,
     steps: HashMap<String, StepState>,
 }
@@ -67,7 +75,7 @@ pub struct JobState {
 impl JobState {
     pub fn new(id: &str) -> Self {
         Self {
-            id: id.to_string(),
+            _id: id.to_string(),
             ..Default::default()
         }
     }
@@ -102,6 +110,13 @@ impl WritableRuntimeExprContext for JobState {
             bail!("outputs for id {id} weren't found");
         };
         step_state.set_output(id, name, value)
+    }
+
+    fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()> {
+        let Some(step_state) = self.steps.get_mut(id) else {
+            bail!("outputs for id {id} weren't found");
+        };
+        step_state.set_outputs(id, outputs)
     }
 }
 
@@ -142,5 +157,12 @@ impl WritableRuntimeExprContext for ActionState {
             bail!("outputs for id {id} weren't found");
         };
         step_state.set_output(id, name, value)
+    }
+
+    fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()> {
+        let Some(step_state) = self.steps.get_mut(id) else {
+            bail!("outputs for id {id} weren't found");
+        };
+        step_state.set_outputs(id, outputs)
     }
 }

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use anyhow::{Result, anyhow, bail};
+
+use crate::expr::v3::traits::WritableRuntimeExprContext;
+
+pub enum State {
+    Default,
+    Running,
+    Completed,
+    Failed { error: String },
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+#[derive(Default)]
+pub struct StepState {
+    id: String,
+    state: State,
+    outputs: HashMap<String, String>,
+}
+
+impl StepState {
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn update_state(&mut self, state: State) {
+        self.state = state;
+    }
+}
+
+impl WritableRuntimeExprContext for StepState {
+    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<&'a str> {
+        if self.id != id {
+            bail!("id {id} has no outputs");
+        }
+        self.outputs
+            .get(name)
+            .map(|x| x.as_str())
+            .ok_or_else(|| anyhow!("output '{name}' not found"))
+    }
+
+    fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()> {
+        if self.id != id {
+            bail!("target id {id} is inaccessible");
+        }
+        let _ = self.outputs.insert(name, value);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct JobState {
+    id: String,
+    state: State,
+    steps: HashMap<String, StepState>,
+}
+
+impl JobState {
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn update_state(&mut self, state: State) {
+        self.state = state;
+    }
+
+    pub fn add_step(&mut self, step_id: &str) {
+        self.steps
+            .insert(step_id.to_string(), StepState::new(step_id));
+    }
+
+    pub fn update_step_state(&mut self, step_id: &str, state: State) {
+        let Some(step_state) = self.steps.get_mut(step_id) else {
+            return;
+        };
+        step_state.update_state(state);
+    }
+}
+
+impl WritableRuntimeExprContext for JobState {
+    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<&'a str> {
+        let Some(step_state) = self.steps.get(id) else {
+            bail!("outputs for id {id} weren't found");
+        };
+        step_state.get_output(id, name)
+    }
+
+    fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()> {
+        let Some(step_state) = self.steps.get_mut(id) else {
+            bail!("outputs for id {id} weren't found");
+        };
+        step_state.set_output(id, name, value)
+    }
+}
+
+#[derive(Default)]
+pub struct ActionState {
+    state: State,
+    steps: HashMap<String, StepState>,
+}
+
+impl ActionState {
+    pub fn update_state(&mut self, state: State) {
+        self.state = state;
+    }
+
+    pub fn add_step(&mut self, step_id: &str) {
+        self.steps
+            .insert(step_id.to_string(), StepState::new(step_id));
+    }
+
+    pub fn update_step_state(&mut self, step_id: &str, state: State) {
+        let Some(step_state) = self.steps.get_mut(step_id) else {
+            return;
+        };
+        step_state.update_state(state);
+    }
+}
+
+impl WritableRuntimeExprContext for ActionState {
+    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<&'a str> {
+        let Some(step_state) = self.steps.get(id) else {
+            bail!("outputs for id {id} weren't found");
+        };
+        step_state.get_output(id, name)
+    }
+
+    fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()> {
+        let Some(step_state) = self.steps.get_mut(id) else {
+            bail!("outputs for id {id} weren't found");
+        };
+        step_state.set_output(id, name, value)
+    }
+}

--- a/crates/bld_runner/src/runner/versioned.rs
+++ b/crates/bld_runner/src/runner/versioned.rs
@@ -4,8 +4,8 @@ use crate::runner::v3;
 use anyhow::Result;
 
 pub enum VersionedRunner {
-    V1(v1::Runner),
-    V2(v2::Runner),
+    V1(Box<v1::Runner>),
+    V2(Box<v2::Runner>),
     V3(v3::FileRunner),
 }
 

--- a/crates/bld_runner/src/runs_on/v3.rs
+++ b/crates/bld_runner/src/runs_on/v3.rs
@@ -97,7 +97,7 @@ impl RunsOn {
 impl<'a> EvalObject<'a> for RunsOn {
     fn eval_object<RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>(
         &'a self,
-        path: &mut Peekable<Pairs<'_, Rule>>,
+        path: &mut Peekable<Pairs<'a, Rule>>,
         rctx: &'a RCtx,
         wctx: &'a WCtx,
     ) -> Result<ExprValue<'a>> {
@@ -184,7 +184,7 @@ impl<'a> EvalObject<'a> for RunsOn {
 impl<'a> EvalObject<'a> for SshConfig {
     fn eval_object<RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>(
         &'a self,
-        path: &mut Peekable<Pairs<'_, Rule>>,
+        path: &mut Peekable<Pairs<'a, Rule>>,
         rctx: &'a RCtx,
         wctx: &'a WCtx,
     ) -> Result<ExprValue<'a>> {
@@ -214,7 +214,7 @@ impl<'a> EvalObject<'a> for SshConfig {
 impl<'a> EvalObject<'a> for SshUserAuth {
     fn eval_object<RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>(
         &'a self,
-        path: &mut Peekable<Pairs<'_, Rule>>,
+        path: &mut Peekable<Pairs<'a, Rule>>,
         _rctx: &'a RCtx,
         _wctx: &'a WCtx,
     ) -> Result<ExprValue<'a>> {

--- a/crates/bld_utils/src/variables.rs
+++ b/crates/bld_utils/src/variables.rs
@@ -11,3 +11,14 @@ pub fn parse_variables(variables: &[String]) -> HashMap<String, String> {
         })
         .collect::<HashMap<String, String>>()
 }
+
+pub fn parse_variables_iter<'a>(variables: impl Iterator<Item = &'a str>) -> HashMap<String, String> {
+    variables
+        .flat_map(|v| {
+            let mut split = v.split('=');
+            let name = split.next()?.to_owned();
+            let value = split.next()?.to_owned();
+            Some((name, value))
+        })
+        .collect::<HashMap<String, String>>()
+}

--- a/crates/bld_utils/src/variables.rs
+++ b/crates/bld_utils/src/variables.rs
@@ -12,7 +12,9 @@ pub fn parse_variables(variables: &[String]) -> HashMap<String, String> {
         .collect::<HashMap<String, String>>()
 }
 
-pub fn parse_variables_iter<'a>(variables: impl Iterator<Item = &'a str>) -> HashMap<String, String> {
+pub fn parse_variables_iter<'a>(
+    variables: impl Iterator<Item = &'a str>,
+) -> HashMap<String, String> {
     variables
         .flat_map(|v| {
             let mut split = v.split('=');


### PR DESCRIPTION
### In this PR:
- Added new definition for `BLD_OUTPUTS` environment variable.
- Updated all platforms (machine, container and ssh) in order to return a new hash map with all the output variables generated from a shell command. This is achieved by an outputs file that is generated for each shell command and is accessible through the `$BLD_OUTPUTS` environment variable.
- Updated the job runner and action runner in order to receive the outputs from a shell command.
- Added the new `state` module that contains the step, action and job states that is initialized on each run and implements the appropriate trait for the writable expression context.
- Updated pipeline, action and step in order to appropriatelly handle the outputs usage in an expression.