### PR TITLE
280 update and add validation rules for v3 pipelines and actions

### DIFF
--- a/.bld/dockerfiles/Dockerfile
+++ b/.bld/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.94-trixie
+FROM docker.io/library/rust:1.95-trixie
 
 LABEL org.opencontainers.image.source=https://github.com/Kani-Maki-Gang/bld
 LABEL org.opencontainers.image.description="The container image for building and testing the Bld project."

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -17,7 +17,7 @@ use anyhow::{Result, anyhow, bail};
 use bld_core::fs::FileSystem;
 
 #[cfg(feature = "all")]
-use bld_config::BldConfig;
+use bld_config::{BldConfig, definitions::{KEYWORD_BLD_DIR_V3, KEYWORD_PROJECT_DIR_V3, KEYWORD_RUN_PROPS_ID_V3, KEYWORD_RUN_PROPS_START_TIME_V3}};
 
 #[cfg(feature = "all")]
 use crate::{
@@ -155,6 +155,23 @@ impl<'a> EvalObject<'a> for Action {
                 };
 
                 step.eval_object(&mut object_parts.peekable(), rctx, wctx)
+            }
+
+            // Keywords section
+            value if value == KEYWORD_BLD_DIR_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_root_dir())))
+            }
+
+            value if value == KEYWORD_PROJECT_DIR_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_project_dir())))
+            }
+
+            value if value == KEYWORD_RUN_PROPS_ID_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_run_id())))
+            }
+
+            value if value == KEYWORD_RUN_PROPS_START_TIME_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_run_start_time())))
             }
 
             value => bail!("invalid expression identifier {value}"),

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -172,7 +172,6 @@ impl<'a> Validate<'a> for Action {
         for (name, input) in self.inputs.iter() {
             debug!("Validating input: {}", name);
             ctx.push_section(name);
-            ctx.validate_keywords(name);
             input.validate(ctx).await;
             ctx.pop_section();
         }

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -17,7 +17,13 @@ use anyhow::{Result, anyhow, bail};
 use bld_core::fs::FileSystem;
 
 #[cfg(feature = "all")]
-use bld_config::{BldConfig, definitions::{KEYWORD_BLD_DIR_V3, KEYWORD_PROJECT_DIR_V3, KEYWORD_RUN_PROPS_ID_V3, KEYWORD_RUN_PROPS_START_TIME_V3}};
+use bld_config::{
+    BldConfig,
+    definitions::{
+        KEYWORD_BLD_DIR_V3, KEYWORD_PROJECT_DIR_V3, KEYWORD_RUN_PROPS_ID_V3,
+        KEYWORD_RUN_PROPS_START_TIME_V3,
+    },
+};
 
 #[cfg(feature = "all")]
 use crate::{

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -190,6 +190,11 @@ impl<'a> Validate<'a> for Action {
     async fn validate<C: ValidatorContext<'a>>(&'a self, ctx: &mut C) {
         debug!("Validating action: {}", self.name);
 
+        debug!("Validating action's name value");
+        ctx.push_section("name");
+        ctx.validate_expressions(&self.name);
+        ctx.pop_section();
+
         debug!("Validating action's inputs section");
         ctx.push_section("inputs");
         for (name, input) in self.inputs.iter() {

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     pub fn name_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut action = Action::default();
         let data = vec!["test", "hello world", ""];
@@ -215,7 +215,7 @@ mod tests {
         for entry in data {
             action.name = entry.to_string();
 
-            let exec = CommonExprExecutor::new(&action, &rctx, &mut wctx);
+            let exec = CommonExprExecutor::new(&action, &rctx, &wctx);
             let Ok(value) = exec.eval("${{ name }}") else {
                 panic!("result is an error during expression evaluation");
             };
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     pub fn inputs_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut action = Action::default();
         action
@@ -260,7 +260,7 @@ mod tests {
             },
         );
 
-        let exec = CommonExprExecutor::new(&action, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&action, &rctx, &wctx);
 
         for (k, v) in &action.inputs {
             let expr = format!("{} inputs.{k} {}", "${{", "}}");
@@ -295,14 +295,14 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext {
             inputs: data.clone().into_arc(),
             ..Default::default()
         };
         let action = Action::default();
 
-        let exec = CommonExprExecutor::new(&action, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&action, &rctx, &wctx);
 
         for (name, expected) in data {
             let expr = format!("{} inputs.{name} {}", "${{", "}}");

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -4,6 +4,7 @@ use super::traits::ReadonlyRuntimeExprContext;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use std::{collections::HashMap, sync::Arc};
+use uuid::Uuid;
 
 #[derive(Debug, Default)]
 pub struct CommonReadonlyRuntimeExprContext {
@@ -64,14 +65,23 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
     }
 }
 
-#[derive(Default)]
 pub struct CommonWritableRuntimeExprContext {
+    exec_id: String,
     outputs: HashMap<String, String>,
+}
+
+impl CommonWritableRuntimeExprContext {
+    pub fn new() -> Self {
+        Self {
+            exec_id: Uuid::new_v4().to_string(),
+            outputs: HashMap::new(),
+        }
+    }
 }
 
 impl WritableRuntimeExprContext for CommonWritableRuntimeExprContext {
     fn get_exec_id(&self) -> Option<&str> {
-        None
+        Some(&self.exec_id)
     }
 
     fn get_output<'a>(&'a self, _id: &str, name: &str) -> Result<&'a str> {

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -4,7 +4,6 @@ use super::traits::ReadonlyRuntimeExprContext;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use std::{collections::HashMap, sync::Arc};
-use uuid::Uuid;
 
 #[derive(Debug, Default)]
 pub struct CommonReadonlyRuntimeExprContext {
@@ -65,30 +64,27 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
     }
 }
 
-pub struct CommonWritableRuntimeExprContext {
-    exec_id: String,
+pub struct CommonWritableRuntimeExprContext<'a> {
+    exec_id: &'a str,
     outputs: HashMap<String, String>,
 }
 
-impl CommonWritableRuntimeExprContext {
-    pub fn new() -> Self {
+impl<'a> CommonWritableRuntimeExprContext<'a> {
+    pub fn new(exec_id: &'a str) -> Self {
         Self {
-            exec_id: Uuid::new_v4().to_string(),
+            exec_id,
             outputs: HashMap::new(),
         }
     }
 }
 
-impl WritableRuntimeExprContext for CommonWritableRuntimeExprContext {
+impl<'a> WritableRuntimeExprContext for CommonWritableRuntimeExprContext<'a> {
     fn get_exec_id(&self) -> Option<&str> {
-        Some(&self.exec_id)
+        Some(self.exec_id)
     }
 
-    fn get_output<'a>(&'a self, _id: &str, name: &str) -> Result<&'a str> {
-        self.outputs
-            .get(name)
-            .map(|x| x.as_str())
-            .ok_or_else(|| anyhow!("output value not found"))
+    fn get_output<'b>(&'b self, _id: &str, _name: &str) -> Result<&'b str> {
+        Ok("")
     }
 
     fn set_output(&mut self, _id: &str, name: String, value: String) -> Result<()> {

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -70,7 +70,7 @@ pub struct CommonWritableRuntimeExprContext {
 }
 
 impl WritableRuntimeExprContext for CommonWritableRuntimeExprContext {
-    fn get_exec_id<'a>(&'a self) -> Option<&'a str> {
+    fn get_exec_id(&self) -> Option<&str> {
         None
     }
 

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -1,5 +1,3 @@
-use crate::expr::v3::traits::WritableRuntimeExprContext;
-
 use super::traits::ReadonlyRuntimeExprContext;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
@@ -61,39 +59,5 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
 
     fn get_run_start_time(&'a self) -> &'a str {
         &self.run_start_time
-    }
-}
-
-pub struct CommonWritableRuntimeExprContext<'a> {
-    exec_id: &'a str,
-    outputs: HashMap<String, String>,
-}
-
-impl<'a> CommonWritableRuntimeExprContext<'a> {
-    pub fn new(exec_id: &'a str) -> Self {
-        Self {
-            exec_id,
-            outputs: HashMap::new(),
-        }
-    }
-}
-
-impl<'a> WritableRuntimeExprContext for CommonWritableRuntimeExprContext<'a> {
-    fn get_exec_id(&self) -> Option<&str> {
-        Some(self.exec_id)
-    }
-
-    fn get_output<'b>(&'b self, _id: &str, _name: &str) -> Result<&'b str> {
-        Ok("")
-    }
-
-    fn set_output(&mut self, _id: &str, name: String, value: String) -> Result<()> {
-        self.outputs.insert(name, value);
-        Ok(())
-    }
-
-    fn set_outputs(&mut self, _id: &str, outputs: HashMap<String, String>) -> Result<()> {
-        self.outputs = outputs;
-        Ok(())
     }
 }

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -1,3 +1,5 @@
+use crate::expr::v3::traits::WritableRuntimeExprContext;
+
 use super::traits::ReadonlyRuntimeExprContext;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
@@ -59,5 +61,33 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
 
     fn get_run_start_time(&'a self) -> &'a str {
         &self.run_start_time
+    }
+}
+
+#[derive(Default)]
+pub struct CommonWritableRuntimeExprContext {
+    outputs: HashMap<String, String>,
+}
+
+impl WritableRuntimeExprContext for CommonWritableRuntimeExprContext {
+    fn get_exec_id<'a>(&'a self) -> Option<&'a str> {
+        None
+    }
+
+    fn get_output<'a>(&'a self, _id: &str, name: &str) -> Result<&'a str> {
+        self.outputs
+            .get(name)
+            .map(|x| x.as_str())
+            .ok_or_else(|| anyhow!("output value not found"))
+    }
+
+    fn set_output(&mut self, _id: &str, name: String, value: String) -> Result<()> {
+        self.outputs.insert(name, value);
+        Ok(())
+    }
+
+    fn set_outputs(&mut self, _id: &str, outputs: HashMap<String, String>) -> Result<()> {
+        self.outputs = outputs;
+        Ok(())
     }
 }

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -32,7 +32,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
 impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>
     EvalExpr<'a> for CommonExprExecutor<'a, T, RCtx, WCtx>
 {
-    fn eval_cmp(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_cmp(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         if !matches!(
             expr.as_rule(),
             Rule::Equals
@@ -91,7 +91,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         }
     }
 
-    fn eval_symbol(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_symbol(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         let Rule::Symbol = expr.as_rule() else {
             bail!("expected symbol rule, found {:?}", expr.as_rule());
         };
@@ -112,7 +112,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         }
     }
 
-    fn eval_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_expr(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         let Rule::Expression = expr.as_rule() else {
             bail!("expected expression rule, found {:?}", expr.as_rule());
         };
@@ -146,7 +146,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         }
     }
 
-    fn eval_logical_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
+    fn eval_logical_expr(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
         let Rule::LogicalExpression = expr.as_rule() else {
             bail!(
                 "expected logical expression rule, found {:?}",
@@ -207,7 +207,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         result.ok_or_else(|| anyhow!("no value was computed during logical expression evaluation"))
     }
 
-    fn eval(&'a self, expr: &'a str) -> Result<ExprValue<'a>> {
+    fn eval(&self, expr: &'a str) -> Result<ExprValue<'a>> {
         let mut pairs = ExprParser::parse(Rule::Full, expr)?;
         let pair = pairs.next().ok_or_else(|| anyhow!("no expression found"))?;
 
@@ -253,10 +253,10 @@ mod tests {
             ("${{ -150.20 }}", ExprValue::Number(-150.20)),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let Ok(value) = exec.eval(expr) else {
@@ -282,10 +282,10 @@ mod tests {
             ("${{ false }}", ExprValue::Boolean(false)),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let Ok(value) = exec.eval(expr) else {
@@ -311,10 +311,10 @@ mod tests {
             ExprValue::Text(ExprText::Owned("hello".to_string())),
         )];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             match exec.eval(expr) {
@@ -352,7 +352,7 @@ mod tests {
             ("${{ env.NODE }}", ExprValue::Text(ExprText::Ref("lts"))),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
 
         let mut pipeline = Pipeline::default();
@@ -370,7 +370,7 @@ mod tests {
             .insert("WORKDIR".to_string(), "/home/somedir".to_string());
         pipeline.env.insert("NODE".to_string(), "lts".to_string());
 
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             match exec.eval(expr) {
@@ -411,10 +411,10 @@ mod tests {
             ("${{ \"hello\" == 52.0 }}", Err(anyhow!(""))),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -460,10 +460,10 @@ mod tests {
             ("${{ \"hello\" != 52.0 }}", Err(anyhow!(""))),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -505,10 +505,10 @@ mod tests {
             ),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -555,10 +555,10 @@ mod tests {
             ),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -597,10 +597,10 @@ mod tests {
             ("${{ \"hello\" < \"world\" }}", Ok(ExprValue::Boolean(true))),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -647,10 +647,10 @@ mod tests {
             ),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -705,10 +705,10 @@ mod tests {
             ),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -773,10 +773,10 @@ mod tests {
             ),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -841,10 +841,10 @@ mod tests {
             ),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);
@@ -885,7 +885,7 @@ mod tests {
             ),
         ];
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
 
         let mut pipeline = Pipeline::default();
@@ -899,7 +899,7 @@ mod tests {
             .inputs
             .insert("age".to_string(), Input::Simple("30".to_string()));
 
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (expr, expected) in data {
             let value = exec.eval(expr);

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -20,7 +20,7 @@ pub struct CommonExprExecutor<
 impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: WritableRuntimeExprContext>
     CommonExprExecutor<'a, T, RCtx, WCtx>
 {
-    pub fn new(obj_executor: &'a T, rctx: &'a RCtx, wctx: &'a mut WCtx) -> Self {
+    pub fn new(obj_executor: &'a T, rctx: &'a RCtx, wctx: &'a WCtx) -> Self {
         Self {
             obj_executor,
             rctx,

--- a/crates/bld_runner/src/expr/v3/parser.rs
+++ b/crates/bld_runner/src/expr/v3/parser.rs
@@ -292,7 +292,7 @@ mod tests {
                             for (i, object_part) in object_parts.into_iter().enumerate() {
                                 assert_eq!(object_part.as_rule(), Rule::ObjectPart);
                                 assert_eq!(object_part.as_span().as_str(), symbol[i + 1]);
-                                assert_eq!(object_part.into_inner().count(), 0 as usize);
+                                assert_eq!(object_part.into_inner().count(), 0_usize);
                             }
                         }
 

--- a/crates/bld_runner/src/expr/v3/parser.rs
+++ b/crates/bld_runner/src/expr/v3/parser.rs
@@ -234,7 +234,7 @@ mod tests {
                 for (i, object_part) in object_parts.into_iter().enumerate() {
                     assert_eq!(object_part.as_rule(), Rule::ObjectPart);
                     assert_eq!(object_part.as_span().as_str(), spans[i]);
-                    assert_eq!(object_part.into_inner().count(), 0 as usize);
+                    assert_eq!(object_part.into_inner().count(), 0_usize);
                 }
             }
         }

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -168,9 +168,9 @@ pub trait EvalObject<'a> {
 }
 
 pub trait EvalExpr<'a> {
-    fn eval_cmp(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
-    fn eval_symbol(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
-    fn eval_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
-    fn eval_logical_expr(&'a self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
-    fn eval(&'a self, expr: &'a str) -> Result<ExprValue<'a>>;
+    fn eval_cmp(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
+    fn eval_symbol(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
+    fn eval_expr(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
+    fn eval_logical_expr(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
+    fn eval(&self, expr: &'a str) -> Result<ExprValue<'a>>;
 }

--- a/crates/bld_runner/src/external/v3.rs
+++ b/crates/bld_runner/src/external/v3.rs
@@ -62,9 +62,7 @@ impl<'a> Validate<'a> for External {
 
         debug!("Validating external's with section");
         ctx.push_section("with");
-        ctx.push_section("inputs");
         validate_external_with(ctx, &self.uses, self.server.as_deref(), &self.with).await;
-        ctx.pop_section();
         ctx.pop_section();
 
         debug!("Validating external's env section");
@@ -146,7 +144,6 @@ async fn validate_external_with<'a, C: ValidatorContext<'a>>(
     for (name, input) in with.iter() {
         debug!("Validating input: {}", name);
         ctx.push_section(name);
-        ctx.validate_keywords(name);
         ctx.validate_symbols(input);
         ctx.pop_section();
     }

--- a/crates/bld_runner/src/external/v3.rs
+++ b/crates/bld_runner/src/external/v3.rs
@@ -46,7 +46,7 @@ impl<'a> Validate<'a> for External {
         if let Some(name) = self.name.as_deref() {
             debug!("Validating external's name value");
             ctx.push_section("name");
-            ctx.validate_symbols(name);
+            ctx.validate_expressions(name);
             ctx.pop_section();
         };
 
@@ -76,8 +76,8 @@ impl<'a> Validate<'a> for External {
 async fn validate_external_file<'a, C: ValidatorContext<'a>>(ctx: &mut C, uses: &'a str) {
     use crate::VersionedFileLoader;
 
-    if ctx.contains_symbols(uses) {
-        ctx.validate_symbols(uses);
+    if ctx.contains_expressions(uses) {
+        ctx.validate_expressions(uses);
         return;
     }
 
@@ -97,8 +97,8 @@ fn validate_external_server<'a, C: ValidatorContext<'a>>(ctx: &mut C, server: Op
         return;
     };
 
-    if ctx.contains_symbols(server) {
-        ctx.validate_symbols(server);
+    if ctx.contains_expressions(server) {
+        ctx.validate_expressions(server);
     } else {
         let config = ctx.get_config();
         if config.server(server).is_err() {
@@ -144,7 +144,7 @@ async fn validate_external_with<'a, C: ValidatorContext<'a>>(
     for (name, input) in with.iter() {
         debug!("Validating input: {}", name);
         ctx.push_section(name);
-        ctx.validate_symbols(input);
+        ctx.validate_expressions(input);
         ctx.pop_section();
     }
 }

--- a/crates/bld_runner/src/files/v3.rs
+++ b/crates/bld_runner/src/files/v3.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "all")]
 use bld_config::BldConfig;
@@ -27,6 +27,20 @@ pub enum RunnerFile {
 }
 
 impl RunnerFile {
+    pub fn env_map(&self) -> HashMap<String, String> {
+        match self {
+            Self::PipelineFileType(pipeline) => pipeline.env.clone(),
+            Self::ActionFileType(_) => HashMap::new(),
+        }
+    }
+
+    pub fn inputs_map(&self) -> HashMap<String, String> {
+        match self {
+            Self::PipelineFileType(pipeline) => pipeline.inputs_map(),
+            Self::ActionFileType(action) => action.inputs_map(),
+        }
+    }
+
     pub fn required_inputs(&self) -> Option<HashSet<&str>> {
         match self {
             Self::PipelineFileType(pipeline) => pipeline.required_inputs(),

--- a/crates/bld_runner/src/files/v3.rs
+++ b/crates/bld_runner/src/files/v3.rs
@@ -77,11 +77,6 @@ impl Dependencies for RunnerFile {
                         dependecies.append(&mut local_deps);
                     }
                 }
-                for external in &pipeline.external {
-                    if external.server.is_none() {
-                        dependecies.push(external.uses.to_owned());
-                    }
-                }
                 dependecies
             }
 

--- a/crates/bld_runner/src/inputs/v3.rs
+++ b/crates/bld_runner/src/inputs/v3.rs
@@ -47,12 +47,12 @@ impl<'a> Validate<'a> for Input {
         match self {
             Input::Simple(v) => {
                 debug!("Validating input: {}", v);
-                ctx.validate_symbols(v);
+                ctx.validate_expressions(v);
             }
             Input::Complex { default, .. } => {
                 if let Some(v) = default {
                     ctx.push_section("default");
-                    ctx.validate_symbols(v);
+                    ctx.validate_expressions(v);
                     ctx.pop_section();
                 }
             }

--- a/crates/bld_runner/src/pipeline/v2.rs
+++ b/crates/bld_runner/src/pipeline/v2.rs
@@ -91,8 +91,8 @@ impl Dependencies for Pipeline {
     async fn local_deps(&self, config: &BldConfig, _fs: &FileSystem) -> Vec<String> {
         let from_steps = self
             .jobs
-            .iter()
-            .flat_map(|(_, steps)| steps)
+            .values()
+            .flatten()
             .flat_map(|s| s.local_dependencies(config));
 
         let from_external = self

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     pub fn name_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut pipeline = Pipeline::default();
         let data = vec![Some("test"), Some("hello world"), Some(""), None];
@@ -285,7 +285,7 @@ mod tests {
         for entry in data {
             pipeline.name = entry.map(|x| x.to_string());
 
-            let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+            let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
             let Ok(value) = exec.eval("${{ name }}") else {
                 panic!("result is an error during expression evaluation");
             };
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     pub fn cron_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut pipeline = Pipeline::default();
         let data = vec![
@@ -316,7 +316,7 @@ mod tests {
         for entry in data {
             pipeline.cron = entry.map(|x| x.to_string());
 
-            let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+            let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
             let Ok(value) = exec.eval("${{ cron }}") else {
                 panic!("result is an error during expression evaluation");
             };
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     pub fn dispose_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut pipeline = Pipeline::default();
         let data = vec![true, false];
@@ -342,7 +342,7 @@ mod tests {
         for entry in data {
             pipeline.dispose = entry;
 
-            let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+            let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
             let Ok(value) = exec.eval("${{ dispose }}") else {
                 panic!("result is an error during expression evaluation");
             };
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     pub fn env_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut pipeline = Pipeline::default();
         pipeline.env.insert("NODE".to_string(), "22.10".to_string());
@@ -365,14 +365,14 @@ mod tests {
             .env
             .insert("HOME".to_string(), "/home/user".to_string());
 
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (k, v) in &pipeline.env {
             let expr = format!("{} env.{k} {}", "${{", "}}");
             let Ok(value) = exec.eval(&expr) else {
                 panic!("result is an error during expression evaluation");
             };
-            let expected = ExprValue::Text(ExprText::Ref(&v));
+            let expected = ExprValue::Text(ExprText::Ref(v));
             assert!(matches!(
                 value.try_eq(&expected),
                 Ok(ExprValue::Boolean(true))
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     pub fn inputs_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut pipeline = Pipeline::default();
         pipeline
@@ -411,7 +411,7 @@ mod tests {
             },
         );
 
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (k, v) in &pipeline.inputs {
             let expr = format!("{} inputs.{k} {}", "${{", "}}");
@@ -446,13 +446,13 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext {
             inputs: data.clone().into_arc(),
             ..Default::default()
         };
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (name, expected) in data {
             let expr = format!("{} inputs.{name} {}", "${{", "}}");
@@ -480,13 +480,13 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
 
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext {
             env: data.clone().into_arc(),
             ..Default::default()
         };
         let pipeline = Pipeline::default();
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         for (name, expected) in data {
             let expr = format!("{} env.{name} {}", "${{", "}}");

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -101,6 +101,32 @@ impl Pipeline {
         }
         ctx.pop_section();
     }
+
+    #[cfg(feature = "all")]
+    async fn validate_jobs<'a, C: ValidatorContext<'a>>(&'a self, ctx: &mut C) {
+        ctx.push_section("jobs");
+
+        if self.jobs.is_empty() {
+            ctx.append_error("Pipeline must have at least one job defined");
+        }
+
+        for (job, steps) in &self.jobs {
+            ctx.push_job_section(job);
+            debug!("Validating {job} job's steps");
+            let mut step_ids = HashSet::new();
+            for step in steps {
+                let step_id = step.id();
+                if !step_ids.insert(step_id) {
+                    ctx.push_section(step_id);
+                    ctx.append_error(&format!("Duplicate step id '{step_id}' found in job"));
+                    ctx.pop_section();
+                }
+                step.validate(ctx).await;
+            }
+            ctx.pop_section();
+        }
+        ctx.pop_section();
+    }
 }
 
 impl IntoVariables for Pipeline {
@@ -264,16 +290,7 @@ impl<'a> Validate<'a> for Pipeline {
         ctx.pop_section();
 
         debug!("Validating pipeline's jobs section");
-        ctx.push_section("jobs");
-        for (job, steps) in &self.jobs {
-            ctx.push_job_section(job);
-            debug!("Validating {job} job's steps");
-            for step in steps {
-                step.validate(ctx).await;
-            }
-            ctx.pop_section();
-        }
-        ctx.pop_section();
+        self.validate_jobs(ctx).await;
     }
 }
 

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -1,9 +1,13 @@
 use crate::{
-    external::v3::External,
     inputs::v3::Input,
     runs_on::v3::RunsOn,
     step::v3::Step,
     traits::{IntoVariables, Variables},
+};
+#[cfg(feature = "all")]
+use bld_config::definitions::{
+    KEYWORD_BLD_DIR_V3, KEYWORD_PROJECT_DIR_V3, KEYWORD_RUN_PROPS_ID_V3,
+    KEYWORD_RUN_PROPS_START_TIME_V3,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -44,9 +48,6 @@ pub struct Pipeline {
 
     #[serde(default)]
     pub inputs: HashMap<String, Input>,
-
-    #[serde(default)]
-    pub external: Vec<External>,
 
     #[serde(default)]
     pub jobs: HashMap<String, Vec<Step>>,
@@ -203,7 +204,24 @@ impl<'a> EvalObject<'a> for Pipeline {
                 step.eval_object(&mut object_parts.peekable(), rctx, wctx)
             }
 
-            value => bail!("invalid expression identifier {value}"),
+            // Keywords section
+            value if value == KEYWORD_BLD_DIR_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_root_dir())))
+            }
+
+            value if value == KEYWORD_PROJECT_DIR_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_project_dir())))
+            }
+
+            value if value == KEYWORD_RUN_PROPS_ID_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_run_id())))
+            }
+
+            value if value == KEYWORD_RUN_PROPS_START_TIME_V3 => {
+                Ok(ExprValue::Text(ExprText::Ref(rctx.get_run_start_time())))
+            }
+
+            value => bail!("invalid expression identifier '{value}'"),
         }
     }
 }
@@ -226,7 +244,6 @@ impl<'a> Validate<'a> for Pipeline {
         for (name, input) in self.inputs.iter() {
             debug!("Validating input: {}", name);
             ctx.push_section(name);
-            ctx.validate_keywords(name);
             input.validate(ctx).await;
             ctx.pop_section();
         }
@@ -235,13 +252,6 @@ impl<'a> Validate<'a> for Pipeline {
         debug!("Validating pipeline's env section");
         ctx.push_section("env");
         ctx.validate_env(&self.env);
-        ctx.pop_section();
-
-        debug!("Validating pipeline external section");
-        ctx.push_section("external");
-        for external in &self.external {
-            external.validate(ctx).await;
-        }
         ctx.pop_section();
 
         debug!("Validating pipeline's jobs section");

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -92,12 +92,14 @@ impl Pipeline {
         let Some(cron) = self.cron.as_ref() else {
             return;
         };
-        if let Err(e) = Schedule::from_str(cron) {
+        ctx.push_section("cron");
+        if ctx.contains_expressions(cron) {
+            ctx.validate_expressions(cron);
+        } else if let Err(e) = Schedule::from_str(cron) {
             let error = format!("{cron} {e}");
-            ctx.push_section("cron");
             ctx.append_error(&error);
-            ctx.pop_section();
         }
+        ctx.pop_section();
     }
 }
 
@@ -230,6 +232,13 @@ impl<'a> EvalObject<'a> for Pipeline {
 impl<'a> Validate<'a> for Pipeline {
     async fn validate<C: ValidatorContext<'a>>(&'a self, ctx: &mut C) {
         debug!("Validating pipeline");
+
+        if let Some(name) = self.name.as_ref() {
+            debug!("Validating pipeline's name value");
+            ctx.push_section("name");
+            ctx.validate_expressions(name);
+            ctx.pop_section();
+        }
 
         debug!("Validating pipeline's runs_on section");
         ctx.push_section("runs_on");

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -257,7 +257,7 @@ impl<'a> Validate<'a> for Pipeline {
         debug!("Validating pipeline's jobs section");
         ctx.push_section("jobs");
         for (job, steps) in &self.jobs {
-            ctx.push_section(job);
+            ctx.push_job_section(job);
             debug!("Validating {job} job's steps");
             for step in steps {
                 step.validate(ctx).await;

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -52,7 +52,7 @@ impl<S: RootState> ActionRunner<S> {
             bail!("more than one condition found for step");
         };
 
-        let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &mut self.state);
+        let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &self.state);
         let value = expr_exec.eval(condition)?;
         Ok(matches!(value, ExprValue::Boolean(true)))
     }
@@ -67,7 +67,7 @@ impl<S: RootState> ActionRunner<S> {
         debug!("executing shell command {}", command);
 
         let mut cmd = command.to_string();
-        let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &mut self.state);
+        let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &self.state);
 
         for entry in self.expr_regex.find_iter(command) {
             let entry = entry.as_str();

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -93,7 +93,7 @@ impl<S: RootState> ActionRunner<S> {
             match step {
                 Step::ComplexSh(complex) => self.complex_shell(complex).await,
                 Step::ExternalFile(_external) => {
-                    unimplemented!()
+                    bail!("external calls are not supported in actions")
                 }
             }
             .inspect(|_| self.state.update_node_state(step.id(), State::Completed))

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -250,11 +250,8 @@ impl<S: RootState> JobRunner<S> {
             bail!("more than one condition found for step");
         };
 
-        let expr_exec = CommonExprExecutor::new(
-            self.pipeline.as_ref(),
-            self.expr_rctx.as_ref(),
-            &self.state,
-        );
+        let expr_exec =
+            CommonExprExecutor::new(self.pipeline.as_ref(), self.expr_rctx.as_ref(), &self.state);
         let value = expr_exec.eval(condition)?;
         Ok(matches!(value, ExprValue::Boolean(true)))
     }

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -253,18 +253,15 @@ impl<S: RootState> JobRunner<S> {
         let expr_exec = CommonExprExecutor::new(
             self.pipeline.as_ref(),
             self.expr_rctx.as_ref(),
-            &mut self.state,
+            &self.state,
         );
         let value = expr_exec.eval(condition)?;
         Ok(matches!(value, ExprValue::Boolean(true)))
     }
 
     fn eval_all_expr(&mut self, value: &str) -> Result<String> {
-        let expr_exec = CommonExprExecutor::new(
-            self.pipeline.as_ref(),
-            self.expr_rctx.as_ref(),
-            &mut self.state,
-        );
+        let expr_exec =
+            CommonExprExecutor::new(self.pipeline.as_ref(), self.expr_rctx.as_ref(), &self.state);
 
         let mut result = value.to_string();
         for entry in self.expr_regex.find_iter(value) {

--- a/crates/bld_runner/src/runs_on/v3.rs
+++ b/crates/bld_runner/src/runs_on/v3.rs
@@ -752,11 +752,10 @@ mod tests {
         let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline {
-
-        runs_on: RunsOn::SshFromGlobalConfig {
-            ssh_config: "some_global_ssh_config".to_string(),
-        },
-        ..Default::default()
+            runs_on: RunsOn::SshFromGlobalConfig {
+                ssh_config: "some_global_ssh_config".to_string(),
+            },
+            ..Default::default()
         };
         let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 

--- a/crates/bld_runner/src/runs_on/v3.rs
+++ b/crates/bld_runner/src/runs_on/v3.rs
@@ -477,12 +477,13 @@ mod tests {
 
     #[test]
     pub fn runs_on_machine_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
-        let mut pipeline = Pipeline::default();
-        pipeline.runs_on = RunsOn::ContainerOrMachine("machine".to_string());
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
-
+        let pipeline = Pipeline {
+            runs_on: RunsOn::ContainerOrMachine("machine".to_string()),
+            ..Default::default()
+        };
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
         let expected = ExprValue::Text(ExprText::Ref("machine"));
         let actual = exec.eval("${{ runs_on }}").unwrap();
         assert!(matches!(
@@ -493,7 +494,7 @@ mod tests {
 
     #[test]
     pub fn runs_on_container_name_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut pipeline = Pipeline::default();
 
@@ -513,7 +514,7 @@ mod tests {
 
         for (value, expected) in data {
             pipeline.runs_on = RunsOn::ContainerOrMachine(value.to_string());
-            let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+            let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
             let actual = exec.eval("${{ runs_on }}").unwrap();
             assert!(matches!(
@@ -525,16 +526,18 @@ mod tests {
 
     #[test]
     pub fn runs_on_pull_image_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
-        let mut pipeline = Pipeline::default();
-        pipeline.runs_on = RunsOn::Pull {
-            image: "ubuntu:latest".to_string(),
-            registry: Some(Registry::FromConfig("registry-config".to_string())),
-            pull: Some(true),
-            docker_url: Some("docker-url".to_string()),
+        let pipeline = Pipeline {
+            runs_on: RunsOn::Pull {
+                image: "ubuntu:latest".to_string(),
+                registry: Some(Registry::FromConfig("registry-config".to_string())),
+                pull: Some(true),
+                docker_url: Some("docker-url".to_string()),
+            },
+            ..Default::default()
         };
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ runs_on.image }}").unwrap();
         assert!(matches!(
@@ -563,16 +566,18 @@ mod tests {
 
     #[test]
     pub fn runs_on_build_image_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
-        let mut pipeline = Pipeline::default();
-        pipeline.runs_on = RunsOn::Build {
-            name: "test-image".to_string(),
-            tag: "1.3.4".to_string(),
-            dockerfile: "path-to-dockerfile".to_string(),
-            docker_url: Some("docker-url".to_string()),
+        let pipeline = Pipeline {
+            runs_on: RunsOn::Build {
+                name: "test-image".to_string(),
+                tag: "1.3.4".to_string(),
+                dockerfile: "path-to-dockerfile".to_string(),
+                docker_url: Some("docker-url".to_string()),
+            },
+            ..Default::default()
         };
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ runs_on.name}}").unwrap();
         assert!(matches!(
@@ -601,19 +606,21 @@ mod tests {
 
     #[test]
     pub fn runs_on_ssh_with_user_auth_key_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
-        let mut pipeline = Pipeline::default();
-        pipeline.runs_on = RunsOn::Ssh(SshConfig {
-            host: "localhost".to_string(),
-            port: "3000".to_string(),
-            user: "some_user".to_string(),
-            userauth: SshUserAuth::Keys {
-                public_key: Some("some_public_key".to_string()),
-                private_key: "some_private_key".to_string(),
-            },
-        });
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let pipeline = Pipeline {
+            runs_on: RunsOn::Ssh(SshConfig {
+                host: "localhost".to_string(),
+                port: "3000".to_string(),
+                user: "some_user".to_string(),
+                userauth: SshUserAuth::Keys {
+                    public_key: Some("some_public_key".to_string()),
+                    private_key: "some_private_key".to_string(),
+                },
+            }),
+            ..Default::default()
+        };
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ runs_on.host }}").unwrap();
         assert!(matches!(
@@ -654,18 +661,20 @@ mod tests {
 
     #[test]
     pub fn runs_on_ssh_with_user_password_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
-        let mut pipeline = Pipeline::default();
-        pipeline.runs_on = RunsOn::Ssh(SshConfig {
-            host: "localhost".to_string(),
-            port: "3000".to_string(),
-            user: "some_user".to_string(),
-            userauth: SshUserAuth::Password {
-                password: "some_password".to_string(),
-            },
-        });
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let pipeline = Pipeline {
+            runs_on: RunsOn::Ssh(SshConfig {
+                host: "localhost".to_string(),
+                port: "3000".to_string(),
+                user: "some_user".to_string(),
+                userauth: SshUserAuth::Password {
+                    password: "some_password".to_string(),
+                },
+            }),
+            ..Default::default()
+        };
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ runs_on.host }}").unwrap();
         assert!(matches!(
@@ -700,16 +709,18 @@ mod tests {
 
     #[test]
     pub fn runs_on_ssh_with_user_agent_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
-        let mut pipeline = Pipeline::default();
-        pipeline.runs_on = RunsOn::Ssh(SshConfig {
-            host: "localhost".to_string(),
-            port: "3000".to_string(),
-            user: "some_user".to_string(),
-            userauth: SshUserAuth::Agent,
-        });
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let pipeline = Pipeline {
+            runs_on: RunsOn::Ssh(SshConfig {
+                host: "localhost".to_string(),
+                port: "3000".to_string(),
+                user: "some_user".to_string(),
+                userauth: SshUserAuth::Agent,
+            }),
+            ..Default::default()
+        };
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ runs_on.host }}").unwrap();
         assert!(matches!(
@@ -738,13 +749,16 @@ mod tests {
 
     #[test]
     pub fn runs_on_ssh_config_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
-        let mut pipeline = Pipeline::default();
-        pipeline.runs_on = RunsOn::SshFromGlobalConfig {
+        let pipeline = Pipeline {
+
+        runs_on: RunsOn::SshFromGlobalConfig {
             ssh_config: "some_global_ssh_config".to_string(),
+        },
+        ..Default::default()
         };
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ runs_on.ssh_config }}").unwrap();
         assert!(matches!(

--- a/crates/bld_runner/src/runs_on/v3.rs
+++ b/crates/bld_runner/src/runs_on/v3.rs
@@ -337,7 +337,14 @@ impl<'a> Validate<'a> for RunsOn {
                 ctx.pop_section();
 
                 ctx.push_section("port");
-                ctx.validate_expressions(&config.port);
+                if ctx.contains_expressions(&config.port) {
+                    ctx.validate_expressions(&config.port);
+                } else if config.port.parse::<u16>().is_err() {
+                    ctx.append_error(&format!(
+                        "'{}' is not a valid port number (must be 0-65535)",
+                        config.port
+                    ));
+                }
                 ctx.pop_section();
 
                 ctx.push_section("user");

--- a/crates/bld_runner/src/runs_on/v3.rs
+++ b/crates/bld_runner/src/runs_on/v3.rs
@@ -290,15 +290,15 @@ impl<'a> Validate<'a> for RunsOn {
                 docker_url,
             } => {
                 ctx.push_section("name");
-                ctx.validate_symbols(name);
+                ctx.validate_expressions(name);
                 ctx.pop_section();
 
                 ctx.push_section("tag");
-                ctx.validate_symbols(tag);
+                ctx.validate_expressions(tag);
                 ctx.pop_section();
 
                 ctx.push_section("dockerfile");
-                ctx.validate_symbols(dockerfile);
+                ctx.validate_expressions(dockerfile);
                 ctx.validate_file_path(dockerfile);
                 ctx.pop_section();
 
@@ -314,7 +314,7 @@ impl<'a> Validate<'a> for RunsOn {
                 registry,
             } => {
                 ctx.push_section("image");
-                ctx.validate_symbols(image);
+                ctx.validate_expressions(image);
                 ctx.pop_section();
 
                 if let Some(docker_url) = docker_url {
@@ -325,7 +325,7 @@ impl<'a> Validate<'a> for RunsOn {
                 }
             }
 
-            RunsOn::ContainerOrMachine(value) => ctx.validate_symbols(value),
+            RunsOn::ContainerOrMachine(value) => ctx.validate_expressions(value),
 
             RunsOn::SshFromGlobalConfig { ssh_config } => {
                 validate_global_ssh_config(ctx, ssh_config);
@@ -333,15 +333,15 @@ impl<'a> Validate<'a> for RunsOn {
 
             RunsOn::Ssh(config) => {
                 ctx.push_section("host");
-                ctx.validate_symbols(&config.host);
+                ctx.validate_expressions(&config.host);
                 ctx.pop_section();
 
                 ctx.push_section("port");
-                ctx.validate_symbols(&config.port);
+                ctx.validate_expressions(&config.port);
                 ctx.pop_section();
 
                 ctx.push_section("user");
-                ctx.validate_symbols(&config.user);
+                ctx.validate_expressions(&config.user);
                 ctx.pop_section();
 
                 ctx.push_section("auth");
@@ -354,20 +354,20 @@ impl<'a> Validate<'a> for RunsOn {
                     } => {
                         if let Some(pubkey) = public_key {
                             ctx.push_section("public_key");
-                            ctx.validate_symbols(pubkey);
+                            ctx.validate_expressions(pubkey);
                             ctx.validate_file_path(pubkey);
                             ctx.pop_section();
                         }
 
                         ctx.push_section("private_key");
-                        ctx.validate_symbols(private_key);
+                        ctx.validate_expressions(private_key);
                         ctx.validate_file_path(private_key);
                         ctx.pop_section();
                     }
 
                     SshUserAuth::Password { password } => {
                         ctx.push_section("password");
-                        ctx.validate_symbols(password);
+                        ctx.validate_expressions(password);
                         ctx.pop_section();
                     }
                 }
@@ -381,8 +381,8 @@ impl<'a> Validate<'a> for RunsOn {
 fn validate_docker_url<'a, C: ValidatorContext<'a>>(ctx: &mut C, value: &'a str) {
     ctx.push_section("docker_url");
 
-    if ctx.contains_symbols(value) {
-        ctx.validate_symbols(value);
+    if ctx.contains_expressions(value) {
+        ctx.validate_expressions(value);
     } else {
         let config = ctx.get_config();
         match &config.local.docker_url {
@@ -411,18 +411,18 @@ fn validate_registry<'a, C: ValidatorContext<'a>>(ctx: &mut C, registry: &'a Reg
         }
         Registry::Full(config) => {
             ctx.push_section("url");
-            ctx.validate_symbols(&config.url);
+            ctx.validate_expressions(&config.url);
             ctx.pop_section();
 
             if let Some(username) = &config.username {
                 ctx.push_section("username");
-                ctx.validate_symbols(username);
+                ctx.validate_expressions(username);
                 ctx.pop_section();
             }
 
             if let Some(password) = &config.password {
                 ctx.push_section("password");
-                ctx.validate_symbols(password);
+                ctx.validate_expressions(password);
                 ctx.pop_section();
             }
         }
@@ -433,8 +433,8 @@ fn validate_registry<'a, C: ValidatorContext<'a>>(ctx: &mut C, registry: &'a Reg
 
 #[cfg(feature = "all")]
 fn validate_global_registry_config<'a, C: ValidatorContext<'a>>(ctx: &mut C, value: &'a str) {
-    if ctx.contains_symbols(value) {
-        ctx.validate_symbols(value);
+    if ctx.contains_expressions(value) {
+        ctx.validate_expressions(value);
     } else {
         let config = ctx.get_config();
         if config.registry(value).is_none() {
@@ -447,8 +447,8 @@ fn validate_global_registry_config<'a, C: ValidatorContext<'a>>(ctx: &mut C, val
 fn validate_global_ssh_config<'a, C: ValidatorContext<'a>>(ctx: &mut C, value: &'a str) {
     ctx.push_section("ssh_config");
 
-    if ctx.contains_symbols(value) {
-        ctx.validate_symbols(value);
+    if ctx.contains_expressions(value) {
+        ctx.validate_expressions(value);
     } else {
         let config = ctx.get_config();
         if let Err(e) = config.ssh(value) {

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -90,12 +90,14 @@ impl Step {
 impl Dependencies for Step {
     async fn local_deps(&self, _config: &BldConfig, fs: &FileSystem) -> Vec<String> {
         match self {
-            Self::ExternalFile(external)
-                if matches!(fs.path(&external.uses).await.map(|x| x.is_yaml()), Ok(true)) =>
-            {
-                vec![external.uses.to_owned()]
+            Self::ExternalFile(external) => {
+                if matches!(fs.path(&external.uses).await.map(|x| x.is_yaml()), Ok(true)) {
+                    vec![external.uses.to_owned()]
+                } else {
+                    vec![]
+                }
             }
-            Self::ComplexSh { .. } | Self::ExternalFile { .. } => vec![],
+            Self::ComplexSh { .. } => vec![],
         }
     }
 }
@@ -153,8 +155,17 @@ impl<'a> Validate<'a> for Step {
                     ctx.pop_section();
                 }
 
+                if let Some(condition) = complex.condition.as_ref() {
+                    debug!("Validating step's if condition");
+                    ctx.push_section("if");
+                    ctx.validate_symbols(condition);
+                    ctx.pop_section();
+                }
+
                 debug!("Validating step's run command");
+                ctx.push_section("run");
                 ctx.validate_symbols(&complex.run);
+                ctx.pop_section();
 
                 ctx.pop_section();
             }

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -165,12 +165,19 @@ impl<'a> Validate<'a> for Step {
                 if let Some(condition) = complex.condition.as_ref() {
                     debug!("Validating step's if condition");
                     ctx.push_section("if");
-                    ctx.validate_expressions(condition);
+                    if ctx.expression_count(condition) > 1 {
+                        ctx.append_error("Condition must contain at most one expression");
+                    } else {
+                        ctx.validate_expressions(condition);
+                    }
                     ctx.pop_section();
                 }
 
                 debug!("Validating step's run command");
                 ctx.push_section("run");
+                if complex.run.trim().is_empty() {
+                    ctx.append_error("Run command must not be empty");
+                }
                 ctx.validate_expressions(&complex.run);
                 ctx.pop_section();
 

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -148,6 +148,13 @@ impl<'a> Validate<'a> for Step {
                 debug!("Step is a complex shell command");
                 ctx.push_section(&complex.id);
 
+                if let Some(name) = complex.name.as_ref() {
+                    debug!("Validating step's name value");
+                    ctx.push_section("name");
+                    ctx.validate_expressions(name);
+                    ctx.pop_section();
+                }
+
                 if let Some(wd) = complex.working_dir.as_ref() {
                     debug!("Validating step's working directory");
                     ctx.push_section("working_dir");

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -180,7 +180,6 @@ mod tests {
             exec::CommonExprExecutor,
             traits::{EvalExpr, ExprText, ExprValue, MockWritableRuntimeExprContext},
         },
-        external::v3::External,
         pipeline::v3::Pipeline,
         step::v3::{ShellCommand, Step},
     };
@@ -221,7 +220,7 @@ mod tests {
         );
 
         wctx.expect_get_exec_id().returning_st(|| Some("main"));
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ steps.second.name }}").unwrap();
         assert!(matches!(
@@ -271,7 +270,7 @@ mod tests {
 
         let mut wctx = MockWritableRuntimeExprContext::new();
         wctx.expect_get_exec_id().returning_st(|| Some("backup"));
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ steps.first.name }}").unwrap();
         assert!(matches!(
@@ -299,7 +298,7 @@ mod tests {
 
     #[test]
     pub fn steps_complex_step_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut action = Action::default();
         action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
@@ -324,7 +323,7 @@ mod tests {
             condition: Some("first_condition".to_string()),
         })));
 
-        let exec = CommonExprExecutor::new(&action, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&action, &rctx, &wctx);
 
         let actual = exec.eval("${{ steps.second.name }}").unwrap();
         assert!(matches!(
@@ -398,21 +397,21 @@ mod tests {
 
     #[test]
     pub fn jobs_external_step_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::default();
+        let wctx = MockWritableRuntimeExprContext::default();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut pipeline = Pipeline::default();
         pipeline.jobs.insert(
             "main".to_string(),
             vec![
-                Step::ExternalFile(Box::new(External::default())),
-                Step::ExternalFile(Box::new(External::default())),
+                Step::ExternalFile(Box::default()),
+                Step::ExternalFile(Box::default()),
             ],
         );
         pipeline.jobs.insert(
             "backup".to_string(),
-            vec![Step::ExternalFile(Box::new(External::default()))],
+            vec![Step::ExternalFile(Box::default())],
         );
-        let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let actual = exec.eval("${{ jobs.main.first }}");
         assert!(actual.is_err());
@@ -426,19 +425,19 @@ mod tests {
 
     #[test]
     pub fn steps_external_step_expr_eval_success() {
-        let mut wctx = MockWritableRuntimeExprContext::new();
+        let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut action = Action::default();
         action
             .steps
-            .push(Step::ExternalFile(Box::new(External::default())));
+            .push(Step::ExternalFile(Box::default()));
         action
             .steps
-            .push(Step::ExternalFile(Box::new(External::default())));
+            .push(Step::ExternalFile(Box::default()));
         action
             .steps
-            .push(Step::ExternalFile(Box::new(External::default())));
-        let exec = CommonExprExecutor::new(&action, &rctx, &mut wctx);
+            .push(Step::ExternalFile(Box::default()));
+        let exec = CommonExprExecutor::new(&action, &rctx, &wctx);
 
         let actual = exec.eval("${{ steps.main.first }}");
         assert!(actual.is_err());
@@ -453,7 +452,7 @@ mod tests {
     #[test]
     pub fn jobs_outputs_expr_eval_success() {
         // Arrange
-        let data = vec![
+        let data = [
             (
                 "main",
                 vec![
@@ -488,7 +487,7 @@ mod tests {
         let mut pipeline = Pipeline::default();
 
         for (job, steps) in data.iter() {
-            if pipeline.jobs.get(*job).is_none() {
+            if !pipeline.jobs.contains_key(*job) {
                 pipeline.jobs.insert(job.to_string(), vec![]);
             }
 
@@ -520,7 +519,7 @@ mod tests {
         for (_, steps) in data.iter() {
             for (step, outputs) in steps.iter() {
                 for (name, value) in outputs.iter() {
-                    let exec = CommonExprExecutor::new(&pipeline, &rctx, &mut wctx);
+                    let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
                     let expr = format!("{} steps.{step}.outputs.{name} {}", "${{", "}}");
 
                     // Act
@@ -541,7 +540,7 @@ mod tests {
     #[test]
     pub fn action_outputs_expr_eval_success() {
         // Arrange
-        let data = vec![
+        let data = [
             (
                 "build",
                 vec![
@@ -583,7 +582,7 @@ mod tests {
 
         for (step, outputs) in data.iter() {
             for (name, value) in outputs.iter() {
-                let exec = CommonExprExecutor::new(&action, &rctx, &mut wctx);
+                let exec = CommonExprExecutor::new(&action, &rctx, &wctx);
                 let expr = format!("{} steps.{step}.outputs.{name} {}", "${{", "}}");
 
                 // Act

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -151,20 +151,20 @@ impl<'a> Validate<'a> for Step {
                 if let Some(wd) = complex.working_dir.as_ref() {
                     debug!("Validating step's working directory");
                     ctx.push_section("working_dir");
-                    ctx.validate_symbols(wd);
+                    ctx.validate_expressions(wd);
                     ctx.pop_section();
                 }
 
                 if let Some(condition) = complex.condition.as_ref() {
                     debug!("Validating step's if condition");
                     ctx.push_section("if");
-                    ctx.validate_symbols(condition);
+                    ctx.validate_expressions(condition);
                     ctx.pop_section();
                 }
 
                 debug!("Validating step's run command");
                 ctx.push_section("run");
-                ctx.validate_symbols(&complex.run);
+                ctx.validate_expressions(&complex.run);
                 ctx.pop_section();
 
                 ctx.pop_section();

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -428,15 +428,9 @@ mod tests {
         let wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let mut action = Action::default();
-        action
-            .steps
-            .push(Step::ExternalFile(Box::default()));
-        action
-            .steps
-            .push(Step::ExternalFile(Box::default()));
-        action
-            .steps
-            .push(Step::ExternalFile(Box::default()));
+        action.steps.push(Step::ExternalFile(Box::default()));
+        action.steps.push(Step::ExternalFile(Box::default()));
+        action.steps.push(Step::ExternalFile(Box::default()));
         let exec = CommonExprExecutor::new(&action, &rctx, &wctx);
 
         let actual = exec.eval("${{ steps.main.first }}");

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -1,19 +1,7 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Write,
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{collections::HashMap, fmt::Write, path::PathBuf, sync::Arc};
 
 use anyhow::{Result, bail};
-use bld_config::{
-    BldConfig,
-    definitions::{
-        KEYWORD_BLD_DIR_V3, KEYWORD_PROJECT_DIR_V3, KEYWORD_RUN_PROPS_ID_V3,
-        KEYWORD_RUN_PROPS_START_TIME_V3,
-    },
-    path,
-};
+use bld_config::{BldConfig, path};
 use bld_core::fs::FileSystem;
 use bld_pkg::PackageManager;
 use regex::Regex;
@@ -32,15 +20,6 @@ pub fn create_expression_regex() -> Result<Regex> {
     Ok(Regex::new(EXPR_REGEX)?)
 }
 
-pub fn create_keywords() -> HashSet<&'static str> {
-    let mut keywords = HashSet::new();
-    keywords.insert(KEYWORD_BLD_DIR_V3);
-    keywords.insert(KEYWORD_PROJECT_DIR_V3);
-    keywords.insert(KEYWORD_RUN_PROPS_ID_V3);
-    keywords.insert(KEYWORD_RUN_PROPS_START_TIME_V3);
-    keywords
-}
-
 pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
     validatable: &'a V,
     config: Arc<BldConfig>,
@@ -49,7 +28,6 @@ pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
     expr_regex: Regex,
     expr_rctx: &'a CommonReadonlyRuntimeExprContext,
     expr_wctx: &'a CommonWritableRuntimeExprContext,
-    keywords: HashSet<&'a str>,
     section: Vec<&'a str>,
     errors: String,
 }
@@ -71,7 +49,6 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> CommonValidator<'a, V> {
             expr_regex: create_expression_regex()?,
             expr_rctx,
             expr_wctx,
-            keywords: create_keywords(),
             section: Vec::new(),
             errors: String::new(),
         })
@@ -119,14 +96,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
                 continue;
             };
             let section = self.section.join(" > ");
-            let _ = writeln!(self.errors, "[{section}] Invalid expression, {}", e);
-        }
-    }
-
-    fn validate_keywords(&mut self, name: &'a str) {
-        if self.keywords.contains(name) {
-            let section = self.section.join(" > ");
-            let _ = writeln!(self.errors, "[{section}] Invalid name, reserved as keyword",);
+            let _ = writeln!(self.errors, "[{section}] {}", e);
         }
     }
 
@@ -145,7 +115,6 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
         for (k, v) in env.iter() {
             debug!("Validating env: {}", k);
             self.section.push(k);
-            self.validate_keywords(k);
             self.validate_symbols(v);
             self.section.pop();
         }

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -150,6 +150,10 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
         let _ = writeln!(self.errors, "[{section}] {error}");
     }
 
+    fn expression_count(&self, value: &str) -> usize {
+        self.expr_regex.find_iter(value).count()
+    }
+
     fn contains_expressions(&mut self, value: &str) -> bool {
         self.expr_regex.find(value).is_some()
     }

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -150,11 +150,11 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
         let _ = writeln!(self.errors, "[{section}] {error}");
     }
 
-    fn contains_symbols(&mut self, value: &str) -> bool {
+    fn contains_expressions(&mut self, value: &str) -> bool {
         self.expr_regex.find(value).is_some()
     }
 
-    fn validate_symbols(&mut self, value: &'a str) {
+    fn validate_expressions(&mut self, value: &'a str) {
         let expr_wctx = self
             .expr_wctx
             .iter()
@@ -174,7 +174,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
     }
 
     fn validate_file_path(&mut self, value: &'a str) {
-        if self.contains_symbols(value) {
+        if self.contains_expressions(value) {
             return;
         }
         let path = path![value];
@@ -188,7 +188,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
         for (k, v) in env.iter() {
             debug!("Validating env: {}", k);
             self.section.push(Section::Other(k));
-            self.validate_symbols(v);
+            self.validate_expressions(v);
             self.section.pop();
         }
     }
@@ -197,7 +197,6 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
 impl<'a, V: Validate<'a> + EvalObject<'a>> ConsumeValidator for CommonValidator<'a, V> {
     async fn validate(mut self) -> Result<()> {
         self.validatable.validate(&mut self).await;
-
         if self.errors.is_empty() {
             Ok(())
         } else {

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -16,7 +16,6 @@ use bld_config::{
 };
 use bld_core::fs::FileSystem;
 use bld_pkg::PackageManager;
-use bld_utils::sync::IntoArc;
 use regex::Regex;
 use tracing::debug;
 
@@ -24,7 +23,7 @@ use crate::expr::v3::{
     context::{CommonReadonlyRuntimeExprContext, CommonWritableRuntimeExprContext},
     exec::CommonExprExecutor,
     parser::EXPR_REGEX,
-    traits::EvalObject,
+    traits::{EvalExpr, EvalObject},
 };
 
 use super::{ConsumeValidator, Validate, ValidatorContext};
@@ -48,8 +47,8 @@ pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
     file_system: Arc<FileSystem>,
     package_manager: Arc<PackageManager>,
     expr_regex: Regex,
-    expr_rctx: CommonReadonlyRuntimeExprContext,
-    expr_wctx: CommonWritableRuntimeExprContext,
+    expr_rctx: &'a CommonReadonlyRuntimeExprContext,
+    expr_wctx: &'a CommonWritableRuntimeExprContext,
     keywords: HashSet<&'a str>,
     section: Vec<&'a str>,
     errors: String,
@@ -61,15 +60,9 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> CommonValidator<'a, V> {
         config: Arc<BldConfig>,
         file_system: Arc<FileSystem>,
         package_manager: Arc<PackageManager>,
+        expr_rctx: &'a CommonReadonlyRuntimeExprContext,
+        expr_wctx: &'a CommonWritableRuntimeExprContext,
     ) -> Result<Self> {
-        let expr_rctx = CommonReadonlyRuntimeExprContext::new(
-            config.clone(),
-            HashMap::<String, String>::new().into_arc(),
-            HashMap::<String, String>::new().into_arc(),
-            String::new(),
-            String::new(),
-        );
-        let expr_wctx = CommonWritableRuntimeExprContext::default();
         Ok(Self {
             validatable,
             config,
@@ -119,9 +112,15 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
         self.expr_regex.find(value).is_some()
     }
 
-    fn validate_symbols<'b: 'a>(&'b mut self, value: &str) {
-        let expr_exec = CommonExprExecutor::new(self.validatable, &self.expr_rctx, &self.expr_wctx);
-        for entry in self.expr_regex.find_iter(value) {}
+    fn validate_symbols(&mut self, value: &'a str) {
+        let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, self.expr_wctx);
+        for entry in self.expr_regex.find_iter(value) {
+            let Err(e) = expr_exec.eval(entry.as_str()) else {
+                continue;
+            };
+            let section = self.section.join(" > ");
+            let _ = writeln!(self.errors, "[{section}] Invalid expression, {}", e);
+        }
     }
 
     fn validate_keywords(&mut self, name: &'a str) {

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -11,13 +11,26 @@ use crate::expr::v3::{
     context::{CommonReadonlyRuntimeExprContext, CommonWritableRuntimeExprContext},
     exec::CommonExprExecutor,
     parser::EXPR_REGEX,
-    traits::{EvalExpr, EvalObject},
+    traits::{EvalExpr, EvalObject, WritableRuntimeExprContext},
 };
 
 use super::{ConsumeValidator, Validate, ValidatorContext};
 
 pub fn create_expression_regex() -> Result<Regex> {
     Ok(Regex::new(EXPR_REGEX)?)
+}
+
+enum Section<'a> {
+    Job(&'a str),
+    Other(&'a str),
+}
+
+impl<'a> Section<'a> {
+    pub fn inner(&self) -> &'a str {
+        match self {
+            Section::Other(s) | Section::Job(s) => s,
+        }
+    }
 }
 
 pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
@@ -27,8 +40,9 @@ pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
     package_manager: Arc<PackageManager>,
     expr_regex: Regex,
     expr_rctx: &'a CommonReadonlyRuntimeExprContext,
-    expr_wctx: &'a CommonWritableRuntimeExprContext,
-    section: Vec<&'a str>,
+    expr_wctx: &'a [CommonWritableRuntimeExprContext<'a>],
+    section: Vec<Section<'a>>,
+    current_job: Option<Section<'a>>,
     errors: String,
 }
 
@@ -39,7 +53,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> CommonValidator<'a, V> {
         file_system: Arc<FileSystem>,
         package_manager: Arc<PackageManager>,
         expr_rctx: &'a CommonReadonlyRuntimeExprContext,
-        expr_wctx: &'a CommonWritableRuntimeExprContext,
+        expr_wctx: &'a [CommonWritableRuntimeExprContext],
     ) -> Result<Self> {
         Ok(Self {
             validatable,
@@ -50,8 +64,17 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> CommonValidator<'a, V> {
             expr_rctx,
             expr_wctx,
             section: Vec::new(),
+            current_job: None,
             errors: String::new(),
         })
+    }
+
+    fn section_txt(&self) -> String {
+        self.section
+            .iter()
+            .map(|x| x.inner())
+            .collect::<Vec<&'a str>>()
+            .join(" > ")
     }
 }
 
@@ -69,11 +92,19 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
     }
 
     fn push_section(&mut self, section: &'a str) {
-        self.section.push(section);
+        self.section.push(Section::Other(section));
+    }
+
+    fn push_job_section(&mut self, section: &'a str) {
+        self.section.push(Section::Job(section));
+        self.current_job = Some(Section::Job(section));
     }
 
     fn pop_section(&mut self) {
-        self.section.pop();
+        let section = self.section.pop();
+        if matches!(section, Some(Section::Job(_))) {
+            self.current_job = None;
+        }
     }
 
     fn clear_section(&mut self) {
@@ -81,7 +112,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
     }
 
     fn append_error(&mut self, error: &str) {
-        let section = self.section.join(" > ");
+        let section = self.section_txt();
         let _ = writeln!(self.errors, "[{section}] {error}");
     }
 
@@ -90,12 +121,20 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
     }
 
     fn validate_symbols(&mut self, value: &'a str) {
-        let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, self.expr_wctx);
+        let expr_wctx = self
+            .expr_wctx
+            .iter()
+            .find(|x| x.get_exec_id() == self.current_job.as_ref().map(|x| x.inner()))
+            .or_else(|| self.expr_wctx.iter().next());
+
+        let Some(expr_wctx) = expr_wctx else { return };
+
+        let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, expr_wctx);
         for entry in self.expr_regex.find_iter(value) {
             let Err(e) = expr_exec.eval(entry.as_str()) else {
                 continue;
             };
-            let section = self.section.join(" > ");
+            let section = self.section_txt();
             let _ = writeln!(self.errors, "[{section}] {}", e);
         }
     }
@@ -106,7 +145,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
         }
         let path = path![value];
         if !path.is_file() {
-            let section = self.section.join(" > ");
+            let section = self.section_txt();
             let _ = writeln!(self.errors, "[{section} > {value}] File not found");
         }
     }
@@ -114,7 +153,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValida
     fn validate_env(&mut self, env: &'a HashMap<String, String>) {
         for (k, v) in env.iter() {
             debug!("Validating env: {}", k);
-            self.section.push(k);
+            self.section.push(Section::Other(k));
             self.validate_symbols(v);
             self.section.pop();
         }

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -16,13 +16,21 @@ use bld_config::{
 };
 use bld_core::fs::FileSystem;
 use bld_pkg::PackageManager;
+use bld_utils::sync::IntoArc;
 use regex::Regex;
 use tracing::debug;
+
+use crate::expr::v3::{
+    context::{CommonReadonlyRuntimeExprContext, CommonWritableRuntimeExprContext},
+    exec::CommonExprExecutor,
+    parser::EXPR_REGEX,
+    traits::EvalObject,
+};
 
 use super::{ConsumeValidator, Validate, ValidatorContext};
 
 pub fn create_expression_regex() -> Result<Regex> {
-    Ok(Regex::new(r"\$\{\{\s*(\b\w+\b)\s*\}\}")?)
+    Ok(Regex::new(EXPR_REGEX)?)
 }
 
 pub fn create_keywords() -> HashSet<&'static str> {
@@ -34,30 +42,42 @@ pub fn create_keywords() -> HashSet<&'static str> {
     keywords
 }
 
-pub struct CommonValidator<'a, V: Validate<'a>> {
+pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
     validatable: &'a V,
     config: Arc<BldConfig>,
     file_system: Arc<FileSystem>,
     package_manager: Arc<PackageManager>,
-    regex: Regex,
+    expr_regex: Regex,
+    expr_rctx: CommonReadonlyRuntimeExprContext,
+    expr_wctx: CommonWritableRuntimeExprContext,
     keywords: HashSet<&'a str>,
     section: Vec<&'a str>,
     errors: String,
 }
 
-impl<'a, V: Validate<'a>> CommonValidator<'a, V> {
+impl<'a, V: Validate<'a> + EvalObject<'a>> CommonValidator<'a, V> {
     pub fn new(
         validatable: &'a V,
         config: Arc<BldConfig>,
         file_system: Arc<FileSystem>,
         package_manager: Arc<PackageManager>,
     ) -> Result<Self> {
+        let expr_rctx = CommonReadonlyRuntimeExprContext::new(
+            config.clone(),
+            HashMap::<String, String>::new().into_arc(),
+            HashMap::<String, String>::new().into_arc(),
+            String::new(),
+            String::new(),
+        );
+        let expr_wctx = CommonWritableRuntimeExprContext::default();
         Ok(Self {
             validatable,
             config,
             file_system,
             package_manager,
-            regex: create_expression_regex()?,
+            expr_regex: create_expression_regex()?,
+            expr_rctx,
+            expr_wctx,
             keywords: create_keywords(),
             section: Vec::new(),
             errors: String::new(),
@@ -65,7 +85,7 @@ impl<'a, V: Validate<'a>> CommonValidator<'a, V> {
     }
 }
 
-impl<'a, V: Validate<'a>> ValidatorContext<'a> for CommonValidator<'a, V> {
+impl<'a, V: Validate<'a> + EvalObject<'a>> ValidatorContext<'a> for CommonValidator<'a, V> {
     fn get_config(&self) -> Arc<BldConfig> {
         self.config.clone()
     }
@@ -96,10 +116,13 @@ impl<'a, V: Validate<'a>> ValidatorContext<'a> for CommonValidator<'a, V> {
     }
 
     fn contains_symbols(&mut self, value: &str) -> bool {
-        self.regex.find(value).is_some()
+        self.expr_regex.find(value).is_some()
     }
 
-    fn validate_symbols(&mut self, _value: &'a str) {}
+    fn validate_symbols<'b: 'a>(&'b mut self, value: &str) {
+        let expr_exec = CommonExprExecutor::new(self.validatable, &self.expr_rctx, &self.expr_wctx);
+        for entry in self.expr_regex.find_iter(value) {}
+    }
 
     fn validate_keywords(&mut self, name: &'a str) {
         if self.keywords.contains(name) {
@@ -130,7 +153,7 @@ impl<'a, V: Validate<'a>> ValidatorContext<'a> for CommonValidator<'a, V> {
     }
 }
 
-impl<'a, V: Validate<'a>> ConsumeValidator for CommonValidator<'a, V> {
+impl<'a, V: Validate<'a> + EvalObject<'a>> ConsumeValidator for CommonValidator<'a, V> {
     async fn validate(mut self) -> Result<()> {
         self.validatable.validate(&mut self).await;
 

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use tracing::debug;
 
 use crate::expr::v3::{
-    context::{CommonReadonlyRuntimeExprContext, CommonWritableRuntimeExprContext},
+    context::CommonReadonlyRuntimeExprContext,
     exec::CommonExprExecutor,
     parser::EXPR_REGEX,
     traits::{EvalExpr, EvalObject, WritableRuntimeExprContext},
@@ -33,6 +33,40 @@ impl<'a> Section<'a> {
     }
 }
 
+pub struct ValidatorWritableRuntimeExprContext<'a> {
+    exec_id: &'a str,
+    outputs: HashMap<String, String>,
+}
+
+impl<'a> ValidatorWritableRuntimeExprContext<'a> {
+    pub fn new(exec_id: &'a str) -> Self {
+        Self {
+            exec_id,
+            outputs: HashMap::new(),
+        }
+    }
+}
+
+impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> {
+    fn get_exec_id(&self) -> Option<&str> {
+        Some(self.exec_id)
+    }
+
+    fn get_output<'b>(&'b self, _id: &str, _name: &str) -> Result<&'b str> {
+        Ok("")
+    }
+
+    fn set_output(&mut self, _id: &str, name: String, value: String) -> Result<()> {
+        self.outputs.insert(name, value);
+        Ok(())
+    }
+
+    fn set_outputs(&mut self, _id: &str, outputs: HashMap<String, String>) -> Result<()> {
+        self.outputs = outputs;
+        Ok(())
+    }
+}
+
 pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
     validatable: &'a V,
     config: Arc<BldConfig>,
@@ -40,7 +74,7 @@ pub struct CommonValidator<'a, V: Validate<'a> + EvalObject<'a>> {
     package_manager: Arc<PackageManager>,
     expr_regex: Regex,
     expr_rctx: &'a CommonReadonlyRuntimeExprContext,
-    expr_wctx: &'a [CommonWritableRuntimeExprContext<'a>],
+    expr_wctx: &'a [ValidatorWritableRuntimeExprContext<'a>],
     section: Vec<Section<'a>>,
     current_job: Option<Section<'a>>,
     errors: String,
@@ -53,7 +87,7 @@ impl<'a, V: Validate<'a> + EvalObject<'a>> CommonValidator<'a, V> {
         file_system: Arc<FileSystem>,
         package_manager: Arc<PackageManager>,
         expr_rctx: &'a CommonReadonlyRuntimeExprContext,
-        expr_wctx: &'a [CommonWritableRuntimeExprContext],
+        expr_wctx: &'a [ValidatorWritableRuntimeExprContext],
     ) -> Result<Self> {
         Ok(Self {
             validatable,

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -7,8 +7,8 @@ use bld_pkg::PackageManager;
 use bld_utils::sync::IntoArc;
 
 use crate::{
-    expr::v3::context::{CommonReadonlyRuntimeExprContext, CommonWritableRuntimeExprContext},
-    files::v3::RunnerFile,
+    expr::v3::context::CommonReadonlyRuntimeExprContext, files::v3::RunnerFile,
+    validator::v3::ValidatorWritableRuntimeExprContext,
 };
 
 use super::{CommonValidator, ConsumeValidator};
@@ -19,7 +19,7 @@ pub struct RunnerFileValidator<'a> {
     file_system: Arc<FileSystem>,
     package_manager: Arc<PackageManager>,
     expr_rctx: CommonReadonlyRuntimeExprContext,
-    expr_wctx: Vec<CommonWritableRuntimeExprContext<'a>>,
+    expr_wctx: Vec<ValidatorWritableRuntimeExprContext<'a>>,
 }
 
 impl<'a> RunnerFileValidator<'a> {
@@ -40,10 +40,10 @@ impl<'a> RunnerFileValidator<'a> {
             RunnerFile::PipelineFileType(pipeline) => pipeline
                 .jobs
                 .keys()
-                .map(|k| CommonWritableRuntimeExprContext::new(k))
+                .map(|k| ValidatorWritableRuntimeExprContext::new(k))
                 .collect(),
             RunnerFile::ActionFileType(_) => {
-                vec![CommonWritableRuntimeExprContext::new("action")]
+                vec![ValidatorWritableRuntimeExprContext::new("action")]
             }
         };
         Ok(Self {

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -1,17 +1,25 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::fs::FileSystem;
 use bld_pkg::PackageManager;
+use bld_utils::sync::IntoArc;
 
-use crate::{action::v3::Action, files::v3::RunnerFile, pipeline::v3::Pipeline};
+use crate::{
+    expr::v3::context::{CommonReadonlyRuntimeExprContext, CommonWritableRuntimeExprContext},
+    files::v3::RunnerFile,
+};
 
 use super::{CommonValidator, ConsumeValidator};
 
-pub enum RunnerFileValidator<'a> {
-    Pipeline(CommonValidator<'a, Pipeline>),
-    Action(CommonValidator<'a, Action>),
+pub struct RunnerFileValidator<'a> {
+    file: &'a RunnerFile,
+    config: Arc<BldConfig>,
+    file_system: Arc<FileSystem>,
+    package_manager: Arc<PackageManager>,
+    expr_rctx: CommonReadonlyRuntimeExprContext,
+    expr_wctx: CommonWritableRuntimeExprContext,
 }
 
 impl<'a> RunnerFileValidator<'a> {
@@ -21,26 +29,53 @@ impl<'a> RunnerFileValidator<'a> {
         file_system: Arc<FileSystem>,
         package_manager: Arc<PackageManager>,
     ) -> Result<Self> {
-        match file {
-            RunnerFile::PipelineFileType(pip) => {
-                let validator =
-                    CommonValidator::new(pip.as_ref(), config, file_system, package_manager)?;
-                Ok(Self::Pipeline(validator))
-            }
-            RunnerFile::ActionFileType(action) => {
-                let validator =
-                    CommonValidator::new(action.as_ref(), config, file_system, package_manager)?;
-                Ok(Self::Action(validator))
-            }
-        }
+        let expr_rctx = CommonReadonlyRuntimeExprContext::new(
+            config.clone(),
+            HashMap::<String, String>::new().into_arc(),
+            HashMap::<String, String>::new().into_arc(),
+            String::new(),
+            String::new(),
+        );
+        let expr_wctx = CommonWritableRuntimeExprContext::default();
+
+        Ok(Self {
+            file,
+            config,
+            file_system,
+            package_manager,
+            expr_rctx,
+            expr_wctx,
+        })
     }
 }
 
 impl ConsumeValidator for RunnerFileValidator<'_> {
     async fn validate(self) -> Result<()> {
-        match self {
-            Self::Pipeline(validator) => validator.validate().await,
-            Self::Action(validator) => validator.validate().await,
+        match self.file {
+            RunnerFile::PipelineFileType(pip) => {
+                CommonValidator::new(
+                    pip.as_ref(),
+                    self.config,
+                    self.file_system,
+                    self.package_manager,
+                    &self.expr_rctx,
+                    &self.expr_wctx,
+                )?
+                .validate()
+                .await
+            }
+            RunnerFile::ActionFileType(action) => {
+                CommonValidator::new(
+                    action.as_ref(),
+                    self.config,
+                    self.file_system,
+                    self.package_manager,
+                    &self.expr_rctx,
+                    &self.expr_wctx,
+                )?
+                .validate()
+                .await
+            }
         }
     }
 }

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -19,7 +19,7 @@ pub struct RunnerFileValidator<'a> {
     file_system: Arc<FileSystem>,
     package_manager: Arc<PackageManager>,
     expr_rctx: CommonReadonlyRuntimeExprContext,
-    expr_wctx: CommonWritableRuntimeExprContext,
+    expr_wctx: Vec<CommonWritableRuntimeExprContext<'a>>,
 }
 
 impl<'a> RunnerFileValidator<'a> {
@@ -36,7 +36,16 @@ impl<'a> RunnerFileValidator<'a> {
             String::new(),
             String::new(),
         );
-        let expr_wctx = CommonWritableRuntimeExprContext::new();
+        let expr_wctx = match &file {
+            RunnerFile::PipelineFileType(pipeline) => pipeline
+                .jobs
+                .keys()
+                .map(|k| CommonWritableRuntimeExprContext::new(k))
+                .collect(),
+            RunnerFile::ActionFileType(_) => {
+                vec![CommonWritableRuntimeExprContext::new("action")]
+            }
+        };
         Ok(Self {
             file,
             config,

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
 use bld_config::BldConfig;
@@ -36,8 +36,7 @@ impl<'a> RunnerFileValidator<'a> {
             String::new(),
             String::new(),
         );
-        let expr_wctx = CommonWritableRuntimeExprContext::default();
-
+        let expr_wctx = CommonWritableRuntimeExprContext::new();
         Ok(Self {
             file,
             config,

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -31,8 +31,8 @@ impl<'a> RunnerFileValidator<'a> {
     ) -> Result<Self> {
         let expr_rctx = CommonReadonlyRuntimeExprContext::new(
             config.clone(),
-            HashMap::<String, String>::new().into_arc(),
-            HashMap::<String, String>::new().into_arc(),
+            file.inputs_map().into_arc(),
+            file.env_map().into_arc(),
             String::new(),
             String::new(),
         );

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -15,8 +15,8 @@ pub trait ValidatorContext<'a> {
     #[allow(dead_code)]
     fn clear_section(&mut self);
     fn append_error(&mut self, error: &str);
-    fn contains_symbols(&mut self, value: &str) -> bool;
-    fn validate_symbols(&mut self, symbol: &'a str);
+    fn contains_expressions(&mut self, value: &str) -> bool;
+    fn validate_expressions(&mut self, symbol: &'a str);
     fn validate_file_path(&mut self, value: &'a str);
     fn validate_env(&mut self, env: &'a HashMap<String, String>);
 }

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -15,6 +15,7 @@ pub trait ValidatorContext<'a> {
     #[allow(dead_code)]
     fn clear_section(&mut self);
     fn append_error(&mut self, error: &str);
+    fn expression_count(&self, value: &str) -> usize;
     fn contains_expressions(&mut self, value: &str) -> bool;
     fn validate_expressions(&mut self, symbol: &'a str);
     fn validate_file_path(&mut self, value: &'a str);

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -15,7 +15,7 @@ pub trait ValidatorContext<'a> {
     fn clear_section(&mut self);
     fn append_error(&mut self, error: &str);
     fn contains_symbols(&mut self, value: &str) -> bool;
-    fn validate_symbols(&mut self, symbol: &'a str);
+    fn validate_symbols<'b: 'a>(&'b mut self, symbol: &str);
     fn validate_keywords(&mut self, name: &'a str);
     fn validate_file_path(&mut self, value: &'a str);
     fn validate_env(&mut self, env: &'a HashMap<String, String>);

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -16,7 +16,6 @@ pub trait ValidatorContext<'a> {
     fn append_error(&mut self, error: &str);
     fn contains_symbols(&mut self, value: &str) -> bool;
     fn validate_symbols(&mut self, symbol: &'a str);
-    fn validate_keywords(&mut self, name: &'a str);
     fn validate_file_path(&mut self, value: &'a str);
     fn validate_env(&mut self, env: &'a HashMap<String, String>);
 }

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -10,6 +10,7 @@ pub trait ValidatorContext<'a> {
     fn get_fs(&self) -> Arc<FileSystem>;
     fn get_package_manager(&self) -> Arc<PackageManager>;
     fn push_section(&mut self, section: &'a str);
+    fn push_job_section(&mut self, section: &'a str);
     fn pop_section(&mut self);
     #[allow(dead_code)]
     fn clear_section(&mut self);

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -15,7 +15,7 @@ pub trait ValidatorContext<'a> {
     fn clear_section(&mut self);
     fn append_error(&mut self, error: &str);
     fn contains_symbols(&mut self, value: &str) -> bool;
-    fn validate_symbols<'b: 'a>(&'b mut self, symbol: &str);
+    fn validate_symbols(&mut self, symbol: &'a str);
     fn validate_keywords(&mut self, name: &'a str);
     fn validate_file_path(&mut self, value: &'a str);
     fn validate_env(&mut self, env: &'a HashMap<String, String>);

--- a/crates/bld_ui/src/components/button.rs
+++ b/crates/bld_ui/src/components/button.rs
@@ -2,7 +2,7 @@ use super::colors::Colors;
 use leptos::*;
 
 pub fn get_button_color_classes(color: Option<Colors>) -> &'static str {
-    let color = color.unwrap_or_else(|| Colors::Violet);
+    let color = color.unwrap_or(Colors::Violet);
     match color {
         Colors::Slate => "bg-slate-700 hover:bg-slate-600 focus:bg-slate-600",
         Colors::Gray => "bg-gray-700 hover:bg-gray-600 focus:bg-gray-600",

--- a/crates/bld_ui/src/components/colors.rs
+++ b/crates/bld_ui/src/components/colors.rs
@@ -1,5 +1,4 @@
 #[allow(dead_code)]
-
 pub enum Colors {
     Slate,
     Gray,

--- a/crates/bld_ui/src/components/tabs.rs
+++ b/crates/bld_ui/src/components/tabs.rs
@@ -22,7 +22,7 @@ pub fn Tabs(
     view! {
         <div class="flex flex-col">
             <div class="hidden sm:block">
-                <nav class=move || nav_class() aria-label="Tabs">
+                <nav class=nav_class aria-label="Tabs">
                     {children()}
                 </nav>
             </div>

--- a/crates/bld_ui/src/pages/home/cron/delete.rs
+++ b/crates/bld_ui/src/pages/home/cron/delete.rs
@@ -19,7 +19,7 @@ type DeleteActionArgs = (
 
 async fn delete(id: String) -> Result<()> {
     let res = reqwest::Client::new()
-        .delete(&format!("http://localhost:6080/v1/cron/{}", id))
+        .delete(format!("http://localhost:6080/v1/cron/{}", id))
         .send()
         .await?;
 

--- a/crates/bld_ui/src/pages/home/cron/edit/details.rs
+++ b/crates/bld_ui/src/pages/home/cron/edit/details.rs
@@ -3,7 +3,7 @@ use bld_models::dtos::CronJobResponse;
 use leptos::*;
 
 #[component]
-pub fn CronJobsEditDetails<F: Fn() -> () + 'static>(
+pub fn CronJobsEditDetails<F: Fn() + 'static>(
     #[prop(into)] job: Signal<CronJobResponse>,
     save: F,
     delete: Option<WriteSignal<bool>>,

--- a/crates/bld_ui/src/pages/home/cron/helpers.rs
+++ b/crates/bld_ui/src/pages/home/cron/helpers.rs
@@ -13,10 +13,7 @@ pub fn hash_map_rw_signals(
     pipeline_items
         .into_iter()
         .map(|(k, v)| {
-            let value = cron_items
-                .as_mut()
-                .and_then(|c| c.remove(&k))
-                .unwrap_or_else(|| v);
+            let value = cron_items.as_mut().and_then(|c| c.remove(&k)).unwrap_or(v);
 
             (k, create_rw_signal(value))
         })

--- a/crates/bld_ui/src/pages/home/cron/mod.rs
+++ b/crates/bld_ui/src/pages/home/cron/mod.rs
@@ -26,7 +26,7 @@ fn get_params(limit: String, pipeline: String) -> Option<JobFiltersParams> {
         },
         None,
         None,
-        limit.parse::<u64>().map(|x| Some(x)).unwrap_or_default(),
+        limit.parse::<u64>().map(Some).unwrap_or_default(),
     ))
 }
 

--- a/crates/bld_ui/src/pages/home/dashboard/kpis.rs
+++ b/crates/bld_ui/src/pages/home/dashboard/kpis.rs
@@ -49,7 +49,7 @@ pub fn DashboardKpis() -> impl IntoView {
                     count: data.count as u64,
                     title: "Running pipelines".to_string(),
                     footnote: if data.available_workers == 0 {
-                        format!("Full worker capacity has been reached")
+                        "Full worker capacity has been reached".to_string()
                     } else {
                         format!("{} worker available in the server", data.available_workers)
                     },

--- a/crates/bld_ui/src/pages/home/pipelines/actions/copy.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/actions/copy.rs
@@ -123,7 +123,7 @@ pub fn PipelineCopyButton(
                     logging::console_error("App dialog context not found");
                     return;
                 };
-                let _ = content
+                content
                     .set(
                         Some(
                             view! {

--- a/crates/bld_ui/src/pages/home/pipelines/actions/delete.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/actions/delete.rs
@@ -103,7 +103,7 @@ pub fn PipelineDeleteButton(
                     logging::console_error("App dialog context not found");
                     return;
                 };
-                let _ = content
+                content
                     .set(
                         Some(
                             view! {

--- a/crates/bld_ui/src/pages/home/pipelines/actions/move.rs
+++ b/crates/bld_ui/src/pages/home/pipelines/actions/move.rs
@@ -126,7 +126,7 @@ pub fn PipelineMoveButton(
                     logging::console_error("App dialog context not found");
                     return;
                 };
-                let _ = content
+                content
                     .set(
                         Some(
                             view! {


### PR DESCRIPTION
### In this PR:
- Updated validator in order to be able to validate expressions using a read and write context.
- Updated validation lints in order to catch more errors.
- Minor other fixes.