### PR TITLE
266 migrate to actix ws

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,24 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-web-actors"
-version = "4.3.1+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98c5300b38fd004fe7d2a964f9a90813fdbe8a81fed500587e78b1b71c6f980"
-dependencies = [
- "actix",
- "actix-codec",
- "actix-http",
- "actix-web",
- "bytes",
- "bytestring",
- "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "actix-web-codegen"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +924,6 @@ dependencies = [
  "actix",
  "actix-codec",
  "actix-web",
- "actix-web-actors",
  "anyhow",
  "bld_config",
  "bld_core",
@@ -1014,7 +995,6 @@ dependencies = [
  "actix-codec",
  "actix-http",
  "actix-web",
- "actix-web-actors",
  "anyhow",
  "awc",
  "bld_config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "bld_core",
  "bld_http",
  "bld_models",
+ "bld_sock",
  "bld_utils",
  "bollard",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-util",
  "log",
  "once_cell",
@@ -61,26 +61,26 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.9.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
+checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.8.11",
  "base64 0.22.1",
  "bitflags 2.6.0",
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "flate2",
+ "foldhash",
  "futures-core",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -90,8 +90,8 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
- "sha1",
+ "rand 0.10.1",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -106,7 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -146,7 +146,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tracing",
 ]
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.9.0"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
+checksum = "2233f53f6cb18ae038ce1f0713ca0c72ca0c4b71fe9aaeb59924ce2c89c6dd85"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -209,13 +209,13 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.8.11",
  "bytes",
  "bytestring",
  "cfg-if",
  "cookie 0.16.2",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
+ "foldhash",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -231,8 +231,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.6.3",
  "time",
+ "tracing",
  "url",
 ]
 
@@ -263,7 +264,23 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "actix-ws"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf53c3cdd63dd6f289980b430238f9a2f6d19f8bce8e418272e08d3da43f0f"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytestring",
+ "futures-core",
+ "futures-sink",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -274,16 +291,7 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -298,7 +306,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -310,7 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -528,7 +535,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -608,7 +615,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -625,7 +632,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -654,7 +661,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -670,7 +677,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -695,37 +702,22 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cookie 0.16.2",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "itoa",
  "log",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "rustls 0.20.9",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1046,7 +1038,7 @@ dependencies = [
  "actix-codec",
  "actix-http",
  "actix-web",
- "actix-web-actors",
+ "actix-ws",
  "anyhow",
  "bld_config",
  "bld_core",
@@ -1109,6 +1101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1194,14 +1195,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1210,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1303,6 +1304,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,7 +1387,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1434,6 +1446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const_format"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1482,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1511,6 +1538,15 @@ name = "cpufeatures"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1596,7 +1632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1612,15 +1648,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.15",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1635,7 +1680,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1659,7 +1704,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1670,7 +1715,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1695,7 +1740,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1704,7 +1749,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1727,7 +1772,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1740,7 +1785,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.87",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1749,10 +1817,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1763,7 +1842,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1797,7 +1876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1845,14 +1924,14 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1933,7 +2012,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1981,6 +2060,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -2098,7 +2183,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2156,10 +2241,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "git2"
@@ -2235,15 +2328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2251,7 +2344,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2270,7 +2363,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2308,9 +2401,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2332,12 +2434,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -2366,7 +2462,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2456,6 +2552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,14 +2570,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2593,7 +2698,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.5.0",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2752,8 +2857,14 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2801,13 +2912,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.17.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2818,7 +2930,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2921,6 +3033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "leptos"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,9 +3119,9 @@ dependencies = [
  "cfg-if",
  "drain_filter_polyfill",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "html-escape",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "itertools 0.12.1",
  "js-sys",
  "leptos_reactive",
@@ -3029,13 +3147,13 @@ checksum = "6cb53d4794240b684a2f4be224b84bee9e62d2abc498cf2bcd643cd565e01d96"
 dependencies = [
  "anyhow",
  "camino",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "parking_lot 0.12.3",
  "proc-macro2",
  "quote",
  "rstml",
  "serde",
- "syn 2.0.87",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -3057,7 +3175,7 @@ dependencies = [
  "quote",
  "rstml",
  "server_fn_macro",
- "syn 2.0.87",
+ "syn 2.0.117",
  "tracing",
  "uuid",
 ]
@@ -3071,7 +3189,7 @@ dependencies = [
  "base64 0.22.1",
  "cfg-if",
  "futures",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "js-sys",
  "oco_ref",
  "paste",
@@ -3133,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -3272,7 +3390,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3302,7 +3420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3353,15 +3471,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3387,7 +3504,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3436,7 +3553,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3460,7 +3577,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -3479,7 +3596,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3520,9 +3637,9 @@ checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
 dependencies = [
  "base64 0.13.1",
  "chrono",
- "getrandom",
+ "getrandom 0.2.15",
  "http 0.2.12",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -3530,15 +3647,6 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "url",
-]
-
-[[package]]
-name = "object"
-version = "0.36.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3553,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openidconnect"
@@ -3574,7 +3682,7 @@ dependencies = [
  "oauth2",
  "p256",
  "p384",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde-value",
@@ -3612,7 +3720,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3673,7 +3781,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3829,7 +3937,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3860,7 +3968,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3921,7 +4029,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -3976,7 +4084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4040,7 +4148,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4067,9 +4175,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -4082,7 +4190,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -4135,8 +4243,14 @@ dependencies = [
  "proc-macro-utils 0.10.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -4152,7 +4266,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4162,7 +4287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4171,8 +4296,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -4247,7 +4378,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
@@ -4353,7 +4484,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -4395,14 +4526,14 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -4418,7 +4549,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "syn_derive",
  "thiserror 1.0.69",
 ]
@@ -4444,7 +4575,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.87",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -4468,17 +4599,11 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -4680,7 +4805,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4738,7 +4863,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.87",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -4802,7 +4927,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "thiserror 1.0.69",
 ]
 
@@ -4826,7 +4951,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4941,7 +5066,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5005,7 +5130,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5048,7 +5173,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5065,7 +5190,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5074,7 +5199,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5120,7 +5245,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "xxhash-rust",
 ]
 
@@ -5131,7 +5256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f2aa8119b558a17992e0ac1fd07f080099564f24532858811ce04f742542440"
 dependencies = [
  "server_fn_macro",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5141,8 +5266,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.15",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5152,8 +5288,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.15",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5196,8 +5332,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5242,6 +5378,16 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5315,7 +5461,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -5349,7 +5495,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5372,7 +5518,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.87",
+ "syn 2.0.117",
  "tempfile",
  "tokio",
  "url",
@@ -5392,7 +5538,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5409,11 +5555,11 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "rust_decimal",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -5454,7 +5600,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -5561,9 +5707,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5579,7 +5725,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5605,7 +5751,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5744,7 +5890,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5755,7 +5901,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5826,20 +5972,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5859,13 +6004,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5941,6 +6086,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
 ]
@@ -5972,7 +6119,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6005,7 +6152,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6070,7 +6217,7 @@ checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6220,7 +6367,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -6274,6 +6421,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6301,7 +6466,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -6335,7 +6500,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6345,6 +6510,28 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -6357,6 +6544,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.6.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -6454,6 +6653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6508,6 +6713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6651,6 +6865,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6714,7 +7022,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6736,7 +7044,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6756,7 +7064,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6785,7 +7093,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,12 +995,15 @@ dependencies = [
  "actix-codec",
  "actix-http",
  "actix-web",
+ "actix-ws",
  "anyhow",
  "awc",
  "bld_config",
  "bld_core",
  "bld_models",
  "bld_utils",
+ "bytes",
+ "bytestring",
  "futures",
  "futures-util",
  "rustls 0.20.9",
@@ -1247,9 +1250,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytestring"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,6 @@
 version = 4
 
 [[package]]
-name = "actix"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
-dependencies = [
- "actix-macros",
- "actix-rt",
- "actix_derive",
- "bitflags 2.6.0",
- "bytes",
- "crossbeam-channel",
- "futures-core",
- "futures-sink",
- "futures-task",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot 0.12.3",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,17 +238,6 @@ dependencies = [
  "futures-sink",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "actix_derive"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -788,8 +752,6 @@ dependencies = [
 name = "bld_commands"
 version = "0.4.0"
 dependencies = [
- "actix",
- "actix-codec",
  "actix-web",
  "anyhow",
  "async-signal",
@@ -807,7 +769,6 @@ dependencies = [
  "clap",
  "futures",
  "openidconnect",
- "rustls 0.20.9",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -835,7 +796,6 @@ dependencies = [
 name = "bld_core"
 version = "0.4.0"
 dependencies = [
- "actix",
  "actix-web",
  "anyhow",
  "async-ssh2-lite",
@@ -870,13 +830,16 @@ dependencies = [
 name = "bld_http"
 version = "0.4.0"
 dependencies = [
+ "actix-codec",
  "anyhow",
  "awc",
  "bld_config",
  "bld_models",
  "bld_utils",
+ "futures-util",
  "rustls 0.20.9",
  "serde",
+ "serde_json",
  "tracing",
 ]
 
@@ -893,7 +856,6 @@ dependencies = [
 name = "bld_models"
 version = "0.4.0"
 dependencies = [
- "actix",
  "anyhow",
  "bld_config",
  "bld_migrations",
@@ -921,13 +883,10 @@ dependencies = [
 name = "bld_runner"
 version = "0.4.0"
 dependencies = [
- "actix",
- "actix-codec",
  "actix-web",
  "anyhow",
  "bld_config",
  "bld_core",
- "bld_http",
  "bld_models",
  "bld_pkg",
  "bld_sock",
@@ -936,7 +895,6 @@ dependencies = [
  "chrono",
  "cron",
  "futures",
- "futures-util",
  "mockall",
  "pest",
  "pest_derive",
@@ -954,14 +912,10 @@ dependencies = [
 name = "bld_server"
 version = "0.4.0"
 dependencies = [
- "actix",
- "actix-codec",
  "actix-cors",
- "actix-http",
  "actix-web",
  "actix-ws",
  "anyhow",
- "awc",
  "bld_config",
  "bld_core",
  "bld_http",
@@ -991,23 +945,18 @@ dependencies = [
 name = "bld_sock"
 version = "0.4.0"
 dependencies = [
- "actix",
- "actix-codec",
- "actix-http",
  "actix-web",
  "actix-ws",
  "anyhow",
  "awc",
  "bld_config",
  "bld_core",
+ "bld_http",
  "bld_models",
  "bld_utils",
  "bytes",
  "bytestring",
  "futures",
- "futures-util",
- "rustls 0.20.9",
- "serde",
  "serde_json",
  "tokio",
  "tracing",
@@ -1017,9 +966,6 @@ dependencies = [
 name = "bld_supervisor"
 version = "0.4.0"
 dependencies = [
- "actix",
- "actix-codec",
- "actix-http",
  "actix-web",
  "actix-ws",
  "anyhow",
@@ -1580,15 +1526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2114,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -2142,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -2161,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2172,21 +2109,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2196,7 +2133,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
  "actix-cors",
  "actix-http",
  "actix-web",
- "actix-web-actors",
+ "actix-ws",
  "anyhow",
  "awc",
  "bld_config",

--- a/crates/bld_commands/Cargo.toml
+++ b/crates/bld_commands/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.13.5"
-actix-codec = "0.5.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
 anyhow = "1.0.93"
 async-signal = "0.2.10"
@@ -33,5 +31,4 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.20"
 uuid = { version = "1.11.0", features = ["v4"] }
 tabled = "0.16.0"
-rustls = "0.20.7"
 openidconnect = "3.5.0"

--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -1,4 +1,4 @@
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_config::definitions::DEFAULT_V3_PIPELINE_CONTENT;

--- a/crates/bld_commands/src/auth/command.rs
+++ b/crates/bld_commands/src/auth/command.rs
@@ -1,14 +1,9 @@
-use std::sync::Arc;
-
-use actix::{Actor, StreamHandler, System, io::SinkWrite};
-use anyhow::{Result, anyhow};
+use actix_web::rt::System;
+use anyhow::Result;
 use bld_config::BldConfig;
-use bld_http::WebSocket;
-use bld_models::dtos::LoginClientMessage;
+use bld_core::logger::Logger;
 use bld_sock::LoginClient;
-use bld_utils::sync::IntoArc;
 use clap::Args;
-use futures::stream::StreamExt;
 use tracing::debug;
 
 use crate::command::BldCommand;
@@ -27,55 +22,20 @@ pub struct AuthCommand {
     server: String,
 }
 
-impl AuthCommand {
-    async fn login(config: Arc<BldConfig>, server: String) -> Result<()> {
-        let server = config.server(&server)?;
-        let auth_path = config.auth_full_path(&server.name);
-        let url = format!("{}/v1/ws-login/", server.base_url_ws());
-
-        debug!("establishing web socket connection on {}", url);
-
-        let (_, framed) = WebSocket::new(&url)?
-            .auth(&auth_path)
-            .await
-            .request()
-            .connect()
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
-
-        let (sink, stream) = framed.split();
-        let addr = LoginClient::create(|ctx| {
-            LoginClient::add_stream(stream, ctx);
-            LoginClient::new(
-                config.clone(),
-                server.name.to_owned(),
-                SinkWrite::new(sink, ctx),
-            )
-        });
-
-        addr.send(LoginClientMessage::Init)
-            .await
-            .map_err(|e| anyhow!(e))
-    }
-}
-
 impl BldCommand for AuthCommand {
     fn verbose(&self) -> bool {
         self.verbose
     }
 
     fn exec(self) -> Result<()> {
-        let system = System::new();
-        let res = system.block_on(async move {
-            let config = BldConfig::load().await?.into_arc();
-            let server = self.server.to_owned();
-
+        System::new().block_on(async move {
+            let config = BldConfig::load().await?;
+            let logger = Logger::shell();
             debug!("running login subcommand with --server: {}", self.server);
-
-            Self::login(config, server).await
-        });
-
-        let _ = system.run();
-        res
+            LoginClient::connect(config, logger, self.server)
+                .await?
+                .run()
+                .await
+        })
     }
 }

--- a/crates/bld_commands/src/check/command.rs
+++ b/crates/bld_commands/src/check/command.rs
@@ -1,5 +1,5 @@
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_config::definitions::TOOL_DEFAULT_PIPELINE_FILE;

--- a/crates/bld_commands/src/config/command.rs
+++ b/crates/bld_commands/src/config/command.rs
@@ -1,5 +1,5 @@
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::{BldConfig, BldLocalConfig, BldRemoteServerConfig};
 use bld_core::fs::FileSystem;

--- a/crates/bld_commands/src/copy/command.rs
+++ b/crates/bld_commands/src/copy/command.rs
@@ -1,4 +1,4 @@
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::fs::FileSystem;

--- a/crates/bld_commands/src/cron/add.rs
+++ b/crates/bld_commands/src/cron/add.rs
@@ -1,5 +1,5 @@
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_http::HttpClient;

--- a/crates/bld_commands/src/cron/cat.rs
+++ b/crates/bld_commands/src/cron/cat.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_http::HttpClient;

--- a/crates/bld_commands/src/cron/list.rs
+++ b/crates/bld_commands/src/cron/list.rs
@@ -1,5 +1,5 @@
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_http::HttpClient;

--- a/crates/bld_commands/src/cron/remove.rs
+++ b/crates/bld_commands/src/cron/remove.rs
@@ -1,5 +1,5 @@
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_http::HttpClient;

--- a/crates/bld_commands/src/cron/update.rs
+++ b/crates/bld_commands/src/cron/update.rs
@@ -1,5 +1,5 @@
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_http::HttpClient;

--- a/crates/bld_commands/src/edit/command.rs
+++ b/crates/bld_commands/src/edit/command.rs
@@ -1,4 +1,4 @@
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::{BldConfig, definitions::TOOL_DEFAULT_PIPELINE_FILE};
 use bld_core::fs::FileSystem;

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -1,5 +1,5 @@
 use crate::command::BldCommand;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::{Result, bail};
 use bld_config::definitions::{
     DEFAULT_V3_PIPELINE_CONTENT, LOCAL_DEFAULT_DB_DIR, LOCAL_DEFAULT_DB_NAME,

--- a/crates/bld_commands/src/monit/command.rs
+++ b/crates/bld_commands/src/monit/command.rs
@@ -1,13 +1,11 @@
 use crate::command::BldCommand;
-use actix::{Actor, StreamHandler, io::SinkWrite};
 use actix_web::rt::System;
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use bld_config::BldConfig;
-use bld_http::WebSocket;
+use bld_core::logger::Logger;
 use bld_models::dtos::MonitInfo;
 use bld_sock::MonitClient;
 use clap::Args;
-use futures::stream::StreamExt;
 use tracing::debug;
 
 #[derive(Args)]
@@ -47,34 +45,15 @@ pub struct MonitCommand {
 impl MonitCommand {
     async fn request(self) -> Result<()> {
         let config = BldConfig::load().await?;
-        let server = config.server(&self.server)?;
-        let auth_path = config.auth_full_path(&server.name);
-        let url = format!("{}/v1/ws-monit/", server.base_url_ws());
-
-        debug!("establishing web socket connection on {}", url);
-
-        let (_, framed) = WebSocket::new(&url)?
-            .auth(&auth_path)
-            .await
-            .request()
-            .connect()
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
-
-        let (sink, stream) = framed.split();
-        let addr = MonitClient::create(|ctx| {
-            MonitClient::add_stream(stream, ctx);
-            MonitClient::new(SinkWrite::new(sink, ctx))
-        });
-
+        let logger = Logger::shell();
         debug!(
             "sending data over: {:?} {:?} {}",
             self.pipeline_id, self.file, self.last
         );
-
-        addr.send(MonitInfo::new(self.pipeline_id, self.file, self.last))
+        MonitClient::connect(config, logger, self.server)
+            .await?
+            .run(MonitInfo::new(self.pipeline_id, self.file, self.last))
             .await
-            .map_err(|e| anyhow!(e))
     }
 }
 
@@ -84,10 +63,6 @@ impl BldCommand for MonitCommand {
     }
 
     fn exec(self) -> Result<()> {
-        let system = System::new();
-        let result = system.block_on(self.request());
-
-        system.run()?;
-        result
+        System::new().block_on(self.request())
     }
 }

--- a/crates/bld_commands/src/move/command.rs
+++ b/crates/bld_commands/src/move/command.rs
@@ -1,4 +1,4 @@
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::fs::FileSystem;

--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -1,16 +1,13 @@
-use actix::{Actor, StreamHandler, io::SinkWrite};
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::{context::Context, fs::FileSystem, logger::Logger};
-use bld_http::{HttpClient, WebSocket};
+use bld_http::HttpClient;
 use bld_models::dtos::ExecClientMessage;
 use bld_pkg::PackageManager;
 use bld_runner::RunnerBuilder;
 use bld_sock::ExecClient;
 use bld_utils::sync::IntoArc;
-use futures::stream::StreamExt;
-use std::{collections::HashMap, sync::Arc, time::Duration};
-use tokio::time::sleep;
+use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
 
 use crate::signals::CommandSignals;
@@ -218,43 +215,21 @@ impl RunAdapter {
     }
 
     async fn run_web_socket(mode: WebSocketRequest) -> Result<()> {
-        let server = mode.config.server(&mode.server)?;
-        let auth_path = mode.config.auth_full_path(&server.name);
-        let url = format!("{}/v1/ws-exec/", server.base_url_ws());
         let data = ExecClientMessage::EnqueueRun {
             name: mode.pipeline,
             env: Some(mode.env),
             inputs: Some(mode.inputs),
         };
 
-        let web_socket = WebSocket::new(&url)?.auth(&auth_path).await;
+        let client = ExecClient::connect(
+            mode.config.clone(),
+            mode.server,
+            Logger::shell().into_arc(),
+            Context::local(mode.config).into_arc(),
+        )
+        .await?;
 
-        let (_, framed) = web_socket
-            .request()
-            .connect()
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
-
-        let (sink, stream) = framed.split();
-        let address = ExecClient::create(|ctx| {
-            ExecClient::add_stream(stream, ctx);
-            ExecClient::new(
-                mode.server.to_owned(),
-                Logger::shell().into_arc(),
-                Context::local(mode.config.clone()).into_arc(),
-                SinkWrite::new(sink, ctx),
-            )
-        });
-
-        debug!("sending message to socket: {:?}", data);
-
-        address.send(data).await.map_err(|e| anyhow!(e))?;
-
-        while address.connected() {
-            sleep(Duration::from_millis(200)).await;
-        }
-
-        Ok(())
+        client.run(data).await
     }
 
     async fn run_http(mode: HttpRequest) -> Result<()> {

--- a/crates/bld_commands/src/run/command.rs
+++ b/crates/bld_commands/src/run/command.rs
@@ -1,6 +1,6 @@
 use crate::command::BldCommand;
 use crate::run::adapter::RunBuilder;
-use actix::System;
+use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_config::definitions::TOOL_DEFAULT_PIPELINE_FILE;

--- a/crates/bld_commands/src/signals.rs
+++ b/crates/bld_commands/src/signals.rs
@@ -1,4 +1,4 @@
-use actix::spawn;
+use actix_web::rt::spawn;
 use anyhow::Result;
 use async_signal::{Signal, Signals};
 use bld_core::signals::{UnixSignals, UnixSignalsBackend};

--- a/crates/bld_commands/src/worker/command.rs
+++ b/crates/bld_commands/src/worker/command.rs
@@ -1,12 +1,9 @@
 use crate::{command::BldCommand, signals::CommandSignals};
-use actix::{Actor, StreamHandler, io::SinkWrite};
 use actix_web::rt::{System, spawn};
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::{context::Context, fs::FileSystem, logger::Logger};
-use bld_http::WebSocket;
 use bld_models::{
-    dtos::WorkerMessages,
     new_connection_pool,
     pipeline_runs::{self, PR_STATE_FAULTED},
 };
@@ -16,10 +13,9 @@ use bld_sock::WorkerClient;
 use bld_utils::{sync::IntoArc, variables::parse_variables};
 use chrono::Utc;
 use clap::Args;
-use futures::{join, stream::StreamExt};
-use std::sync::Arc;
-use tokio::sync::mpsc::{Receiver, channel};
-use tracing::{debug, error};
+use futures::join;
+use tokio::sync::mpsc::channel;
+use tracing::error;
 
 #[derive(Args)]
 #[command(
@@ -94,9 +90,13 @@ impl BldCommand for WorkerCommand {
             let (cmd_signals, signals_rx) = CommandSignals::new()?;
 
             let socket_handle = spawn(async move {
-                if let Err(e) = connect_to_supervisor(socket_cfg, worker_rx).await {
-                    error!("{e}");
-                }
+                let Ok(client) = WorkerClient::connect(socket_cfg, Logger::shell())
+                    .await
+                    .inspect_err(|e| error!("{e}"))
+                else {
+                    return;
+                };
+                let _ = client.run(worker_rx).await.inspect_err(|e| error!("{e}"));
             });
 
             let runner_handle = spawn(async move {
@@ -143,41 +143,4 @@ impl BldCommand for WorkerCommand {
             Ok(())
         })
     }
-}
-
-async fn connect_to_supervisor(
-    config: Arc<BldConfig>,
-    mut worker_rx: Receiver<WorkerMessages>,
-) -> Result<()> {
-    let url = format!("{}/v1/ws-worker/", config.local.supervisor.base_url_ws());
-
-    debug!("establishing web socket connection on {}", url);
-
-    let (_, framed) = WebSocket::new(&url)?
-        .request()
-        .connect()
-        .await
-        .map_err(|e| {
-            error!("{e}");
-            anyhow!(e.to_string())
-        })?;
-
-    let (sink, stream) = framed.split();
-    let addr = WorkerClient::create(|ctx| {
-        WorkerClient::add_stream(stream, ctx);
-        WorkerClient::new(SinkWrite::new(sink, ctx))
-    });
-
-    addr.send(WorkerMessages::Ack).await?;
-    addr.send(WorkerMessages::WhoAmI {
-        pid: std::process::id(),
-    })
-    .await?;
-
-    while let Some(msg) = worker_rx.recv().await {
-        debug!("sending message to supervisor {:?}", msg);
-        addr.send(msg).await?
-    }
-
-    Ok(())
 }

--- a/crates/bld_core/Cargo.toml
+++ b/crates/bld_core/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.13.5"
 actix-web = "4.9.0"
 anyhow = "1.0.93"
 awc = { version = "3.5.1", features = ["rustls"] }

--- a/crates/bld_core/src/context/local.rs
+++ b/crates/bld_core/src/context/local.rs
@@ -1,5 +1,5 @@
 use crate::platform::Platform;
-use actix::spawn;
+use actix_web::rt::spawn;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use bld_http::Request;

--- a/crates/bld_core/src/context/server.rs
+++ b/crates/bld_core/src/context/server.rs
@@ -1,6 +1,6 @@
 use super::run::RemoteRun;
 use crate::platform::Platform;
-use actix::spawn;
+use actix_web::rt::spawn;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use bld_http::Request;

--- a/crates/bld_core/src/platform/mod.rs
+++ b/crates/bld_core/src/platform/mod.rs
@@ -18,7 +18,7 @@ pub use ssh::*;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 use uuid::Uuid;
 
-use actix::spawn;
+use actix_web::rt::spawn;
 use anyhow::{Result, anyhow};
 use tracing::{debug, error};
 

--- a/crates/bld_core/src/scanner.rs
+++ b/crates/bld_core/src/scanner.rs
@@ -19,7 +19,7 @@ enum FileScannerMessage {
 
 struct FileScannerBackend {
     path: PathBuf,
-    file_handle: Option<File>,
+    reader: Option<BufReader<File>>,
     rx: Receiver<FileScannerMessage>,
 }
 
@@ -27,7 +27,7 @@ impl FileScannerBackend {
     pub fn new(path: PathBuf, rx: Receiver<FileScannerMessage>) -> Self {
         Self {
             path,
-            file_handle: None,
+            reader: None,
             rx,
         }
     }
@@ -49,23 +49,25 @@ impl FileScannerBackend {
         }
     }
 
-    async fn try_file_handle(&mut self) -> Option<&mut File> {
-        if self.file_handle.is_none() && self.path.is_file() {
-            self.file_handle = File::open(&self.path).await.map(Some).unwrap_or(None);
+    async fn try_file_handle(&mut self) -> Option<&mut BufReader<File>> {
+        if self.reader.is_none() && self.path.is_file() {
+            self.reader = File::open(&self.path)
+                .await
+                .map(|x| Some(BufReader::new(x)))
+                .unwrap_or(None);
         }
-        self.file_handle.as_mut()
+        self.reader.as_mut()
     }
 
     async fn next(&mut self, resp_tx: oneshot::Sender<Vec<String>>) -> Result<()> {
         let mut content: Vec<String> = vec![];
-        let Some(file_handle) = self.try_file_handle().await else {
+        let Some(reader) = self.try_file_handle().await else {
             resp_tx
                 .send(content)
                 .map_err(|_| anyhow!("oneshot response sender dropped"))?;
             return Ok(());
         };
 
-        let reader = BufReader::new(file_handle);
         let mut lines = reader.lines();
         let mut next = lines.next_line().await?;
         while let Some(line) = next {

--- a/crates/bld_core/src/scanner.rs
+++ b/crates/bld_core/src/scanner.rs
@@ -1,4 +1,4 @@
-use actix::spawn;
+use actix_web::rt::spawn;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use std::path::PathBuf;

--- a/crates/bld_core/src/workers.rs
+++ b/crates/bld_core/src/workers.rs
@@ -1,7 +1,10 @@
-use std::process::ExitStatus;
+use std::{process::ExitStatus, time::Duration};
 
 use anyhow::{Result, anyhow};
-use tokio::process::{Child, Command};
+use tokio::{
+    process::{Child, Command},
+    time::timeout,
+};
 
 #[cfg(target_family = "unix")]
 use nix::{
@@ -58,13 +61,22 @@ impl Worker {
     }
 
     pub async fn cleanup(&mut self) -> Result<ExitStatus> {
-        self.try_wait()
-            .map_err(|_| anyhow!("command is still running. cannot cleanup"))?;
         let child = self
             .child
             .as_mut()
             .ok_or_else(|| anyhow!("worker has not spawned"))?;
-        child.wait().await.map_err(|e| anyhow!(e))
+        match child.try_wait()? {
+            Some(status) => Ok(status),
+            // give the process some time to exit gracefully but don't block
+            // the worker queue indefinitely on a process that never exits
+            None => match timeout(Duration::from_secs(30), child.wait()).await {
+                Ok(status) => status.map_err(|e| anyhow!(e)),
+                Err(_) => {
+                    child.kill().await?;
+                    child.wait().await.map_err(|e| anyhow!(e))
+                }
+            },
+        }
     }
 
     #[cfg(target_family = "unix")]

--- a/crates/bld_http/Cargo.toml
+++ b/crates/bld_http/Cargo.toml
@@ -6,11 +6,14 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-codec = "0.5.2"
 awc = { version = "3.5.1", features = ["rustls"] }
 anyhow = "1.0.93"
 bld_config = { path = "../bld_config", features = ["tokio"] }
 bld_models = { path = "../bld_models", features = ["all"] }
 bld_utils = { path = "../bld_utils" }
 serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.132"
 tracing = "0.1.40"
 rustls = "0.20.7"
+futures-util = "0.3.32"

--- a/crates/bld_http/src/lib.rs
+++ b/crates/bld_http/src/lib.rs
@@ -191,6 +191,7 @@ impl Request {
 
 pub struct WebSock {
     connection: Framed<BoxedSocket, Codec>,
+    pong_pending: bool,
 }
 
 impl WebSock {
@@ -213,7 +214,10 @@ impl WebSock {
 
         let (_, connection) = request.connect().await.map_err(|e| anyhow!("{e}"))?;
 
-        Ok(Self { connection })
+        Ok(Self {
+            connection,
+            pong_pending: false,
+        })
     }
 
     pub async fn text<T: Serialize>(&mut self, value: &T) -> Result<()> {
@@ -231,13 +235,20 @@ impl WebSock {
     }
 
     pub async fn next(&mut self) -> Result<Frame> {
+        // resend a pong whose send was cancelled by a select! on a previous call
+        if self.pong_pending {
+            self.connection.send(Message::Pong("".into())).await?;
+            self.pong_pending = false;
+        }
         let response = self
             .connection
             .next()
             .await
             .ok_or_else(|| anyhow!("unable to read message from ws connection"))??;
         if let Frame::Ping(_) = &response {
+            self.pong_pending = true;
             self.connection.send(Message::Pong("".into())).await?;
+            self.pong_pending = false;
         }
         Ok(response)
     }

--- a/crates/bld_http/src/lib.rs
+++ b/crates/bld_http/src/lib.rs
@@ -1,25 +1,32 @@
-use std::collections::HashMap;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    error::Error,
+    fmt::{Display, Formatter},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
+use actix_codec::Framed;
 use anyhow::{Result, anyhow, bail};
-use awc::http::StatusCode;
-use awc::ws::WebsocketsRequest;
-use awc::{Client, ClientRequest, Connector, SendClientRequest};
+use awc::{
+    BoxedSocket, Client, ClientRequest, Connector, SendClientRequest,
+    http::StatusCode,
+    ws::{Codec, Frame, Message},
+};
 use bld_config::BldConfig;
 use bld_models::dtos::{
     AddJobRequest, AuthTokens, CronJobResponse, ExecClientMessage, HistQueryParams, HistoryEntry,
     JobFiltersParams, PipelineInfoQueryParams, PipelinePathRequest, PipelineQueryParams,
     PullResponse, PushInfo, RefreshTokenParams, UpdateJobRequest,
 };
-use bld_utils::fs::{read_tokens, write_tokens};
-use bld_utils::sync::IntoArc;
-use bld_utils::tls::load_root_certificates;
+use bld_utils::{
+    fs::{read_tokens, write_tokens},
+    sync::IntoArc,
+    tls::load_root_certificates,
+};
+use futures_util::{SinkExt as _, StreamExt as _};
 use rustls::ClientConfig;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
+use serde::{Serialize, de::DeserializeOwned};
 use tracing::{debug, error};
 
 #[derive(Debug)]
@@ -182,12 +189,12 @@ impl Request {
     }
 }
 
-pub struct WebSocket {
-    request: WebsocketsRequest,
+pub struct WebSock {
+    connection: Framed<BoxedSocket, Codec>,
 }
 
-impl WebSocket {
-    pub fn new(url: &str) -> Result<Self> {
+impl WebSock {
+    pub async fn connect(url: &str, auth_path: Option<&Path>) -> Result<Self> {
         let root_certificates = load_root_certificates()?;
 
         let rustls_config = ClientConfig::builder()
@@ -196,23 +203,43 @@ impl WebSocket {
             .with_no_client_auth();
 
         let connector = Connector::new().rustls(rustls_config.into_arc());
+        let mut request = Client::builder().connector(connector).finish().ws(url);
 
-        Ok(Self {
-            request: Client::builder().connector(connector).finish().ws(url),
-        })
-    }
-
-    pub async fn auth(mut self, path: &Path) -> Self {
-        if let Ok(tokens) = read_tokens::<AuthTokens>(path).await {
-            self.request = self
-                .request
-                .header("Authorization", format!("Bearer {}", tokens.access_token));
+        if let Some(path) = auth_path
+            && let Ok(tokens) = read_tokens::<AuthTokens>(path).await
+        {
+            request = request.header("Authorization", format!("Bearer {}", tokens.access_token));
         }
-        self
+
+        let (_, connection) = request.connect().await.map_err(|e| anyhow!("{e}"))?;
+
+        Ok(Self { connection })
     }
 
-    pub fn request(self) -> WebsocketsRequest {
-        self.request
+    pub async fn text<T: Serialize>(&mut self, value: &T) -> Result<()> {
+        let message = serde_json::to_string(value)?;
+        self.connection.send(Message::Text(message.into())).await?;
+        Ok(())
+    }
+
+    pub async fn binary<T: Serialize>(&mut self, value: &T) -> Result<()> {
+        let message = serde_json::to_string(value)?;
+        self.connection
+            .send(Message::Binary(message.into()))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn next(&mut self) -> Result<Frame> {
+        let response = self
+            .connection
+            .next()
+            .await
+            .ok_or_else(|| anyhow!("unable to read message from ws connection"))??;
+        if let Frame::Ping(_) = &response {
+            self.connection.send(Message::Pong("".into())).await?;
+        }
+        Ok(response)
     }
 }
 

--- a/crates/bld_models/Cargo.toml
+++ b/crates/bld_models/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-web_socket = ["dep:actix"]
+web_socket = []
 database = [
     "dep:anyhow",
     "dep:bld_config",
@@ -20,7 +20,6 @@ database = [
 all = ["web_socket", "database"]
 
 [dependencies]
-actix =  { version = "0.13.5", optional = true }
 anyhow = { version = "1.0.93", optional = true }
 bld_config = { path = "../bld_config", optional = true }
 bld_migrations = { path = "../bld_migrations", optional = true }

--- a/crates/bld_models/src/dtos/exec.rs
+++ b/crates/bld_models/src/dtos/exec.rs
@@ -2,11 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[cfg(feature = "web_socket")]
-use actix::Message;
-
-#[cfg(feature = "web_socket")]
-#[derive(Debug, Clone, Serialize, Deserialize, Message)]
-#[rtype(result = "()")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExecClientMessage {
     EnqueueRun {
         name: String,
@@ -16,8 +12,7 @@ pub enum ExecClientMessage {
 }
 
 #[cfg(feature = "web_socket")]
-#[derive(Debug, Serialize, Deserialize, Message)]
-#[rtype(result = "()")]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum ExecServerMessage {
     QueuedRun { run_id: String },
     Log { content: String },

--- a/crates/bld_models/src/dtos/login.rs
+++ b/crates/bld_models/src/dtos/login.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "web_socket")]
-use actix::Message;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,8 +29,7 @@ impl RefreshTokenParams {
 }
 
 #[cfg(feature = "web_socket")]
-#[derive(Debug, Serialize, Deserialize, Message)]
-#[rtype(result = "()")]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum LoginClientMessage {
     Init,
 }

--- a/crates/bld_models/src/dtos/monit.rs
+++ b/crates/bld_models/src/dtos/monit.rs
@@ -1,8 +1,6 @@
-use actix::Message;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Serialize, Deserialize, Message)]
-#[rtype(result = "()")]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct MonitInfo {
     pub id: Option<String>,
     pub name: Option<String>,

--- a/crates/bld_models/src/dtos/monit.rs
+++ b/crates/bld_models/src/dtos/monit.rs
@@ -1,7 +1,7 @@
 use actix::Message;
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Serialize, Deserialize, Message)]
+#[derive(Debug, Default, Serialize, Deserialize, Message)]
 #[rtype(result = "()")]
 pub struct MonitInfo {
     pub id: Option<String>,

--- a/crates/bld_models/src/dtos/supervisor.rs
+++ b/crates/bld_models/src/dtos/supervisor.rs
@@ -1,11 +1,9 @@
-use actix::Message;
 use serde::{Deserialize, Serialize};
 
 pub static SERVER: &str = "server";
 pub static WORKER: &str = "worker";
 
-#[derive(Debug, Serialize, Deserialize, Message)]
-#[rtype(result = "()")]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum ServerMessages {
     Ack,
     Enqueue {
@@ -19,8 +17,7 @@ pub enum ServerMessages {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize, Message)]
-#[rtype(result = "()")]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum WorkerMessages {
     Ack,
     WhoAmI { pid: u32 },

--- a/crates/bld_runner/Cargo.toml
+++ b/crates/bld_runner/Cargo.toml
@@ -7,19 +7,15 @@ edition = "2024"
 
 [features]
 all = [
-    "dep:actix",
-    "dep:actix-codec",
     "dep:actix-web",
     "dep:bollard",
     "dep:bld_core",
-    "dep:bld_http",
     "dep:bld_models",
     "dep:bld_sock",
     "dep:bld_utils",
     "dep:bld_pkg",
     "dep:chrono",
     "dep:futures",
-    "dep:futures-util",
     "dep:serde_json",
     "dep:serde_yaml_ng",
     "dep:tar",
@@ -32,21 +28,17 @@ all = [
 ]
 
 [dependencies]
-actix = { version = "0.13.5", optional = true }
-actix-codec = { version = "0.5.2", optional = true }
 actix-web = { version = "4.9.0", features = ["rustls"], optional = true }
 anyhow = "1.0.93"
 bollard = { version = "0.16.1", features = ["ssl"], optional = true }
 bld_config = { path = "../bld_config" }
 bld_core = { path = "../bld_core", optional = true }
-bld_http = { path = "../bld_http", optional = true }
 bld_models = { path = "../bld_models", features = ["all"], optional = true }
 bld_sock = { path = "../bld_sock", optional = true }
 bld_utils = { path = "../bld_utils", optional = true }
 bld_pkg = { path = "../bld_pkg", optional = true }
 chrono = { version = "0.4.38", default-features = false, features = ["std"], optional = true }
 futures =  { version = "0.3.31", optional = true }
-futures-util = { version = "0.3.31", optional = true }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = { version = "1.0.132", optional = true }
 serde_yaml_ng = { version = "0.10.0", optional = true }

--- a/crates/bld_runner/Cargo.toml
+++ b/crates/bld_runner/Cargo.toml
@@ -10,7 +10,6 @@ all = [
     "dep:actix",
     "dep:actix-codec",
     "dep:actix-web",
-    "dep:actix-web-actors",
     "dep:bollard",
     "dep:bld_core",
     "dep:bld_http",
@@ -36,7 +35,6 @@ all = [
 actix = { version = "0.13.5", optional = true }
 actix-codec = { version = "0.5.2", optional = true }
 actix-web = { version = "4.9.0", features = ["rustls"], optional = true }
-actix-web-actors = { version = "4.3.0", optional = true }
 anyhow = "1.0.93"
 bollard = { version = "0.16.1", features = ["ssl"], optional = true }
 bld_config = { path = "../bld_config" }

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -1,4 +1,4 @@
-use actix::{Actor, StreamHandler, io::SinkWrite, spawn};
+use actix_web::rt::spawn;
 use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use bld_config::definitions::{
@@ -12,12 +12,10 @@ use bld_core::{
     platform::Platform,
     signals::{UnixSignal, UnixSignalMessage, UnixSignalsBackend},
 };
-use bld_http::WebSocket;
 use bld_models::dtos::{ExecClientMessage, WorkerMessages};
 use bld_pkg::PackageManager;
 use bld_sock::ExecClient;
 use bld_utils::sync::IntoArc;
-use futures::stream::StreamExt;
 use std::{collections::HashMap, fmt::Write, future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::Sender, time::sleep};
 use tracing::debug;
@@ -279,9 +277,6 @@ impl Runner {
     }
 
     async fn server_external(&self, server: &str, details: &External) -> Result<()> {
-        let server_name = server.to_owned();
-        let server = self.config.server(server)?;
-        let auth_path = self.config.auth_full_path(&server.name);
         let variables = details
             .variables
             .iter()
@@ -294,47 +289,25 @@ impl Runner {
             .map(|(key, value)| (key.to_owned(), self.apply_context(value)))
             .collect();
 
-        let url = format!("{}/v1/ws-exec/", server.base_url_ws());
+        debug!("establishing web socket connection with server {}", server);
 
-        debug!(
-            "establishing web socket connection with server {}",
-            server.name
-        );
-
-        let (_, framed) = WebSocket::new(&url)?
-            .auth(&auth_path)
-            .await
-            .request()
-            .connect()
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
-
-        let (sink, stream) = framed.split();
-        let addr = ExecClient::create(|ctx| {
-            ExecClient::add_stream(stream, ctx);
-            ExecClient::new(
-                server_name,
-                self.logger.clone(),
-                self.context.clone(),
-                SinkWrite::new(sink, ctx),
-            )
-        });
+        let client = ExecClient::connect(
+            self.config.clone(),
+            server.to_owned(),
+            self.logger.clone(),
+            self.context.clone(),
+        )
+        .await?;
 
         debug!("sending message for pipeline execution over the web socket");
 
-        addr.send(ExecClientMessage::EnqueueRun {
-            name: details.pipeline.to_owned(),
-            env: Some(environment),
-            inputs: Some(variables),
-        })
-        .await
-        .map_err(|e| anyhow!(e))?;
-
-        while addr.connected() {
-            sleep(Duration::from_millis(200)).await;
-        }
-
-        Ok(())
+        client
+            .run(ExecClientMessage::EnqueueRun {
+                name: details.pipeline.to_owned(),
+                env: Some(environment),
+                inputs: Some(variables),
+            })
+            .await
     }
 
     async fn shell(&self, step: &BuildStep, command: &str) -> Result<()> {

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Write, pin::Pin, sync::Arc, time::Duration};
 
-use actix::{Actor, StreamHandler, clock::sleep, io::SinkWrite, spawn};
+use actix_web::rt::spawn;
 use anyhow::{Result, anyhow, bail};
 use bld_config::{
     BldConfig, SshUserAuth,
@@ -17,13 +17,12 @@ use bld_core::{
     regex::RegexCache,
     signals::{UnixSignal, UnixSignalMessage, UnixSignalsBackend},
 };
-use bld_http::WebSocket;
 use bld_models::dtos::{ExecClientMessage, WorkerMessages};
 use bld_pkg::PackageManager;
 use bld_sock::ExecClient;
 use bld_utils::sync::IntoArc;
-use futures::{Future, StreamExt};
-use tokio::{sync::mpsc::Sender, task::JoinHandle};
+use futures::Future;
+use tokio::{sync::mpsc::Sender, task::JoinHandle, time::sleep};
 use tracing::debug;
 
 use crate::{
@@ -193,53 +192,28 @@ impl Job {
     }
 
     async fn server_external(&self, server: &str, details: &External) -> Result<()> {
-        let server_name = server.to_owned();
-        let server = self.config.server(server)?;
-        let auth_path = self.config.auth_full_path(&server.name);
         let variables = details.variables.clone();
         let environment = details.environment.clone();
 
-        let url = format!("{}/v1/ws-exec/", server.base_url_ws());
+        debug!("establishing web socket connection with server {}", server);
 
-        debug!(
-            "establishing web socket connection with server {}",
-            server.name
-        );
-
-        let (_, framed) = WebSocket::new(&url)?
-            .auth(&auth_path)
-            .await
-            .request()
-            .connect()
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
-
-        let (sink, stream) = framed.split();
-        let addr = ExecClient::create(|ctx| {
-            ExecClient::add_stream(stream, ctx);
-            ExecClient::new(
-                server_name,
-                self.logger.clone(),
-                self.context.clone(),
-                SinkWrite::new(sink, ctx),
-            )
-        });
+        let client = ExecClient::connect(
+            self.config.clone(),
+            server.to_owned(),
+            self.logger.clone(),
+            self.context.clone(),
+        )
+        .await?;
 
         debug!("sending message for pipeline execution over the web socket");
 
-        addr.send(ExecClientMessage::EnqueueRun {
-            name: details.pipeline.to_owned(),
-            env: Some(environment),
-            inputs: Some(variables),
-        })
-        .await
-        .map_err(|e| anyhow!(e))?;
-
-        while addr.connected() {
-            sleep(Duration::from_millis(200)).await;
-        }
-
-        Ok(())
+        client
+            .run(ExecClientMessage::EnqueueRun {
+                name: details.pipeline.to_owned(),
+                env: Some(environment),
+                inputs: Some(variables),
+            })
+            .await
     }
 
     async fn shell(&self, working_dir: &Option<String>, command: &str) -> Result<()> {

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -1,17 +1,14 @@
-use std::{collections::HashMap, fmt::Write, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Write, sync::Arc};
 
-use actix::{Actor, StreamHandler, clock::sleep, io::SinkWrite};
 use anyhow::{Result, anyhow, bail};
 use bld_config::BldConfig;
 use bld_core::{
     context::Context, fs::FileSystem, logger::Logger, platform::Platform, regex::RegexCache,
 };
-use bld_http::WebSocket;
 use bld_models::dtos::ExecClientMessage;
 use bld_pkg::PackageManager;
 use bld_sock::ExecClient;
 use bld_utils::sync::IntoArc;
-use futures::StreamExt;
 use regex::Regex;
 use tokio::task::JoinHandle;
 use tracing::debug;
@@ -157,51 +154,26 @@ impl<S: RootState> JobRunner<S> {
     async fn server_external(&mut self, server: &str, details: &External) -> Result<()> {
         let inputs = self.variables_external(&details.with)?;
         let env = self.variables_external(&details.env)?;
-        let server_name = server.to_owned();
-        let server = self.config.server(server)?;
-        let auth_path = self.config.auth_full_path(&server.name);
 
-        let url = format!("{}/v1/ws-exec/", server.base_url_ws());
+        debug!("establishing web socket connection with server {}", server);
 
-        debug!(
-            "establishing web socket connection with server {}",
-            server.name
-        );
-
-        let (_, framed) = WebSocket::new(&url)?
-            .auth(&auth_path)
-            .await
-            .request()
-            .connect()
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
-
-        let (sink, stream) = framed.split();
-        let addr = ExecClient::create(|ctx| {
-            ExecClient::add_stream(stream, ctx);
-            ExecClient::new(
-                server_name,
-                self.logger.clone(),
-                self.run_ctx.clone(),
-                SinkWrite::new(sink, ctx),
-            )
-        });
+        let client = ExecClient::connect(
+            self.config.clone(),
+            server.to_owned(),
+            self.logger.clone(),
+            self.run_ctx.clone(),
+        )
+        .await?;
 
         debug!("sending message for pipeline execution over the web socket");
 
-        addr.send(ExecClientMessage::EnqueueRun {
-            name: details.uses.to_owned(),
-            env: Some(env),
-            inputs: Some(inputs),
-        })
-        .await
-        .map_err(|e| anyhow!(e))?;
-
-        while addr.connected() {
-            sleep(Duration::from_millis(200)).await;
-        }
-
-        Ok(())
+        client
+            .run(ExecClientMessage::EnqueueRun {
+                name: details.uses.to_owned(),
+                env: Some(env),
+                inputs: Some(inputs),
+            })
+            .await
     }
 
     fn variables_external(

--- a/crates/bld_runner/src/runner/v3/pipeline.rs
+++ b/crates/bld_runner/src/runner/v3/pipeline.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Write, sync::Arc, time::Duration};
 
-use actix::{clock::sleep, spawn};
+use actix_web::rt::spawn;
 use anyhow::{Result, anyhow, bail};
 use bld_config::{BldConfig, SshUserAuth};
 use bld_core::{
@@ -18,7 +18,7 @@ use bld_models::dtos::WorkerMessages;
 use bld_pkg::PackageManager;
 use bld_utils::sync::IntoArc;
 use regex::Regex;
-use tokio::sync::mpsc::Sender;
+use tokio::{sync::mpsc::Sender, time::sleep};
 use tracing::debug;
 
 use crate::{

--- a/crates/bld_server/Cargo.toml
+++ b/crates/bld_server/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 actix = "0.13.5"
 actix-codec = "0.5.2"
 actix-cors = "0.7.0"
-actix-http = "3.9.0"
+actix-http = "3.11.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
 actix-web-actors = "4.3.0"
 awc = { version = "3.5.1", features = ["rustls"] }

--- a/crates/bld_server/Cargo.toml
+++ b/crates/bld_server/Cargo.toml
@@ -6,13 +6,9 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.13.5"
-actix-codec = "0.5.2"
 actix-cors = "0.7.0"
-actix-http = "3.11.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
 actix-ws = "0.4.0"
-awc = { version = "3.5.1", features = ["rustls"] }
 anyhow = "1.0.93"
 bld_config = { path = "../bld_config", features = ["tokio"] }
 bld_core = { path = "../bld_core" }

--- a/crates/bld_server/Cargo.toml
+++ b/crates/bld_server/Cargo.toml
@@ -11,7 +11,7 @@ actix-codec = "0.5.2"
 actix-cors = "0.7.0"
 actix-http = "3.11.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
-actix-web-actors = "4.3.0"
+actix-ws = "0.4.0"
 awc = { version = "3.5.1", features = ["rustls"] }
 anyhow = "1.0.93"
 bld_config = { path = "../bld_config", features = ["tokio"] }

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -16,7 +16,7 @@ use bld_models::{
     dtos::{ExecClientMessage, ExecServerMessage},
     pipeline_runs::{self, PR_STATE_FAULTED, PR_STATE_FINISHED, PR_STATE_QUEUED},
 };
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use sea_orm::DatabaseConnection;
 use std::{sync::Arc, time::Duration};
 use tracing::{debug, error};
@@ -70,13 +70,17 @@ impl ExecWebsocket {
         }
     }
 
-    pub async fn exec(&self, session: &mut Session) -> bool {
+    pub async fn check_state(&self, session: &mut Session) -> bool {
         let Some(run_id) = self.run_id.as_ref() else {
-            return false;
+            return true;
         };
         match pipeline_runs::select_by_id(self.conn.as_ref(), run_id).await {
-            Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => true,
+            Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => {
+                debug!("run is in a {} state", run.state);
+                false
+            }
             Ok(run) if run.state == PR_STATE_QUEUED => {
+                debug!("run is in a {} state", PR_STATE_QUEUED);
                 let message = format!(
                     "run with id {run_id} has been queued, use the monit command to see the output when it's started"
                 );
@@ -85,7 +89,8 @@ impl ExecWebsocket {
                 }
                 false
             }
-            Err(_) => {
+            Err(e) => {
+                debug!("run encountered error {e}");
                 if let Err(e) = session.text("internal server error").await {
                     error!("{e}");
                 }
@@ -97,14 +102,12 @@ impl ExecWebsocket {
 
     pub async fn handle_message(&mut self, session: &mut Session, message: &str) -> Result<()> {
         let message: ExecClientMessage = serde_json::from_str(message)?;
-
-        debug!("enqueueing run");
-
         let username = self.user.name.to_owned();
         let fs = Arc::clone(&self.fs);
         let pool = Arc::clone(&self.conn);
         let supervisor = Arc::clone(&self.supervisor);
 
+        debug!("enqueueing run");
         match enqueue_worker(&username, fs, pool, supervisor, message).await {
             Ok(run_id) => {
                 self.scanner
@@ -138,55 +141,73 @@ pub async fn ws(
     let (response, mut session, mut msg_stream) = handle(&req, body)?;
 
     spawn(async move {
+        debug!("spawned exec web socket");
         let mut reason: Option<CloseReason> = None;
-        let mut scan_interval = time::interval(Duration::from_millis(500));
-        let mut exec_interval = time::interval(Duration::from_millis(500));
+        let mut scan_interval = time::interval(Duration::from_millis(300));
+        let mut exec_interval = time::interval(Duration::from_millis(300));
 
         loop {
-            if let Some(msg) = msg_stream.next().await {
-                match msg {
-                    Ok(Message::Text(txt)) => {
+            match msg_stream.next().now_or_never() {
+                Some(Some(Ok(msg))) => match msg {
+                    Message::Text(txt) => {
                         if let Err(e) = socket.handle_message(&mut session, &txt).await {
                             error!("handling message error. {e}");
                             break;
                         }
                     }
-                    Ok(Message::Ping(msg)) => {
+
+                    Message::Ping(msg) => {
                         if let Err(e) = session.pong(&msg).await {
                             error!("{e}");
                             break;
                         }
                     }
-                    Ok(Message::Pong(msg)) => {
+
+                    Message::Pong(msg) => {
                         if let Err(e) = session.ping(&msg).await {
                             error!("{e}");
                             break;
                         }
                     }
-                    Ok(Message::Close(r)) => {
+
+                    Message::Close(r) => {
                         reason = r;
                         break;
                     }
-                    Err(e) => {
-                        error!("{e}");
+
+                    _ => {
                         break;
                     }
-                    _ => break,
+                },
+
+                Some(Some(Err(e))) => {
+                    error!("encountered error during message processing. {e}");
+                    break;
                 }
+
+                Some(None) => {
+                    break;
+                }
+
+                None => {}
             }
 
             scan_interval.tick().await;
             socket.scan(&mut session).await;
 
             exec_interval.tick().await;
-            if !socket.exec(&mut session).await {
+            if !socket.check_state(&mut session).await {
                 break;
             }
         }
 
-        if let Err(e) = session.close(reason).await {
-            error!("encountered error while closing websocket session due to {e}");
-        }
+        let _ = session
+            .close(reason)
+            .await
+            .inspect(|_| debug!("closed session successfully"))
+            .inspect_err(|e| {
+                error!("encountered error while closing websocket session due to {e}")
+            });
     });
 
     Ok(response)

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -8,7 +8,7 @@ use actix_web::{
     rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_ws::{CloseCode, CloseReason, Message, Session, handle};
+use actix_ws::Session;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::{fs::FileSystem, scanner::FileScanner};
@@ -16,15 +16,13 @@ use bld_models::{
     dtos::{ExecClientMessage, ExecServerMessage},
     pipeline_runs::{self, PR_STATE_FAULTED, PR_STATE_FINISHED, PR_STATE_QUEUED},
 };
-use futures::StreamExt;
+use bld_sock::session::{self, WebSocketMessage};
 use sea_orm::DatabaseConnection;
-use std::time::{Duration, Instant};
-use tracing::{debug, error, warn};
+use std::time::Duration;
+use tracing::{debug, error};
 
 const SCAN_INTERVAL_MS: u64 = 500;
 const STATE_CHECK_INTERVAL_MS: u64 = 1000;
-const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
-const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 struct ExecWebsocket {
     config: Data<BldConfig>,
@@ -136,91 +134,46 @@ pub async fn ws(
 ) -> actix_web::Result<impl Responder> {
     let user = user.ok_or_else(|| ErrorUnauthorized(""))?;
     let mut socket = ExecWebsocket::new(config, supervisor, conn, fs, user);
-    let (response, mut session, mut msg_stream) = handle(&req, body)?;
+    let (response, mut handler) = session::handle(&req, body)?;
 
     spawn(async move {
         debug!("spawned exec web socket");
-        let mut reason: Option<CloseReason> = None;
         let mut scan_interval = time::interval(Duration::from_millis(SCAN_INTERVAL_MS));
         let mut state_interval = time::interval(Duration::from_millis(STATE_CHECK_INTERVAL_MS));
-        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
-        let mut last_pong = Instant::now();
 
         loop {
             tokio::select! {
-                Some(msg) = msg_stream.next() => {
-                    let Ok(message) = msg.inspect_err(|e| error!("{e}")) else {
-                        break;
-                    };
-                    match message {
-                        Message::Text(txt) => {
-                            if let Err(e) = socket.handle_message(&mut session, &txt).await {
-                                reason = Some(CloseCode::Error.into());
-                                let _ = session.text(e.to_string()).await.inspect_err(|e| error!("{e}"));
+                msg = handler.next() =>  {
+                    match msg {
+                        WebSocketMessage::Text(txt) => {
+                            let session = handler.session();
+                            if let Err(e) = socket.handle_message(session, &txt).await {
                                 error!("handling message error. {e}");
+                                let _ = session.text(e.to_string()).await.inspect_err(|e| error!("{e}"));
+                                handler.error();
                                 break;
                             }
                         }
-
-                        Message::Ping(msg) => {
-                            if let Err(e) = session.pong(&msg).await {
-                                reason = Some(CloseCode::Error.into());
-                                error!("{e}");
-                                break;
-                            }
-                        }
-
-                        Message::Pong(_) => {
-                            last_pong = Instant::now();
-                        }
-
-                        Message::Continuation(_) | Message::Nop => {}
-
-                        Message::Close(r) => {
-                            reason = r;
-                            break;
-                        }
-
-                        _ => {
-                            break;
-                        }
+                        WebSocketMessage::Continue => {}
+                        _ => break,
                     }
                 }
 
                 _ = scan_interval.tick() => {
-                    socket.scan(&mut session).await;
+                    let session = handler.session();
+                    socket.scan(session).await;
                 }
 
                 _ = state_interval.tick() => {
-                    if !socket.check_state(&mut session).await {
-                        break;
-                    }
-                }
-
-                _ = hb_interval.tick() => {
-                    if Instant::now().duration_since(last_pong)
-                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
-                    {
-                        warn!("client heartbeat timed out, closing session");
-                        reason = Some(CloseCode::Away.into());
-                        break;
-                    }
-                    if let Err(e) = session.ping(b"").await {
-                        error!("ping failed: {e}");
-                        reason = Some(CloseCode::Error.into());
+                    let session = handler.session();
+                    if !socket.check_state(session).await {
                         break;
                     }
                 }
             }
         }
 
-        let _ = session
-            .close(reason)
-            .await
-            .inspect(|_| debug!("closed session successfully"))
-            .inspect_err(|e| {
-                error!("encountered error while closing websocket session due to {e}")
-            });
+        handler.cleanup().await;
     });
 
     Ok(response)

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -4,11 +4,12 @@ use crate::{
 };
 use actix::prelude::*;
 use actix_web::{
-    Error, HttpRequest, HttpResponse,
+    HttpRequest, Responder,
     error::ErrorUnauthorized,
+    rt::spawn,
     web::{Data, Payload},
 };
-use actix_web_actors::ws;
+use actix_ws::{CloseReason, Message, Session, handle};
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::{fs::FileSystem, scanner::FileScanner};
@@ -20,6 +21,11 @@ use bld_utils::sync::IntoArc;
 use futures_util::future::ready;
 use sea_orm::DatabaseConnection;
 use std::{sync::Arc, time::Duration};
+use tokio::{
+    sync::{Mutex, RwLock},
+    task::JoinHandle,
+    time,
+};
 use tracing::{debug, error};
 
 pub struct ExecutePipelineSocket {
@@ -180,19 +186,132 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for ExecutePipelineSo
     }
 }
 
+struct ExecState {
+    config: Data<BldConfig>,
+    supervisor: Data<SupervisorMessageSender>,
+    conn: Data<DatabaseConnection>,
+    fs: Data<FileSystem>,
+    user: User,
+    scanner: Option<FileScanner>,
+    run_id: Option<String>,
+}
+
+impl ExecState {
+    pub fn new(
+        config: Data<BldConfig>,
+        supervisor: Data<SupervisorMessageSender>,
+        conn: Data<DatabaseConnection>,
+        fs: Data<FileSystem>,
+        user: User,
+    ) -> Self {
+        Self {
+            config,
+            supervisor,
+            conn,
+            fs,
+            user,
+            scanner: None,
+            run_id: None,
+        }
+    }
+
+    pub async fn exec(&self, session: &mut Session) -> bool {
+        let Some(run_id) = self.run_id.as_ref() else {
+            return false;
+        };
+        match pipeline_runs::select_by_id(self.conn.as_ref(), &run_id).await {
+            Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => true,
+            Ok(run) if run.state == PR_STATE_QUEUED => {
+                let message = format!(
+                    "run with id {run_id} has been queued, use the monit command to see the output when it's started"
+                );
+                if let Err(e) = session.text(message.as_str()).await {
+                    error!("{e}");
+                }
+                true
+            }
+            Err(_) => {
+                if let Err(e) = session.text("internal server error").await {
+                    error!("{e}");
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub async fn handle_message(&mut self, session: &mut Session, message: &str) -> Result<()> {
+        let message: ExecClientMessage = serde_json::from_str(message)?;
+
+        debug!("enqueueing run");
+
+        let username = self.user.name.to_owned();
+        let fs = Arc::clone(&self.fs);
+        let pool = Arc::clone(&self.conn);
+        let supervisor = Arc::clone(&self.supervisor);
+
+        match enqueue_worker(&username, fs, pool, supervisor, message).await {
+            Ok(run_id) => {
+                self.scanner
+                    .replace(FileScanner::new(self.config.as_ref(), &run_id));
+                self.run_id.replace(run_id.to_owned());
+                let message = ExecServerMessage::QueuedRun { run_id };
+                if let Ok(data) = serde_json::to_string(&message) {
+                    session.text(data).await;
+                }
+                Ok(())
+            }
+            Err(e) => {
+                session.text(e.to_string()).await;
+                Err(e)
+            }
+        }
+    }
+}
+
 pub async fn ws(
     user: Option<User>,
     req: HttpRequest,
-    stream: Payload,
-    cfg: Data<BldConfig>,
-    supervisor_sender: Data<SupervisorMessageSender>,
+    body: Payload,
+    config: Data<BldConfig>,
+    supervisor: Data<SupervisorMessageSender>,
     conn: Data<DatabaseConnection>,
     fs: Data<FileSystem>,
-) -> Result<HttpResponse, Error> {
+) -> actix_web::Result<impl Responder> {
     let user = user.ok_or_else(|| ErrorUnauthorized(""))?;
-    println!("{req:?}");
-    let socket = ExecutePipelineSocket::new(user, cfg, supervisor_sender, conn, fs);
-    let res = ws::start(socket, &req, stream);
-    println!("{res:?}");
-    res
+    let mut state = ExecState::new(config, supervisor, conn, fs, user);
+    let (response, mut session, mut msg_stream) = handle(&req, body)?;
+
+    spawn(async move {
+        let mut reason: Option<CloseReason> = None;
+
+        while let Some(Ok(msg)) = msg_stream.recv().await {
+            match msg {
+                Message::Text(txt) => {
+                    if let Err(e) = state.handle_message(&mut session, &txt).await {
+                        error!("handling message error. {e}");
+                        break;
+                    }
+                }
+                Message::Ping(msg) => {
+                    if let Err(e) = session.pong(&msg).await {
+                        error!("{e}");
+                        break;
+                    }
+                }
+                Message::Pong(_) | Message::Binary(_) => {}
+                Message::Close(r) => {
+                    reason = r;
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        if let Err(e) = session.close(reason).await {
+            error!("encountered error while closing websocket session due to {e}");
+        }
+    });
+
+    Ok(response)
 }

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -64,7 +64,9 @@ impl ExecWebsocket {
             let Ok(data) = serde_json::to_string(&message) else {
                 continue;
             };
-            session.text(data);
+            if let Err(e) = session.text(data).await {
+                error!("{e}");
+            }
         }
     }
 
@@ -72,7 +74,7 @@ impl ExecWebsocket {
         let Some(run_id) = self.run_id.as_ref() else {
             return false;
         };
-        match pipeline_runs::select_by_id(self.conn.as_ref(), &run_id).await {
+        match pipeline_runs::select_by_id(self.conn.as_ref(), run_id).await {
             Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => true,
             Ok(run) if run.state == PR_STATE_QUEUED => {
                 let message = format!(
@@ -110,12 +112,12 @@ impl ExecWebsocket {
                 self.run_id.replace(run_id.to_owned());
                 let message = ExecServerMessage::QueuedRun { run_id };
                 if let Ok(data) = serde_json::to_string(&message) {
-                    session.text(data).await;
+                    session.text(data).await?;
                 }
                 Ok(())
             }
             Err(e) => {
-                session.text(e.to_string()).await;
+                session.text(e.to_string()).await?;
                 Err(e)
             }
         }
@@ -141,29 +143,36 @@ pub async fn ws(
         let mut exec_interval = time::interval(Duration::from_millis(500));
 
         loop {
-            let Some(Ok(msg)) = msg_stream.next().await else {
-                break;
-            };
-
-            match msg {
-                Message::Text(txt) => {
-                    if let Err(e) = socket.handle_message(&mut session, &txt).await {
-                        error!("handling message error. {e}");
+            if let Some(msg) = msg_stream.next().await {
+                match msg {
+                    Ok(Message::Text(txt)) => {
+                        if let Err(e) = socket.handle_message(&mut session, &txt).await {
+                            error!("handling message error. {e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Ping(msg)) => {
+                        if let Err(e) = session.pong(&msg).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Pong(msg)) => {
+                        if let Err(e) = session.ping(&msg).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Close(r)) => {
+                        reason = r;
                         break;
                     }
-                }
-                Message::Ping(msg) => {
-                    if let Err(e) = session.pong(&msg).await {
+                    Err(e) => {
                         error!("{e}");
                         break;
                     }
+                    _ => break,
                 }
-                Message::Pong(_) | Message::Binary(_) => {}
-                Message::Close(r) => {
-                    reason = r;
-                    break;
-                }
-                _ => {}
             }
 
             scan_interval.tick().await;

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -2,11 +2,10 @@ use crate::{
     extractors::User,
     supervisor::{channel::SupervisorMessageSender, helpers::enqueue_worker},
 };
-use actix::prelude::*;
 use actix_web::{
     HttpRequest, Responder,
     error::ErrorUnauthorized,
-    rt::spawn,
+    rt::{spawn, time},
     web::{Data, Payload},
 };
 use actix_ws::{CloseReason, Message, Session, handle};
@@ -17,176 +16,12 @@ use bld_models::{
     dtos::{ExecClientMessage, ExecServerMessage},
     pipeline_runs::{self, PR_STATE_FAULTED, PR_STATE_FINISHED, PR_STATE_QUEUED},
 };
-use bld_utils::sync::IntoArc;
-use futures_util::future::ready;
+use futures::StreamExt;
 use sea_orm::DatabaseConnection;
 use std::{sync::Arc, time::Duration};
-use tokio::{
-    sync::{Mutex, RwLock},
-    task::JoinHandle,
-    time,
-};
 use tracing::{debug, error};
 
-pub struct ExecutePipelineSocket {
-    config: Data<BldConfig>,
-    supervisor: Data<SupervisorMessageSender>,
-    conn: Data<DatabaseConnection>,
-    fs: Data<FileSystem>,
-    user: User,
-    scanner: Option<Arc<FileScanner>>,
-    run_id: Option<String>,
-}
-
-impl ExecutePipelineSocket {
-    pub fn new(
-        user: User,
-        config: Data<BldConfig>,
-        supervisor_sender: Data<SupervisorMessageSender>,
-        conn: Data<DatabaseConnection>,
-        fs: Data<FileSystem>,
-    ) -> Self {
-        Self {
-            config,
-            supervisor: supervisor_sender,
-            conn,
-            fs,
-            user,
-            scanner: None,
-            run_id: None,
-        }
-    }
-
-    fn scan(act: &mut Self, ctx: &mut <Self as Actor>::Context) {
-        let Some(scanner) = act.scanner.as_ref() else {
-            return;
-        };
-        let scanner = scanner.clone();
-        let scan_fut = async move { scanner.scan().await }
-            .into_actor(act)
-            .then(|res, _, ctx| {
-                if let Ok(lines) = res {
-                    for line in lines.iter() {
-                        let message = ExecServerMessage::Log {
-                            content: line.to_string(),
-                        };
-                        let _ = serde_json::to_string(&message).map(|data| ctx.text(data));
-                    }
-                }
-                ready(())
-            });
-        ctx.spawn(scan_fut);
-    }
-
-    fn exec(act: &mut Self, ctx: &mut <Self as Actor>::Context) {
-        if let Some(run_id) = act.run_id.as_ref() {
-            let conn = act.conn.clone();
-            let run_id = run_id.to_owned();
-            let select_fut = async move { pipeline_runs::select_by_id(conn.as_ref(), &run_id).await }
-                .into_actor(act)
-                .then(|res, _, ctx| match res {
-                    Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => {
-                        ctx.stop();
-                        ready(())
-                    }
-                    Ok(run) if run.state == PR_STATE_QUEUED => {
-                        ctx.text("run with id {run_id} has been queued, use the monit command to see the output when it's started");
-                        ctx.stop();
-                        ready(())
-                    }
-                    Err(_) => {
-                        ctx.text("internal server error");
-                        ctx.stop();
-                        ready(())
-                    }
-                    _ => ready(())
-                });
-            ctx.spawn(select_fut);
-        }
-    }
-
-    fn handle_client_message(
-        &mut self,
-        message: &str,
-        ctx: &mut <Self as Actor>::Context,
-    ) -> Result<()> {
-        let message: ExecClientMessage = serde_json::from_str(message)?;
-
-        debug!("enqueueing run");
-
-        let username = self.user.name.to_owned();
-        let fs = Arc::clone(&self.fs);
-        let pool = Arc::clone(&self.conn);
-        let supervisor = Arc::clone(&self.supervisor);
-
-        let enqueue_fut =
-            async move { enqueue_worker(&username, fs, pool, supervisor, message).await }
-                .into_actor(self)
-                .then(|res, act, ctx| match res {
-                    Ok(run_id) => {
-                        act.scanner =
-                            Some(FileScanner::new(act.config.as_ref(), &run_id).into_arc());
-                        act.run_id = Some(run_id.to_owned());
-                        let message = ExecServerMessage::QueuedRun { run_id };
-                        if let Ok(data) = serde_json::to_string(&message) {
-                            ctx.text(data);
-                        }
-                        ready(())
-                    }
-                    Err(e) => {
-                        error!("{e}");
-                        ctx.text(e.to_string());
-                        ctx.stop();
-                        ready(())
-                    }
-                });
-
-        ctx.spawn(enqueue_fut);
-
-        Ok(())
-    }
-}
-
-impl Actor for ExecutePipelineSocket {
-    type Context = ws::WebsocketContext<Self>;
-
-    fn started(&mut self, ctx: &mut Self::Context) {
-        ctx.run_interval(Duration::from_millis(500), |act, ctx| {
-            ExecutePipelineSocket::scan(act, ctx);
-        });
-        ctx.run_interval(Duration::from_secs(1), |act, ctx| {
-            ExecutePipelineSocket::exec(act, ctx);
-        });
-    }
-}
-
-impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for ExecutePipelineSocket {
-    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
-        match msg {
-            Ok(ws::Message::Text(txt)) => {
-                if let Err(e) = self.handle_client_message(&txt, ctx) {
-                    ctx.text(e.to_string());
-                    ctx.stop();
-                }
-            }
-
-            Ok(ws::Message::Ping(msg)) => {
-                ctx.pong(&msg);
-            }
-
-            Ok(ws::Message::Pong(_)) => {}
-
-            Ok(ws::Message::Close(reason)) => {
-                ctx.close(reason);
-                ctx.stop();
-            }
-
-            _ => ctx.stop(),
-        }
-    }
-}
-
-struct ExecState {
+struct ExecWebsocket {
     config: Data<BldConfig>,
     supervisor: Data<SupervisorMessageSender>,
     conn: Data<DatabaseConnection>,
@@ -196,7 +31,7 @@ struct ExecState {
     run_id: Option<String>,
 }
 
-impl ExecState {
+impl ExecWebsocket {
     pub fn new(
         config: Data<BldConfig>,
         supervisor: Data<SupervisorMessageSender>,
@@ -215,6 +50,24 @@ impl ExecState {
         }
     }
 
+    pub async fn scan(&self, session: &mut Session) {
+        let Some(scanner) = self.scanner.as_ref() else {
+            return;
+        };
+        let Ok(lines) = scanner.scan().await else {
+            return;
+        };
+        for line in lines.iter() {
+            let message = ExecServerMessage::Log {
+                content: line.to_string(),
+            };
+            let Ok(data) = serde_json::to_string(&message) else {
+                continue;
+            };
+            session.text(data);
+        }
+    }
+
     pub async fn exec(&self, session: &mut Session) -> bool {
         let Some(run_id) = self.run_id.as_ref() else {
             return false;
@@ -228,15 +81,15 @@ impl ExecState {
                 if let Err(e) = session.text(message.as_str()).await {
                     error!("{e}");
                 }
-                true
+                false
             }
             Err(_) => {
                 if let Err(e) = session.text("internal server error").await {
                     error!("{e}");
                 }
-                true
+                false
             }
-            _ => false,
+            _ => true,
         }
     }
 
@@ -279,16 +132,22 @@ pub async fn ws(
     fs: Data<FileSystem>,
 ) -> actix_web::Result<impl Responder> {
     let user = user.ok_or_else(|| ErrorUnauthorized(""))?;
-    let mut state = ExecState::new(config, supervisor, conn, fs, user);
+    let mut socket = ExecWebsocket::new(config, supervisor, conn, fs, user);
     let (response, mut session, mut msg_stream) = handle(&req, body)?;
 
     spawn(async move {
         let mut reason: Option<CloseReason> = None;
+        let mut scan_interval = time::interval(Duration::from_millis(500));
+        let mut exec_interval = time::interval(Duration::from_millis(500));
 
-        while let Some(Ok(msg)) = msg_stream.recv().await {
+        loop {
+            let Some(Ok(msg)) = msg_stream.next().await else {
+                break;
+            };
+
             match msg {
                 Message::Text(txt) => {
-                    if let Err(e) = state.handle_message(&mut session, &txt).await {
+                    if let Err(e) = socket.handle_message(&mut session, &txt).await {
                         error!("handling message error. {e}");
                         break;
                     }
@@ -305,6 +164,14 @@ pub async fn ws(
                     break;
                 }
                 _ => {}
+            }
+
+            scan_interval.tick().await;
+            socket.scan(&mut session).await;
+
+            exec_interval.tick().await;
+            if !socket.exec(&mut session).await {
+                break;
             }
         }
 

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -8,7 +8,7 @@ use actix_web::{
     rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_ws::{CloseReason, Message, Session, handle};
+use actix_ws::{CloseCode, CloseReason, Message, Session, handle};
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::{fs::FileSystem, scanner::FileScanner};
@@ -151,6 +151,7 @@ pub async fn ws(
                     match message {
                         Message::Text(txt) => {
                             if let Err(e) = socket.handle_message(&mut session, &txt).await {
+                                reason = Some(CloseCode::Error.into());
                                 let _ = session.text(e.to_string()).await.inspect_err(|e| error!("{e}"));
                                 error!("handling message error. {e}");
                                 break;
@@ -159,6 +160,7 @@ pub async fn ws(
 
                         Message::Ping(msg) => {
                             if let Err(e) = session.pong(&msg).await {
+                                reason = Some(CloseCode::Error.into());
                                 error!("{e}");
                                 break;
                             }

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -111,22 +111,15 @@ impl ExecWebsocket {
         let supervisor = self.supervisor.clone().into_inner();
 
         debug!("enqueueing run");
-        match enqueue_worker(&username, fs, pool, supervisor, message).await {
-            Ok(run_id) => {
-                self.scanner
-                    .replace(FileScanner::new(self.config.as_ref(), &run_id));
-                self.run_id.replace(run_id.to_owned());
-                let message = ExecServerMessage::QueuedRun { run_id };
-                if let Ok(data) = serde_json::to_string(&message) {
-                    session.text(data).await?;
-                }
-                Ok(())
-            }
-            Err(e) => {
-                session.text(e.to_string()).await?;
-                Err(e)
-            }
+        let run_id = enqueue_worker(&username, fs, pool, supervisor, message).await?;
+        self.scanner
+            .replace(FileScanner::new(self.config.as_ref(), &run_id));
+        self.run_id.replace(run_id.to_owned());
+        let message = ExecServerMessage::QueuedRun { run_id };
+        if let Ok(data) = serde_json::to_string(&message) {
+            session.text(data).await?;
         }
+        Ok(())
     }
 }
 
@@ -158,6 +151,7 @@ pub async fn ws(
                     match message {
                         Message::Text(txt) => {
                             if let Err(e) = socket.handle_message(&mut session, &txt).await {
+                                let _ = session.text(e.to_string()).await.inspect_err(|e| error!("{e}"));
                                 error!("handling message error. {e}");
                                 break;
                             }

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -16,7 +16,7 @@ use bld_models::{
     dtos::{ExecClientMessage, ExecServerMessage},
     pipeline_runs::{self, PR_STATE_FAULTED, PR_STATE_FINISHED, PR_STATE_QUEUED},
 };
-use futures::{FutureExt, StreamExt};
+use futures::StreamExt;
 use sea_orm::DatabaseConnection;
 use std::{sync::Arc, time::Duration};
 use tracing::{debug, error};
@@ -147,57 +147,53 @@ pub async fn ws(
         let mut exec_interval = time::interval(Duration::from_millis(300));
 
         loop {
-            match msg_stream.next().now_or_never() {
-                Some(Some(Ok(msg))) => match msg {
-                    Message::Text(txt) => {
-                        if let Err(e) = socket.handle_message(&mut session, &txt).await {
-                            error!("handling message error. {e}");
-                            break;
-                        }
-                    }
-
-                    Message::Ping(msg) => {
-                        if let Err(e) = session.pong(&msg).await {
-                            error!("{e}");
-                            break;
-                        }
-                    }
-
-                    Message::Pong(msg) => {
-                        if let Err(e) = session.ping(&msg).await {
-                            error!("{e}");
-                            break;
-                        }
-                    }
-
-                    Message::Close(r) => {
-                        reason = r;
+            tokio::select! {
+                Some(message) = msg_stream.next() => {
+                    let Ok(message) = message.inspect_err(|e| error!("{e}")) else {
                         break;
-                    }
+                    };
+                    match message {
+                        Message::Text(txt) => {
+                            if let Err(e) = socket.handle_message(&mut session, &txt).await {
+                                error!("handling message error. {e}");
+                                break;
+                            }
+                        }
 
-                    _ => {
-                        break;
-                    }
-                },
+                        Message::Ping(msg) => {
+                            if let Err(e) = session.pong(&msg).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
 
-                Some(Some(Err(e))) => {
-                    error!("encountered error during message processing. {e}");
-                    break;
+                        Message::Pong(msg) => {
+                            if let Err(e) = session.ping(&msg).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
+
+                        Message::Close(r) => {
+                            reason = r;
+                            break;
+                        }
+
+                        _ => {
+                            break;
+                        }
+                    }
                 }
 
-                Some(None) => {
-                    break;
+                _ = scan_interval.tick() => {
+                    socket.scan(&mut session).await;
                 }
 
-                None => {}
-            }
-
-            scan_interval.tick().await;
-            socket.scan(&mut session).await;
-
-            exec_interval.tick().await;
-            if !socket.check_state(&mut session).await {
-                break;
+                _ = exec_interval.tick() => {
+                    if !socket.check_state(&mut session).await {
+                        break;
+                    }
+                }
             }
         }
 

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -167,12 +167,7 @@ pub async fn ws(
                             }
                         }
 
-                        Message::Pong(msg) => {
-                            if let Err(e) = session.ping(&msg).await {
-                                error!("{e}");
-                                break;
-                            }
-                        }
+                        Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
 
                         Message::Close(r) => {
                             reason = r;

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -18,11 +18,13 @@ use bld_models::{
 };
 use futures::StreamExt;
 use sea_orm::DatabaseConnection;
-use std::time::Duration;
-use tracing::{debug, error};
+use std::time::{Duration, Instant};
+use tracing::{debug, error, warn};
 
 const SCAN_INTERVAL_MS: u64 = 500;
 const STATE_CHECK_INTERVAL_MS: u64 = 1000;
+const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
+const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 struct ExecWebsocket {
     config: Data<BldConfig>,
@@ -141,6 +143,8 @@ pub async fn ws(
         let mut reason: Option<CloseReason> = None;
         let mut scan_interval = time::interval(Duration::from_millis(SCAN_INTERVAL_MS));
         let mut state_interval = time::interval(Duration::from_millis(STATE_CHECK_INTERVAL_MS));
+        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
+        let mut last_pong = Instant::now();
 
         loop {
             tokio::select! {
@@ -166,7 +170,11 @@ pub async fn ws(
                             }
                         }
 
-                        Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
+                        Message::Pong(_) => {
+                            last_pong = Instant::now();
+                        }
+
+                        Message::Continuation(_) | Message::Nop => {}
 
                         Message::Close(r) => {
                             reason = r;
@@ -185,6 +193,21 @@ pub async fn ws(
 
                 _ = state_interval.tick() => {
                     if !socket.check_state(&mut session).await {
+                        break;
+                    }
+                }
+
+                _ = hb_interval.tick() => {
+                    if Instant::now().duration_since(last_pong)
+                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
+                    {
+                        warn!("client heartbeat timed out, closing session");
+                        reason = Some(CloseCode::Away.into());
+                        break;
+                    }
+                    if let Err(e) = session.ping(b"").await {
+                        error!("ping failed: {e}");
+                        reason = Some(CloseCode::Error.into());
                         break;
                     }
                 }

--- a/crates/bld_server/src/sockets/exec.rs
+++ b/crates/bld_server/src/sockets/exec.rs
@@ -18,8 +18,11 @@ use bld_models::{
 };
 use futures::StreamExt;
 use sea_orm::DatabaseConnection;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use tracing::{debug, error};
+
+const SCAN_INTERVAL_MS: u64 = 500;
+const STATE_CHECK_INTERVAL_MS: u64 = 1000;
 
 struct ExecWebsocket {
     config: Data<BldConfig>,
@@ -103,9 +106,9 @@ impl ExecWebsocket {
     pub async fn handle_message(&mut self, session: &mut Session, message: &str) -> Result<()> {
         let message: ExecClientMessage = serde_json::from_str(message)?;
         let username = self.user.name.to_owned();
-        let fs = Arc::clone(&self.fs);
-        let pool = Arc::clone(&self.conn);
-        let supervisor = Arc::clone(&self.supervisor);
+        let fs = self.fs.clone().into_inner();
+        let pool = self.conn.clone().into_inner();
+        let supervisor = self.supervisor.clone().into_inner();
 
         debug!("enqueueing run");
         match enqueue_worker(&username, fs, pool, supervisor, message).await {
@@ -143,13 +146,13 @@ pub async fn ws(
     spawn(async move {
         debug!("spawned exec web socket");
         let mut reason: Option<CloseReason> = None;
-        let mut scan_interval = time::interval(Duration::from_millis(300));
-        let mut exec_interval = time::interval(Duration::from_millis(300));
+        let mut scan_interval = time::interval(Duration::from_millis(SCAN_INTERVAL_MS));
+        let mut state_interval = time::interval(Duration::from_millis(STATE_CHECK_INTERVAL_MS));
 
         loop {
             tokio::select! {
-                Some(message) = msg_stream.next() => {
-                    let Ok(message) = message.inspect_err(|e| error!("{e}")) else {
+                Some(msg) = msg_stream.next() => {
+                    let Ok(message) = msg.inspect_err(|e| error!("{e}")) else {
                         break;
                     };
                     match message {
@@ -184,7 +187,7 @@ pub async fn ws(
                     socket.scan(&mut session).await;
                 }
 
-                _ = exec_interval.tick() => {
+                _ = state_interval.tick() => {
                     if !socket.check_state(&mut session).await {
                         break;
                     }

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -89,11 +89,11 @@ impl LoginSocket {
 
         if let Err(e) = login_attempts::insert(&conn, model).await {
             let message = serde_json::to_string(&LoginServerMessage::Failed(e.to_string()))?;
-            session.text(message).await;
+            session.text(message).await?;
         }
 
         let message = LoginServerMessage::AuthorizationUrl(url.to_string());
-        session.text(serde_json::to_string(&message)?).await;
+        session.text(serde_json::to_string(&message)?).await?;
 
         Ok(())
     }
@@ -117,7 +117,7 @@ impl LoginSocket {
         else {
             let message = LoginServerMessage::Failed("Login operation failed".to_string());
             if let Ok(text) = serde_json::to_string(&message) {
-                session.text(text).await;
+                let _ = session.text(text).await.inspect_err(|e| error!("{e}"));
             }
             return false;
         };
@@ -128,7 +128,7 @@ impl LoginSocket {
             let Some(access_token) = login_attempt.access_token else {
                 let message = LoginServerMessage::Failed("Access token not found".to_string());
                 if let Ok(text) = serde_json::to_string(&message) {
-                    session.text(text).await;
+                    let _ = session.text(text).await.inspect_err(|e| error!("{e}"));
                 }
                 return false;
             };
@@ -136,7 +136,7 @@ impl LoginSocket {
             let auth_tokens = AuthTokens::new(access_token, login_attempt.refresh_token);
             let message = LoginServerMessage::Completed(auth_tokens);
             if let Ok(text) = serde_json::to_string(&message) {
-                session.text(text).await;
+                let _ = session.text(text).await.inspect_err(|e| error!("{e}"));
             }
 
             return false;
@@ -145,7 +145,7 @@ impl LoginSocket {
         if let Ok(LoginAttemptStatus::Failed) = status {
             let message = LoginServerMessage::Failed("Login operation failed".to_string());
             if let Ok(text) = serde_json::to_string(&message) {
-                session.text(text).await;
+                let _ = session.text(text).await.inspect_err(|e| error!("{e}"));
             }
             return false;
         }
@@ -153,17 +153,17 @@ impl LoginSocket {
         if Utc::now().naive_utc() > login_attempt.date_expires {
             let message = LoginServerMessage::Failed("Operation timeout".to_string());
             if let Ok(text) = serde_json::to_string(&message) {
-                session.text(text).await;
+                let _ = session.text(text).await.inspect_err(|e| error!("{e}"));
             }
             return false;
         }
 
-        return true;
+        true
     }
 
     async fn cleanup(&mut self) {
         if let Err(e) =
-            login_attempts::delete_by_csrf_token(&self.conn.as_ref(), &self.csrf_token.secret())
+            login_attempts::delete_by_csrf_token(self.conn.as_ref(), self.csrf_token.secret())
                 .await
         {
             error!("{e}");
@@ -188,28 +188,36 @@ pub async fn ws(
         let mut interval = time::interval(Duration::from_millis(500));
 
         loop {
-            let Some(Ok(msg)) = msg_stream.next().await else {
-                break;
-            };
-
-            match msg {
-                Message::Text(txt) => {
-                    if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
+            if let Some(msg) = msg_stream.next().await {
+                match msg {
+                    Ok(Message::Text(txt)) => {
+                        if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Ping(msg)) => {
+                        if let Err(e) = session.pong(&msg).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Pong(msg)) => {
+                        if let Err(e) = session.ping(&msg).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Close(r)) => {
+                        reason = r;
+                        break;
+                    }
+                    Err(e) => {
                         error!("{e}");
                         break;
                     }
+                    _ => break,
                 }
-                Message::Ping(msg) => {
-                    session.pong(&msg).await;
-                }
-                Message::Pong(msg) => {
-                    session.ping(&msg).await;
-                }
-                Message::Close(r) => {
-                    reason = r;
-                    break;
-                }
-                _ => {}
             }
 
             interval.tick().await;
@@ -221,6 +229,8 @@ pub async fn ws(
         if let Err(e) = session.close(reason).await {
             error!("encountered error while closing websocket session due to {e}");
         }
+
+        socket.cleanup().await
     });
 
     Ok(response)

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 use actix_web::{
-    HttpRequest, Responder, rt::{spawn, time}, web::{Data, Payload}
+    HttpRequest, Responder,
+    rt::{spawn, time},
+    web::{Data, Payload},
 };
 use actix_ws::{CloseReason, Message, Session, handle};
 use anyhow::{Result, bail};
@@ -163,8 +165,7 @@ impl LoginSocket {
 
     async fn cleanup(&mut self) {
         if let Err(e) =
-            login_attempts::delete_by_csrf_token(self.conn.as_ref(), self.csrf_token.secret())
-                .await
+            login_attempts::delete_by_csrf_token(self.conn.as_ref(), self.csrf_token.secret()).await
         {
             error!("{e}");
         }

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -1,29 +1,27 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use actix_web::{
     HttpRequest, Responder,
     rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_ws::{CloseCode, CloseReason, Message, Session, handle};
+use actix_ws::Session;
 use anyhow::{Result, bail};
 use bld_config::{Auth, BldConfig};
 use bld_models::{
     dtos::{AuthTokens, LoginClientMessage, LoginServerMessage},
     login_attempts::{self, InsertLoginAttempt, LoginAttemptStatus},
 };
+use bld_sock::session::{self, WebSocketMessage};
 use chrono::Utc;
-use futures::StreamExt;
 use openidconnect::{
     CsrfToken, Nonce, PkceCodeChallenge,
     core::{CoreAuthenticationFlow, CoreClient},
 };
 use sea_orm::DatabaseConnection;
-use tracing::{error, warn};
+use tracing::error;
 
 const STATUS_CHECK_INTERVAL_MS: u64 = 500;
-const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
-const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 pub struct LoginSocket {
     csrf_token: CsrfToken,
@@ -184,80 +182,39 @@ pub async fn ws(
     let csrf_token = CsrfToken::new_random();
     let nonce = Nonce::new_random();
     let mut socket = LoginSocket::new(csrf_token, nonce, config, client, conn);
-    let (response, mut session, mut msg_stream) = handle(&req, body)?;
+    let (response, mut handler) = session::handle(&req, body)?;
 
     spawn(async move {
-        let mut reason: Option<CloseReason> = None;
         let mut interval = time::interval(Duration::from_millis(STATUS_CHECK_INTERVAL_MS));
-        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
-        let mut last_pong = Instant::now();
 
         loop {
             tokio::select! {
-                Some(msg) = msg_stream.next() => {
-                    let Ok(msg) = msg.inspect_err(|e| error!("{e}")) else {
-                        break;
-                    };
+                msg = handler.next() => {
                     match msg {
-                        Message::Text(txt) => {
-                            if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
-                                reason = Some(CloseCode::Error.into());
+                        WebSocketMessage::Text(txt) => {
+                            let session = handler.session();
+                            if let Err(e) = socket.handle_client_message(session, &txt).await {
                                 error!("{e}");
+                                handler.error();
                                 break;
                             }
                         }
-
-                        Message::Ping(msg) => {
-                            if let Err(e) = session.pong(&msg).await {
-                                reason = Some(CloseCode::Error.into());
-                                error!("{e}");
-                                break;
-                            }
-                        }
-
-                        Message::Pong(_) => {
-                            last_pong = Instant::now();
-                        }
-
-                        Message::Continuation(_) | Message::Nop => {}
-
-                        Message::Close(r) => {
-                            reason = r;
-                            break;
-                        }
-
+                        WebSocketMessage::Continue => {}
                         _ => break,
                     }
                 }
 
                 _ = interval.tick() => {
-                    if !socket.check_status(&mut session).await {
-                        break;
-                    }
-                }
-
-                _ = hb_interval.tick() => {
-                    if Instant::now().duration_since(last_pong)
-                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
-                    {
-                        warn!("client heartbeat timed out, closing session");
-                        reason = Some(CloseCode::Away.into());
-                        break;
-                    }
-                    if let Err(e) = session.ping(b"").await {
-                        error!("ping failed: {e}");
-                        reason = Some(CloseCode::Error.into());
+                    let session = handler.session();
+                    if !socket.check_status(session).await {
                         break;
                     }
                 }
             }
         }
 
-        if let Err(e) = session.close(reason).await {
-            error!("encountered error while closing websocket session due to {e}");
-        }
-
-        socket.cleanup().await
+        handler.cleanup().await;
+        socket.cleanup().await;
     });
 
     Ok(response)

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -1,14 +1,11 @@
 use std::time::Duration;
 
-use actix::{
-    Actor, ActorContext, AsyncContext, StreamHandler, WrapFuture,
-    fut::{future::ActorFutureExt, ready},
-};
 use actix_web::{
     Error, HttpRequest, HttpResponse,
+    rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_web_actors::ws::{Message, ProtocolError, WebsocketContext, start};
+use actix_ws::{CloseReason, Message, Session, handle};
 use anyhow::{Result, bail};
 use bld_config::{Auth, BldConfig};
 use bld_models::{
@@ -16,6 +13,7 @@ use bld_models::{
     login_attempts::{self, InsertLoginAttempt, LoginAttemptStatus},
 };
 use chrono::Utc;
+use futures::StreamExt;
 use openidconnect::{
     CsrfToken, Nonce, PkceCodeChallenge,
     core::{CoreAuthenticationFlow, CoreClient},
@@ -48,7 +46,7 @@ impl LoginSocket {
         }
     }
 
-    fn openid_authorization_url(&mut self, ctx: &mut <Self as Actor>::Context) -> Result<()> {
+    async fn openid_authorization_url(&mut self, session: &mut Session) -> Result<()> {
         let Some(client) = self.client.get_ref() else {
             bail!("openid core client hasn't be registered for server");
         };
@@ -83,173 +81,147 @@ impl LoginSocket {
         let nonce = self.nonce.clone();
         let conn = self.conn.clone();
 
-        let login_fut = async move {
-            let model = InsertLoginAttempt {
-                csrf_token: csrf_token.secret().to_owned(),
-                nonce: nonce.secret().to_owned(),
-                pkce_verifier: verifier.secret().to_owned(),
-            };
-            login_attempts::insert(&conn, model).await
+        let model = InsertLoginAttempt {
+            csrf_token: csrf_token.secret().to_owned(),
+            nonce: nonce.secret().to_owned(),
+            pkce_verifier: verifier.secret().to_owned(),
+        };
+
+        if let Err(e) = login_attempts::insert(&conn, model).await {
+            let message = serde_json::to_string(&LoginServerMessage::Failed(e.to_string()))?;
+            session.text(message).await;
         }
-        .into_actor(self)
-        .then(|res: Result<()>, _, ctx| {
-            if let Err(e) = res {
-                let message = serde_json::to_string(&LoginServerMessage::Failed(e.to_string()));
-                if let Ok(message) = message {
-                    ctx.text(message);
-                } else {
-                    ctx.stop();
-                }
-            }
-            ready(())
-        });
-        ctx.spawn(login_fut);
 
         let message = LoginServerMessage::AuthorizationUrl(url.to_string());
-        ctx.text(serde_json::to_string(&message)?);
+        session.text(serde_json::to_string(&message)?).await;
 
         Ok(())
     }
 
-    fn handle_client_message(
-        &mut self,
-        ctx: &mut <Self as Actor>::Context,
-        message: &str,
-    ) -> Result<()> {
+    async fn handle_client_message(&mut self, session: &mut Session, message: &str) -> Result<()> {
         let _: LoginClientMessage = serde_json::from_str(message)?;
 
         match &self.config.as_ref().local.server.auth {
-            Some(Auth::OpenId(_)) => self.openid_authorization_url(ctx)?,
+            Some(Auth::OpenId(_)) => self.openid_authorization_url(session).await?,
             _ => bail!("no authentication method configured for server"),
         }
 
         Ok(())
     }
 
-    fn check_status(act: &Self, ctx: &mut <Self as Actor>::Context) {
-        let csrf_token = act.csrf_token.secret().to_owned();
-        let conn = act.conn.clone();
-        let status_fut =
-            async move { login_attempts::select_by_csrf_token(&conn, &csrf_token).await }
-                .into_actor(act)
-                .then(|res, _, ctx| {
-                    let Ok(login_attempt) = res else {
-                        let message =
-                            LoginServerMessage::Failed("Login operation failed".to_string());
-                        if let Ok(text) = serde_json::to_string(&message) {
-                            ctx.text(text);
-                        }
-                        return ready(());
-                    };
-
-                    let status: Result<LoginAttemptStatus> = login_attempt.status.try_into();
-
-                    if let Ok(LoginAttemptStatus::Completed) = status {
-                        let Some(access_token) = login_attempt.access_token else {
-                            let message =
-                                LoginServerMessage::Failed("Access token not found".to_string());
-                            if let Ok(text) = serde_json::to_string(&message) {
-                                ctx.text(text);
-                            }
-                            return ready(());
-                        };
-
-                        let auth_tokens =
-                            AuthTokens::new(access_token, login_attempt.refresh_token);
-                        let message = LoginServerMessage::Completed(auth_tokens);
-                        if let Ok(text) = serde_json::to_string(&message) {
-                            ctx.text(text);
-                        }
-
-                        return ready(());
-                    }
-
-                    if let Ok(LoginAttemptStatus::Failed) = status {
-                        let message =
-                            LoginServerMessage::Failed("Login operation failed".to_string());
-                        if let Ok(text) = serde_json::to_string(&message) {
-                            ctx.text(text);
-                        }
-                        return ready(());
-                    }
-
-                    if Utc::now().naive_utc() > login_attempt.date_expires {
-                        let message = LoginServerMessage::Failed("Operation timeout".to_string());
-                        if let Ok(text) = serde_json::to_string(&message) {
-                            ctx.text(text);
-                        }
-                        ctx.stop();
-                        return ready(());
-                    }
-
-                    ready(())
-                });
-        ctx.spawn(status_fut);
-    }
-
-    fn cleanup(&mut self, ctx: &mut <LoginSocket as Actor>::Context) {
-        let token = self.csrf_token.secret().to_owned();
+    async fn check_status(&self, session: &mut Session) -> bool {
+        let csrf_token = self.csrf_token.secret().to_owned();
         let conn = self.conn.clone();
-        let logins_remove_fut =
-            async move { login_attempts::delete_by_csrf_token(&conn, &token).await }
-                .into_actor(self)
-                .then(|res, _, _| {
-                    if let Err(e) = res {
-                        error!("{e}");
-                    }
-                    ready(())
-                });
-        ctx.wait(logins_remove_fut);
-    }
-}
 
-impl Actor for LoginSocket {
-    type Context = WebsocketContext<Self>;
+        let Ok(login_attempt) = login_attempts::select_by_csrf_token(&conn, &csrf_token).await
+        else {
+            let message = LoginServerMessage::Failed("Login operation failed".to_string());
+            if let Ok(text) = serde_json::to_string(&message) {
+                session.text(text).await;
+            }
+            return false;
+        };
 
-    fn started(&mut self, ctx: &mut Self::Context) {
-        ctx.run_interval(Duration::from_secs(1), |act, ctx| {
-            LoginSocket::check_status(act, ctx);
-        });
-    }
+        let status: Result<LoginAttemptStatus> = login_attempt.status.try_into();
 
-    fn stopped(&mut self, ctx: &mut Self::Context) {
-        self.cleanup(ctx);
-    }
-}
-
-impl StreamHandler<Result<Message, ProtocolError>> for LoginSocket {
-    fn handle(&mut self, item: Result<Message, ProtocolError>, ctx: &mut Self::Context) {
-        match item {
-            Ok(Message::Text(txt)) => {
-                if let Err(e) = self.handle_client_message(ctx, &txt) {
-                    error!("{e}");
-                    ctx.stop();
+        if let Ok(LoginAttemptStatus::Completed) = status {
+            let Some(access_token) = login_attempt.access_token else {
+                let message = LoginServerMessage::Failed("Access token not found".to_string());
+                if let Ok(text) = serde_json::to_string(&message) {
+                    session.text(text).await;
                 }
+                return false;
+            };
+
+            let auth_tokens = AuthTokens::new(access_token, login_attempt.refresh_token);
+            let message = LoginServerMessage::Completed(auth_tokens);
+            if let Ok(text) = serde_json::to_string(&message) {
+                session.text(text).await;
             }
-            Ok(Message::Ping(msg)) => {
-                ctx.pong(&msg);
+
+            return false;
+        }
+
+        if let Ok(LoginAttemptStatus::Failed) = status {
+            let message = LoginServerMessage::Failed("Login operation failed".to_string());
+            if let Ok(text) = serde_json::to_string(&message) {
+                session.text(text).await;
             }
-            Ok(Message::Pong(msg)) => {
-                ctx.ping(&msg);
+            return false;
+        }
+
+        if Utc::now().naive_utc() > login_attempt.date_expires {
+            let message = LoginServerMessage::Failed("Operation timeout".to_string());
+            if let Ok(text) = serde_json::to_string(&message) {
+                session.text(text).await;
             }
-            Ok(Message::Close(reason)) => {
-                ctx.close(reason);
-                ctx.stop();
-            }
-            _ => {}
+            return false;
+        }
+
+        return true;
+    }
+
+    async fn cleanup(&mut self) {
+        if let Err(e) =
+            login_attempts::delete_by_csrf_token(&self.conn.as_ref(), &self.csrf_token.secret())
+                .await
+        {
+            error!("{e}");
         }
     }
 }
 
 pub async fn ws(
     req: HttpRequest,
-    stream: Payload,
+    body: Payload,
     config: Data<BldConfig>,
     client: Data<Option<CoreClient>>,
     conn: Data<DatabaseConnection>,
 ) -> Result<HttpResponse, Error> {
     let csrf_token = CsrfToken::new_random();
     let nonce = Nonce::new_random();
-    let socket = LoginSocket::new(csrf_token, nonce, config, client, conn);
-    start(socket, &req, stream)
+    let mut socket = LoginSocket::new(csrf_token, nonce, config, client, conn);
+    let (response, mut session, mut msg_stream) = handle(&req, body)?;
+
+    spawn(async move {
+        let mut reason: Option<CloseReason> = None;
+        let mut interval = time::interval(Duration::from_millis(500));
+
+        loop {
+            let Some(Ok(msg)) = msg_stream.next().await else {
+                break;
+            };
+
+            match msg {
+                Message::Text(txt) => {
+                    if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
+                        error!("{e}");
+                        break;
+                    }
+                }
+                Message::Ping(msg) => {
+                    session.pong(&msg).await;
+                }
+                Message::Pong(msg) => {
+                    session.ping(&msg).await;
+                }
+                Message::Close(r) => {
+                    reason = r;
+                    break;
+                }
+                _ => {}
+            }
+
+            interval.tick().await;
+            if !socket.check_status(&mut session).await {
+                break;
+            }
+        }
+
+        if let Err(e) = session.close(reason).await {
+            error!("encountered error while closing websocket session due to {e}");
+        }
+    });
+
+    Ok(response)
 }

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -188,33 +188,31 @@ pub async fn ws(
         loop {
             tokio::select! {
                 Some(msg) = msg_stream.next() => {
+                    let Ok(msg) = msg.inspect_err(|e| error!("{e}")) else {
+                        break;
+                    };
                     match msg {
-                        Ok(Message::Text(txt)) => {
+                        Message::Text(txt) => {
                             if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
                                 error!("{e}");
                                 break;
                             }
                         }
-                        Ok(Message::Ping(msg)) => {
+
+                        Message::Ping(msg) => {
                             if let Err(e) = session.pong(&msg).await {
                                 error!("{e}");
                                 break;
                             }
                         }
-                        Ok(Message::Pong(msg)) => {
-                            if let Err(e) = session.ping(&msg).await {
-                                error!("{e}");
-                                break;
-                            }
-                        }
-                        Ok(Message::Close(r)) => {
+
+                        Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
+
+                        Message::Close(r) => {
                             reason = r;
                             break;
                         }
-                        Err(e) => {
-                            error!("{e}");
-                            break;
-                        }
+
                         _ => break,
                     }
                 }

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -5,7 +5,7 @@ use actix_web::{
     rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_ws::{CloseReason, Message, Session, handle};
+use actix_ws::{CloseCode, CloseReason, Message, Session, handle};
 use anyhow::{Result, bail};
 use bld_config::{Auth, BldConfig};
 use bld_models::{
@@ -197,6 +197,7 @@ pub async fn ws(
                     match msg {
                         Message::Text(txt) => {
                             if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
+                                reason = Some(CloseCode::Error.into());
                                 error!("{e}");
                                 break;
                             }
@@ -204,6 +205,7 @@ pub async fn ws(
 
                         Message::Ping(msg) => {
                             if let Err(e) = session.pong(&msg).await {
+                                reason = Some(CloseCode::Error.into());
                                 error!("{e}");
                                 break;
                             }

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use actix_web::{
     HttpRequest, Responder,
@@ -19,9 +19,11 @@ use openidconnect::{
     core::{CoreAuthenticationFlow, CoreClient},
 };
 use sea_orm::DatabaseConnection;
-use tracing::error;
+use tracing::{error, warn};
 
 const STATUS_CHECK_INTERVAL_MS: u64 = 500;
+const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
+const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 pub struct LoginSocket {
     csrf_token: CsrfToken,
@@ -187,6 +189,8 @@ pub async fn ws(
     spawn(async move {
         let mut reason: Option<CloseReason> = None;
         let mut interval = time::interval(Duration::from_millis(STATUS_CHECK_INTERVAL_MS));
+        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
+        let mut last_pong = Instant::now();
 
         loop {
             tokio::select! {
@@ -211,7 +215,11 @@ pub async fn ws(
                             }
                         }
 
-                        Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
+                        Message::Pong(_) => {
+                            last_pong = Instant::now();
+                        }
+
+                        Message::Continuation(_) | Message::Nop => {}
 
                         Message::Close(r) => {
                             reason = r;
@@ -224,6 +232,21 @@ pub async fn ws(
 
                 _ = interval.tick() => {
                     if !socket.check_status(&mut session).await {
+                        break;
+                    }
+                }
+
+                _ = hb_interval.tick() => {
+                    if Instant::now().duration_since(last_pong)
+                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
+                    {
+                        warn!("client heartbeat timed out, closing session");
+                        reason = Some(CloseCode::Away.into());
+                        break;
+                    }
+                    if let Err(e) = session.ping(b"").await {
+                        error!("ping failed: {e}");
+                        reason = Some(CloseCode::Error.into());
                         break;
                     }
                 }

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -19,6 +19,8 @@ use openidconnect::{
 use sea_orm::DatabaseConnection;
 use tracing::error;
 
+const STATUS_CHECK_INTERVAL_MS: u64 = 500;
+
 pub struct LoginSocket {
     csrf_token: CsrfToken,
     nonce: Nonce,
@@ -183,7 +185,7 @@ pub async fn ws(
 
     spawn(async move {
         let mut reason: Option<CloseReason> = None;
-        let mut interval = time::interval(Duration::from_millis(500));
+        let mut interval = time::interval(Duration::from_millis(STATUS_CHECK_INTERVAL_MS));
 
         loop {
             tokio::select! {

--- a/crates/bld_server/src/sockets/login.rs
+++ b/crates/bld_server/src/sockets/login.rs
@@ -1,9 +1,7 @@
 use std::time::Duration;
 
 use actix_web::{
-    Error, HttpRequest, HttpResponse,
-    rt::{spawn, time},
-    web::{Data, Payload},
+    HttpRequest, Responder, rt::{spawn, time}, web::{Data, Payload}
 };
 use actix_ws::{CloseReason, Message, Session, handle};
 use anyhow::{Result, bail};
@@ -177,7 +175,7 @@ pub async fn ws(
     config: Data<BldConfig>,
     client: Data<Option<CoreClient>>,
     conn: Data<DatabaseConnection>,
-) -> Result<HttpResponse, Error> {
+) -> actix_web::Result<impl Responder> {
     let csrf_token = CsrfToken::new_random();
     let nonce = Nonce::new_random();
     let mut socket = LoginSocket::new(csrf_token, nonce, config, client, conn);
@@ -188,41 +186,44 @@ pub async fn ws(
         let mut interval = time::interval(Duration::from_millis(500));
 
         loop {
-            if let Some(msg) = msg_stream.next().await {
-                match msg {
-                    Ok(Message::Text(txt)) => {
-                        if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
+            tokio::select! {
+                Some(msg) = msg_stream.next() => {
+                    match msg {
+                        Ok(Message::Text(txt)) => {
+                            if let Err(e) = socket.handle_client_message(&mut session, &txt).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
+                        Ok(Message::Ping(msg)) => {
+                            if let Err(e) = session.pong(&msg).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
+                        Ok(Message::Pong(msg)) => {
+                            if let Err(e) = session.ping(&msg).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
+                        Ok(Message::Close(r)) => {
+                            reason = r;
+                            break;
+                        }
+                        Err(e) => {
                             error!("{e}");
                             break;
                         }
+                        _ => break,
                     }
-                    Ok(Message::Ping(msg)) => {
-                        if let Err(e) = session.pong(&msg).await {
-                            error!("{e}");
-                            break;
-                        }
-                    }
-                    Ok(Message::Pong(msg)) => {
-                        if let Err(e) = session.ping(&msg).await {
-                            error!("{e}");
-                            break;
-                        }
-                    }
-                    Ok(Message::Close(r)) => {
-                        reason = r;
-                        break;
-                    }
-                    Err(e) => {
-                        error!("{e}");
-                        break;
-                    }
-                    _ => break,
                 }
-            }
 
-            interval.tick().await;
-            if !socket.check_status(&mut session).await {
-                break;
+                _ = interval.tick() => {
+                    if !socket.check_status(&mut session).await {
+                        break;
+                    }
+                }
             }
         }
 

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -18,6 +18,8 @@ use sea_orm::DatabaseConnection;
 use std::time::Duration;
 use tracing::{debug, error};
 
+const STATE_CHECK_INTERVAL_MS: u64 = 500;
+
 pub struct MonitorPipelineSocket {
     id: String,
     conn: Data<DatabaseConnection>,
@@ -48,7 +50,7 @@ impl MonitorPipelineSocket {
         }
     }
 
-    async fn exec(&self, session: &mut Session) -> bool {
+    async fn check_state(&self, session: &mut Session) -> bool {
         match pipeline_runs::select_by_id(self.conn.as_ref(), &self.id).await {
             Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => false,
             Err(_) => {
@@ -101,8 +103,7 @@ pub async fn ws(
 
     spawn(async move {
         let mut reason: Option<CloseReason> = None;
-        let mut scan_interval = time::interval(Duration::from_millis(500));
-        let mut exec_interval = time::interval(Duration::from_millis(500));
+        let mut interval = time::interval(Duration::from_millis(STATE_CHECK_INTERVAL_MS));
 
         loop {
             tokio::select! {
@@ -136,12 +137,9 @@ pub async fn ws(
                     }
                 }
 
-                _ = scan_interval.tick() => {
+                _ = interval.tick() => {
                     socket.scan(&mut session).await;
-                }
-
-                _ = exec_interval.tick() => {
-                    if !socket.exec(&mut session).await {
+                    if !socket.check_state(&mut session).await {
                         break;
                     }
                 }

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -5,7 +5,7 @@ use actix_web::{
     rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_ws::{CloseCode, CloseReason, Message, Session, handle};
+use actix_ws::Session;
 use anyhow::{Result, bail};
 use bld_config::BldConfig;
 use bld_core::scanner::FileScanner;
@@ -13,14 +13,12 @@ use bld_models::{
     dtos::MonitInfo,
     pipeline_runs::{self, PR_STATE_FAULTED, PR_STATE_FINISHED},
 };
-use futures::StreamExt;
+use bld_sock::session::{self, WebSocketMessage};
 use sea_orm::DatabaseConnection;
-use std::time::{Duration, Instant};
-use tracing::{debug, error, warn};
+use std::time::Duration;
+use tracing::{debug, error};
 
 const STATE_CHECK_INTERVAL_MS: u64 = 500;
-const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
-const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 pub struct MonitorPipelineSocket {
     id: String,
@@ -93,80 +91,40 @@ pub async fn ws(
 ) -> actix_web::Result<impl Responder> {
     user.ok_or_else(|| ErrorUnauthorized(""))?;
     let mut socket = MonitorPipelineSocket::new(conn, config);
-    let (response, mut session, mut msg_stream) = handle(&req, body)?;
+    let (response, mut handler) = session::handle(&req, body)?;
 
     spawn(async move {
-        let mut reason: Option<CloseReason> = None;
         let mut interval = time::interval(Duration::from_millis(STATE_CHECK_INTERVAL_MS));
-        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
-        let mut last_pong = Instant::now();
 
         loop {
             tokio::select! {
-                Some(msg) = msg_stream.next() => {
-                    let Ok(msg) = msg.inspect_err(|e| error!("{e}")) else {
-                        break;
-                    };
+                msg = handler.next() => {
                     match msg {
-                        Message::Text(txt) => {
+                        WebSocketMessage::Text(txt) => {
                             if let Err(e) = socket.dependencies(&txt).await {
-                                reason = Some(CloseCode::Error.into());
+                                let session = handler.session();
                                 let _ = session.text("internal server error").await.inspect_err(|e| error!("{e}"));
                                 error!("{e}");
+                                handler.error();
                                 break;
                             }
                         }
-
-                        Message::Ping(msg) => {
-                            if let Err(e) = session.pong(&msg).await {
-                                reason = Some(CloseCode::Error.into());
-                                error!("{e}");
-                                break;
-                            }
-                        }
-
-                        Message::Pong(_) => {
-                            last_pong = Instant::now();
-                        }
-
-                        Message::Continuation(_) | Message::Nop => {}
-
-                        Message::Close(r) => {
-                            reason = r;
-                            break;
-                        }
-
+                        WebSocketMessage::Continue => {}
                         _ => break,
                     }
                 }
 
                 _ = interval.tick() => {
-                    socket.scan(&mut session).await;
-                    if !socket.check_state(&mut session).await {
-                        break;
-                    }
-                }
-
-                _ = hb_interval.tick() => {
-                    if Instant::now().duration_since(last_pong)
-                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
-                    {
-                        warn!("client heartbeat timed out, closing session");
-                        reason = Some(CloseCode::Away.into());
-                        break;
-                    }
-                    if let Err(e) = session.ping(b"").await {
-                        error!("ping failed: {e}");
-                        reason = Some(CloseCode::Error.into());
+                    let session = handler.session();
+                    socket.scan(session).await;
+                    if !socket.check_state(session).await {
                         break;
                     }
                 }
             }
         }
 
-        if let Err(e) = session.close(reason).await {
-            error!("encountered error while closing websocket session due to {e}");
-        }
+        handler.cleanup().await;
     });
 
     Ok(response)

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -1,9 +1,6 @@
 use crate::extractors::User;
 use actix_web::{
-    Error, HttpRequest, HttpResponse,
-    error::ErrorUnauthorized,
-    rt::{spawn, time},
-    web::{Data, Payload},
+    HttpRequest, Responder, error::ErrorUnauthorized, rt::{spawn, time}, web::{Data, Payload}
 };
 use actix_ws::{CloseReason, Message, Session, handle};
 use anyhow::{Result, bail};
@@ -13,17 +10,16 @@ use bld_models::{
     dtos::MonitInfo,
     pipeline_runs::{self, PR_STATE_FAULTED, PR_STATE_FINISHED},
 };
-use bld_utils::sync::IntoArc;
 use futures::StreamExt;
 use sea_orm::DatabaseConnection;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use tracing::{debug, error};
 
 pub struct MonitorPipelineSocket {
     id: String,
     conn: Data<DatabaseConnection>,
     config: Data<BldConfig>,
-    scanner: Option<Arc<FileScanner>>,
+    scanner: Option<FileScanner>,
 }
 
 impl MonitorPipelineSocket {
@@ -78,7 +74,7 @@ impl MonitorPipelineSocket {
             Ok(run) => {
                 debug!("starting scan for run");
                 self.id.clone_from(&run.id);
-                self.scanner = Some(FileScanner::new(self.config.as_ref(), &run.id).into_arc());
+                self.scanner = Some(FileScanner::new(self.config.as_ref(), &run.id));
                 Ok(())
             }
             Err(e) => {
@@ -95,10 +91,8 @@ pub async fn ws(
     body: Payload,
     conn: Data<DatabaseConnection>,
     config: Data<BldConfig>,
-) -> Result<HttpResponse, Error> {
-    if user.is_none() {
-        return Err(ErrorUnauthorized(""));
-    }
+) -> actix_web::Result<impl Responder> {
+    user.ok_or_else(|| ErrorUnauthorized(""))?;
     let mut socket = MonitorPipelineSocket::new(conn, config);
     let (response, mut session, mut msg_stream) = handle(&req, body)?;
 
@@ -108,44 +102,48 @@ pub async fn ws(
         let mut exec_interval = time::interval(Duration::from_millis(500));
 
         loop {
-            if let Some(msg) = msg_stream.next().await {
-                match msg {
-                    Ok(Message::Text(txt)) => {
-                        if let Err(e) = socket.dependencies(&mut session, &txt).await {
+            tokio::select! {
+                Some(msg) = msg_stream.next() => {
+                    match msg {
+                        Ok(Message::Text(txt)) => {
+                            if let Err(e) = socket.dependencies(&mut session, &txt).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
+                        Ok(Message::Ping(msg)) => {
+                            if let Err(e) = session.pong(&msg).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
+                        Ok(Message::Pong(msg)) => {
+                            if let Err(e) = session.ping(&msg).await {
+                                error!("{e}");
+                                break;
+                            }
+                        }
+                        Ok(Message::Close(r)) => {
+                            reason = r;
+                            break;
+                        }
+                        Err(e) => {
                             error!("{e}");
                             break;
                         }
+                        _ => break,
                     }
-                    Ok(Message::Ping(msg)) => {
-                        if let Err(e) = session.pong(&msg).await {
-                            error!("{e}");
-                            break;
-                        }
-                    }
-                    Ok(Message::Pong(msg)) => {
-                        if let Err(e) = session.ping(&msg).await {
-                            error!("{e}");
-                            break;
-                        }
-                    }
-                    Ok(Message::Close(r)) => {
-                        reason = r;
-                        break;
-                    }
-                    Err(e) => {
-                        error!("{e}");
-                        break;
-                    }
-                    _ => break,
                 }
-            };
 
-            scan_interval.tick().await;
-            socket.scan(&mut session).await;
+                _ = scan_interval.tick() => {
+                    socket.scan(&mut session).await;
+                }
 
-            exec_interval.tick().await;
-            if !socket.exec(&mut session).await {
-                break;
+                _ = exec_interval.tick() => {
+                    if !socket.exec(&mut session).await {
+                        break;
+                    }
+                }
             }
         }
 

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -55,7 +55,7 @@ impl MonitorPipelineSocket {
             return true;
         };
         debug!("checking run state for pipeline run with id {run_id}");
-        match pipeline_runs::select_by_id(self.conn.as_ref(), &run_id).await {
+        match pipeline_runs::select_by_id(self.conn.as_ref(), run_id).await {
             Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => false,
             Err(_) => {
                 if let Err(e) = session.text("internal server error").await {

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -5,7 +5,7 @@ use actix_web::{
     rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_ws::{CloseReason, Message, Session, handle};
+use actix_ws::{CloseCode, CloseReason, Message, Session, handle};
 use anyhow::{Result, bail};
 use bld_config::BldConfig;
 use bld_core::scanner::FileScanner;
@@ -106,6 +106,7 @@ pub async fn ws(
                     match msg {
                         Message::Text(txt) => {
                             if let Err(e) = socket.dependencies(&txt).await {
+                                reason = Some(CloseCode::Error.into());
                                 let _ = session.text("internal server error").await.inspect_err(|e| error!("{e}"));
                                 error!("{e}");
                                 break;
@@ -114,6 +115,7 @@ pub async fn ws(
 
                         Message::Ping(msg) => {
                             if let Err(e) = session.pong(&msg).await {
+                                reason = Some(CloseCode::Error.into());
                                 error!("{e}");
                                 break;
                             }

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -63,7 +63,7 @@ impl MonitorPipelineSocket {
         }
     }
 
-    async fn dependencies(&mut self, session: &mut Session, data: &str) -> Result<()> {
+    async fn dependencies(&mut self, data: &str) -> Result<()> {
         let conn = self.conn.clone();
         let data = serde_json::from_str::<MonitInfo>(data)?;
         let run = if data.last {
@@ -74,19 +74,11 @@ impl MonitorPipelineSocket {
             pipeline_runs::select_by_name(conn.as_ref(), &name).await
         } else {
             bail!("file not found");
-        };
-        match run {
-            Ok(run) => {
-                debug!("starting scan for run");
-                self.id.clone_from(&run.id);
-                self.scanner = Some(FileScanner::new(self.config.as_ref(), &run.id));
-                Ok(())
-            }
-            Err(e) => {
-                session.text("internal server error").await?;
-                Err(e)
-            }
-        }
+        }?;
+        debug!("starting scan for run");
+        self.id.clone_from(&run.id);
+        self.scanner = Some(FileScanner::new(self.config.as_ref(), &run.id));
+        Ok(())
     }
 }
 
@@ -113,7 +105,8 @@ pub async fn ws(
                     };
                     match msg {
                         Message::Text(txt) => {
-                            if let Err(e) = socket.dependencies(&mut session, &txt).await {
+                            if let Err(e) = socket.dependencies(&txt).await {
+                                let _ = session.text("internal server error").await.inspect_err(|e| error!("{e}"));
                                 error!("{e}");
                                 break;
                             }

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -1,6 +1,9 @@
 use crate::extractors::User;
 use actix_web::{
-    HttpRequest, Responder, error::ErrorUnauthorized, rt::{spawn, time}, web::{Data, Payload}
+    HttpRequest, Responder,
+    error::ErrorUnauthorized,
+    rt::{spawn, time},
+    web::{Data, Payload},
 };
 use actix_ws::{CloseReason, Message, Session, handle};
 use anyhow::{Result, bail};
@@ -104,33 +107,31 @@ pub async fn ws(
         loop {
             tokio::select! {
                 Some(msg) = msg_stream.next() => {
+                    let Ok(msg) = msg.inspect_err(|e| error!("{e}")) else {
+                        break;
+                    };
                     match msg {
-                        Ok(Message::Text(txt)) => {
+                        Message::Text(txt) => {
                             if let Err(e) = socket.dependencies(&mut session, &txt).await {
                                 error!("{e}");
                                 break;
                             }
                         }
-                        Ok(Message::Ping(msg)) => {
+
+                        Message::Ping(msg) => {
                             if let Err(e) = session.pong(&msg).await {
                                 error!("{e}");
                                 break;
                             }
                         }
-                        Ok(Message::Pong(msg)) => {
-                            if let Err(e) = session.ping(&msg).await {
-                                error!("{e}");
-                                break;
-                            }
-                        }
-                        Ok(Message::Close(r)) => {
+
+                        Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
+
+                        Message::Close(r) => {
                             reason = r;
                             break;
                         }
-                        Err(e) => {
-                            error!("{e}");
-                            break;
-                        }
+
                         _ => break,
                     }
                 }

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -1,12 +1,12 @@
 use crate::extractors::User;
-use actix::prelude::*;
 use actix_web::{
     Error, HttpRequest, HttpResponse,
     error::ErrorUnauthorized,
+    rt::{spawn, time},
     web::{Data, Payload},
 };
-use actix_web_actors::ws;
-use anyhow::{Result, anyhow, bail};
+use actix_ws::{CloseReason, Message, Session, handle};
+use anyhow::{Result, bail};
 use bld_config::BldConfig;
 use bld_core::scanner::FileScanner;
 use bld_models::{
@@ -14,7 +14,7 @@ use bld_models::{
     pipeline_runs::{self, PR_STATE_FAULTED, PR_STATE_FINISHED},
 };
 use bld_utils::sync::IntoArc;
-use futures_util::future::ready;
+use futures::StreamExt;
 use sea_orm::DatabaseConnection;
 use std::{sync::Arc, time::Duration};
 use tracing::{debug, error};
@@ -36,108 +36,55 @@ impl MonitorPipelineSocket {
         }
     }
 
-    fn scan(act: &mut Self, ctx: &mut <Self as Actor>::Context) {
-        let Some(scanner) = act.scanner.as_ref() else {
+    async fn scan(&self, session: &mut Session) {
+        let Some(scanner) = self.scanner.as_ref() else {
             return;
         };
-        let scanner = scanner.clone();
-        let scan_fut = async move { scanner.scan().await }
-            .into_actor(act)
-            .then(|res, _, ctx| {
-                if let Ok(lines) = res {
-                    for line in lines.iter() {
-                        ctx.text(line.to_string());
-                    }
+        if let Ok(lines) = scanner.scan().await {
+            for line in lines.iter() {
+                if let Err(e) = session.text(line.to_string()).await {
+                    error!("{e}");
                 }
-                ready(())
-            });
-        ctx.spawn(scan_fut);
-    }
-
-    fn exec(act: &mut Self, ctx: &mut <Self as Actor>::Context) {
-        let conn = act.conn.clone();
-        let id = act.id.to_owned();
-        let select_fut = async move { pipeline_runs::select_by_id(conn.as_ref(), &id).await }
-            .into_actor(act)
-            .then(|res, _, ctx| match res {
-                Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => {
-                    ctx.stop();
-                    ready(())
-                }
-                Err(_) => {
-                    ctx.text("internal server error");
-                    ctx.stop();
-                    ready(())
-                }
-                _ => ready(()),
-            });
-        ctx.spawn(select_fut);
-    }
-
-    fn dependencies(&mut self, data: String, ctx: &mut <Self as Actor>::Context) {
-        let conn = self.conn.clone();
-        let pipeline_fut = async move {
-            let data = serde_json::from_str::<MonitInfo>(&data)?;
-            let run = if data.last {
-                pipeline_runs::select_last(conn.as_ref()).await
-            } else if let Some(id) = data.id {
-                pipeline_runs::select_by_id(conn.as_ref(), &id).await
-            } else if let Some(name) = data.name {
-                pipeline_runs::select_by_name(conn.as_ref(), &name).await
-            } else {
-                bail!("file not found");
-            };
-            run.map_err(|_| anyhow!("file not found"))
+            }
         }
-        .into_actor(self)
-        .then(|res, act, ctx| match res {
+    }
+
+    async fn exec(&self, session: &mut Session) -> bool {
+        match pipeline_runs::select_by_id(self.conn.as_ref(), &self.id).await {
+            Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => false,
+            Err(_) => {
+                if let Err(e) = session.text("internal server error").await {
+                    error!("{e}");
+                }
+                false
+            }
+            _ => true,
+        }
+    }
+
+    async fn dependencies(&mut self, session: &mut Session, data: &str) -> Result<()> {
+        let conn = self.conn.clone();
+        let data = serde_json::from_str::<MonitInfo>(data)?;
+        let run = if data.last {
+            pipeline_runs::select_last(conn.as_ref()).await
+        } else if let Some(id) = data.id {
+            pipeline_runs::select_by_id(conn.as_ref(), &id).await
+        } else if let Some(name) = data.name {
+            pipeline_runs::select_by_name(conn.as_ref(), &name).await
+        } else {
+            bail!("file not found");
+        };
+        match run {
             Ok(run) => {
                 debug!("starting scan for run");
-                act.id.clone_from(&run.id);
-                act.scanner = Some(FileScanner::new(act.config.as_ref(), &run.id).into_arc());
-                ready(())
+                self.id.clone_from(&run.id);
+                self.scanner = Some(FileScanner::new(self.config.as_ref(), &run.id).into_arc());
+                Ok(())
             }
             Err(e) => {
-                error!("{e}");
-                ctx.text("internal server error");
-                ctx.stop();
-                ready(())
+                session.text("internal server error").await?;
+                Err(e)
             }
-        });
-
-        ctx.spawn(pipeline_fut);
-    }
-}
-
-impl Actor for MonitorPipelineSocket {
-    type Context = ws::WebsocketContext<Self>;
-
-    fn started(&mut self, ctx: &mut Self::Context) {
-        ctx.run_interval(Duration::from_millis(500), |act, ctx| {
-            MonitorPipelineSocket::scan(act, ctx);
-        });
-        ctx.run_interval(Duration::from_secs(1), |act, ctx| {
-            MonitorPipelineSocket::exec(act, ctx);
-        });
-    }
-}
-
-impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MonitorPipelineSocket {
-    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
-        match msg {
-            Ok(ws::Message::Text(txt)) => {
-                debug!("received message {txt}");
-                self.dependencies(txt.to_string(), ctx);
-            }
-            Ok(ws::Message::Ping(msg)) => {
-                ctx.pong(&msg);
-            }
-            Ok(ws::Message::Pong(_)) => {}
-            Ok(ws::Message::Close(reason)) => {
-                ctx.close(reason);
-                ctx.stop();
-            }
-            _ => ctx.stop(),
         }
     }
 }
@@ -145,15 +92,67 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MonitorPipelineSo
 pub async fn ws(
     user: Option<User>,
     req: HttpRequest,
-    stream: Payload,
+    body: Payload,
     conn: Data<DatabaseConnection>,
     config: Data<BldConfig>,
 ) -> Result<HttpResponse, Error> {
     if user.is_none() {
         return Err(ErrorUnauthorized(""));
     }
-    println!("{req:?}");
-    let res = ws::start(MonitorPipelineSocket::new(conn, config), &req, stream);
-    println!("{res:?}");
-    res
+    let mut socket = MonitorPipelineSocket::new(conn, config);
+    let (response, mut session, mut msg_stream) = handle(&req, body)?;
+
+    spawn(async move {
+        let mut reason: Option<CloseReason> = None;
+        let mut scan_interval = time::interval(Duration::from_millis(500));
+        let mut exec_interval = time::interval(Duration::from_millis(500));
+
+        loop {
+            if let Some(msg) = msg_stream.next().await {
+                match msg {
+                    Ok(Message::Text(txt)) => {
+                        if let Err(e) = socket.dependencies(&mut session, &txt).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Ping(msg)) => {
+                        if let Err(e) = session.pong(&msg).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Pong(msg)) => {
+                        if let Err(e) = session.ping(&msg).await {
+                            error!("{e}");
+                            break;
+                        }
+                    }
+                    Ok(Message::Close(r)) => {
+                        reason = r;
+                        break;
+                    }
+                    Err(e) => {
+                        error!("{e}");
+                        break;
+                    }
+                    _ => break,
+                }
+            };
+
+            scan_interval.tick().await;
+            socket.scan(&mut session).await;
+
+            exec_interval.tick().await;
+            if !socket.exec(&mut session).await {
+                break;
+            }
+        }
+
+        if let Err(e) = session.close(reason).await {
+            error!("encountered error while closing websocket session due to {e}");
+        }
+    });
+
+    Ok(response)
 }

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -21,7 +21,7 @@ use tracing::{debug, error};
 const STATE_CHECK_INTERVAL_MS: u64 = 500;
 
 pub struct MonitorPipelineSocket {
-    id: String,
+    id: Option<String>,
     conn: Data<DatabaseConnection>,
     config: Data<BldConfig>,
     scanner: Option<FileScanner>,
@@ -30,7 +30,7 @@ pub struct MonitorPipelineSocket {
 impl MonitorPipelineSocket {
     pub fn new(conn: Data<DatabaseConnection>, config: Data<BldConfig>) -> Self {
         Self {
-            id: String::new(),
+            id: None,
             conn,
             config,
             scanner: None,
@@ -51,7 +51,11 @@ impl MonitorPipelineSocket {
     }
 
     async fn check_state(&self, session: &mut Session) -> bool {
-        match pipeline_runs::select_by_id(self.conn.as_ref(), &self.id).await {
+        let Some(run_id) = self.id.as_ref() else {
+            return true;
+        };
+        debug!("checking run state for pipeline run with id {run_id}");
+        match pipeline_runs::select_by_id(self.conn.as_ref(), &run_id).await {
             Ok(run) if run.state == PR_STATE_FINISHED || run.state == PR_STATE_FAULTED => false,
             Err(_) => {
                 if let Err(e) = session.text("internal server error").await {
@@ -66,18 +70,22 @@ impl MonitorPipelineSocket {
     async fn dependencies(&mut self, data: &str) -> Result<()> {
         let conn = self.conn.clone();
         let data = serde_json::from_str::<MonitInfo>(data)?;
+        debug!("{data:?}");
         let run = if data.last {
+            debug!("fetching the last pipeline run");
             pipeline_runs::select_last(conn.as_ref()).await
         } else if let Some(id) = data.id {
+            debug!("fetching pipeline run by id {id}");
             pipeline_runs::select_by_id(conn.as_ref(), &id).await
         } else if let Some(name) = data.name {
+            debug!("fetching pipeline run by name {name}");
             pipeline_runs::select_by_name(conn.as_ref(), &name).await
         } else {
             bail!("file not found");
         }?;
-        debug!("starting scan for run");
-        self.id.clone_from(&run.id);
+        debug!("starting scan for run with id {}", run.id);
         self.scanner = Some(FileScanner::new(self.config.as_ref(), &run.id));
+        self.id.replace(run.id);
         Ok(())
     }
 }

--- a/crates/bld_server/src/sockets/monit.rs
+++ b/crates/bld_server/src/sockets/monit.rs
@@ -15,10 +15,12 @@ use bld_models::{
 };
 use futures::StreamExt;
 use sea_orm::DatabaseConnection;
-use std::time::Duration;
-use tracing::{debug, error};
+use std::time::{Duration, Instant};
+use tracing::{debug, error, warn};
 
 const STATE_CHECK_INTERVAL_MS: u64 = 500;
+const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
+const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 pub struct MonitorPipelineSocket {
     id: String,
@@ -96,6 +98,8 @@ pub async fn ws(
     spawn(async move {
         let mut reason: Option<CloseReason> = None;
         let mut interval = time::interval(Duration::from_millis(STATE_CHECK_INTERVAL_MS));
+        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
+        let mut last_pong = Instant::now();
 
         loop {
             tokio::select! {
@@ -121,7 +125,11 @@ pub async fn ws(
                             }
                         }
 
-                        Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
+                        Message::Pong(_) => {
+                            last_pong = Instant::now();
+                        }
+
+                        Message::Continuation(_) | Message::Nop => {}
 
                         Message::Close(r) => {
                             reason = r;
@@ -135,6 +143,21 @@ pub async fn ws(
                 _ = interval.tick() => {
                     socket.scan(&mut session).await;
                     if !socket.check_state(&mut session).await {
+                        break;
+                    }
+                }
+
+                _ = hb_interval.tick() => {
+                    if Instant::now().duration_since(last_pong)
+                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
+                    {
+                        warn!("client heartbeat timed out, closing session");
+                        reason = Some(CloseCode::Away.into());
+                        break;
+                    }
+                    if let Err(e) = session.ping(b"").await {
+                        error!("ping failed: {e}");
+                        reason = Some(CloseCode::Error.into());
                         break;
                     }
                 }

--- a/crates/bld_server/src/supervisor/channel.rs
+++ b/crates/bld_server/src/supervisor/channel.rs
@@ -1,14 +1,9 @@
-use actix::{Actor, StreamHandler, io::SinkWrite};
-use actix_codec::Framed;
-use actix_http::ws::Codec;
 use actix_web::rt::spawn;
 use anyhow::{Result, anyhow, bail};
-use awc::BoxedSocket;
 use bld_config::BldConfig;
-use bld_http::WebSocket;
+use bld_core::logger::Logger;
 use bld_models::dtos::ServerMessages;
-use bld_sock::EnqueueClient;
-use futures::stream::StreamExt;
+use bld_sock::{EnqueueClient, EnqueueClientState};
 use std::{env::current_exe, sync::Arc, time::Duration};
 use tokio::{
     process::{Child, Command},
@@ -21,24 +16,22 @@ use tracing::{debug, error};
 const INITIAL_DELAY: u64 = 500;
 const RETRY_DELAY: u64 = 2000;
 
-async fn try_ws_connection(url: &str) -> Result<Framed<BoxedSocket, Codec>> {
+async fn try_ws_connection(url: &str) -> Result<EnqueueClient> {
     // small wait for the supervisor
     sleep(Duration::from_millis(INITIAL_DELAY)).await;
 
     for _ in 0..10 {
         debug!("establishing web socket connection on {}", url);
 
-        let Ok((_, framed)) = WebSocket::new(url)?.request().connect().await.map_err(|e| {
-            error!(
-                "connection to supervisor web socket failed due to {e}, retrying in {RETRY_DELAY}ms"
-            );
-            anyhow!(e.to_string())
-        }) else {
-            sleep(Duration::from_millis(RETRY_DELAY)).await;
-            continue;
-        };
-
-        return Ok(framed);
+        match EnqueueClient::connect(url, Logger::shell()).await {
+            Ok(client) => return Ok(client),
+            Err(e) => {
+                error!(
+                    "connection to supervisor web socket failed due to {e}, retrying in {RETRY_DELAY}ms"
+                );
+                sleep(Duration::from_millis(RETRY_DELAY)).await;
+            }
+        }
     }
 
     bail!("unable to establish connection to supervisor websocket");
@@ -70,34 +63,35 @@ impl SupervisorMessageReceiver {
                 error!("{e}");
                 break 'retry_loop;
             }
-            let framed = try_ws_connection(&url).await?;
-            let (sink, stream) = framed.split();
-            let address = EnqueueClient::create(|ctx| {
-                EnqueueClient::add_stream(stream, ctx);
-                EnqueueClient::new(SinkWrite::new(sink, ctx))
-            });
+            let mut client = try_ws_connection(&url).await?;
 
-            address.send(ServerMessages::Ack).await.inspect_err(|e| {
-                error!("failed to send Ack to supervisor, {e}");
-            })?;
-
-            if let Some(msg) = self.last_message {
-                address.send(msg).await?;
-                self.last_message = None;
+            if let Some(msg) = self.last_message.take() {
+                client.send(&msg).await?;
             }
 
-            while let Some(msg) = self.rx.recv().await {
-                if !address.connected() {
-                    self.kill_inner().await;
-                    self.last_message = Some(msg);
-                    continue 'retry_loop;
+            loop {
+                tokio::select! {
+                    msg = self.rx.recv() => {
+                        let Some(msg) = msg else {
+                            break 'retry_loop;
+                        };
+                        if client.send(&msg).await.is_err() {
+                            self.kill_inner().await;
+                            self.last_message = Some(msg);
+                            continue 'retry_loop;
+                        }
+                    }
+                    state = client.next() => {
+                        if let EnqueueClientState::Completed = state {
+                            self.kill_inner().await;
+                            continue 'retry_loop;
+                        }
+                    }
                 }
-
-                address.send(msg).await?;
             }
-
-            self.kill_inner().await;
         }
+
+        self.kill_inner().await;
 
         Ok(())
     }

--- a/crates/bld_server/src/supervisor/channel.rs
+++ b/crates/bld_server/src/supervisor/channel.rs
@@ -15,6 +15,7 @@ use tracing::{debug, error};
 
 const INITIAL_DELAY: u64 = 500;
 const RETRY_DELAY: u64 = 2000;
+const RESPAWN_DELAY: u64 = 5000;
 
 async fn try_ws_connection(url: &str) -> Result<EnqueueClient> {
     // small wait for the supervisor
@@ -60,13 +61,28 @@ impl SupervisorMessageReceiver {
 
         'retry_loop: loop {
             if let Err(e) = self.spawn_inner() {
-                error!("{e}");
-                break 'retry_loop;
+                error!("failed to spawn supervisor process: {e}, retrying in {RESPAWN_DELAY}ms");
+                sleep(Duration::from_millis(RESPAWN_DELAY)).await;
+                continue 'retry_loop;
             }
-            let mut client = try_ws_connection(&url).await?;
 
-            if let Some(msg) = self.last_message.take() {
-                client.send(&msg).await?;
+            let mut client = match try_ws_connection(&url).await {
+                Ok(client) => client,
+                Err(e) => {
+                    error!("{e}, respawning supervisor in {RESPAWN_DELAY}ms");
+                    self.kill_inner().await;
+                    sleep(Duration::from_millis(RESPAWN_DELAY)).await;
+                    continue 'retry_loop;
+                }
+            };
+
+            if let Some(msg) = self.last_message.take()
+                && client.send(&msg).await.is_err()
+            {
+                self.kill_inner().await;
+                self.last_message = Some(msg);
+                sleep(Duration::from_millis(RESPAWN_DELAY)).await;
+                continue 'retry_loop;
             }
 
             loop {

--- a/crates/bld_sock/Cargo.toml
+++ b/crates/bld_sock/Cargo.toml
@@ -10,7 +10,6 @@ actix = "0.13.5"
 actix-codec = "0.5.2"
 actix-http = "3.11.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
-actix-web-actors = "4.3.0"
 awc = { version = "3.5.1", features = ["rustls"] }
 anyhow = "1.0.93"
 bld_config = { path = "../bld_config" }

--- a/crates/bld_sock/Cargo.toml
+++ b/crates/bld_sock/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 [dependencies]
 actix = "0.13.5"
 actix-codec = "0.5.2"
-actix-http = "3.9.0"
+actix-http = "3.11.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
 actix-web-actors = "4.3.0"
 awc = { version = "3.5.1", features = ["rustls"] }

--- a/crates/bld_sock/Cargo.toml
+++ b/crates/bld_sock/Cargo.toml
@@ -10,6 +10,7 @@ actix = "0.13.5"
 actix-codec = "0.5.2"
 actix-http = "3.11.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
+actix-ws = "0.4.0"
 awc = { version = "3.5.1", features = ["rustls"] }
 anyhow = "1.0.93"
 bld_config = { path = "../bld_config" }
@@ -23,3 +24,5 @@ serde_json = "1.0.132"
 tokio = { version = "1.43.1", features = ["full"] }
 tracing = "0.1.40"
 rustls = "0.20.7"
+bytes = "1.11.1"
+bytestring = "1.5.1"

--- a/crates/bld_sock/Cargo.toml
+++ b/crates/bld_sock/Cargo.toml
@@ -6,23 +6,18 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.13.5"
-actix-codec = "0.5.2"
-actix-http = "3.11.2"
 actix-web = { version = "4.9.0", features = ["rustls"] }
 actix-ws = "0.4.0"
 awc = { version = "3.5.1", features = ["rustls"] }
 anyhow = "1.0.93"
 bld_config = { path = "../bld_config" }
 bld_core = { path = "../bld_core" }
+bld_http = { path = "../bld_http" }
 bld_models = { path = "../bld_models", features = ["all"] }
 bld_utils = { path = "../bld_utils" }
 futures = "0.3.31"
-futures-util = "0.3.31"
-serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.132"
 tokio = { version = "1.43.1", features = ["full"] }
 tracing = "0.1.40"
-rustls = "0.20.7"
 bytes = "1.11.1"
 bytestring = "1.5.1"

--- a/crates/bld_sock/src/clients/enqueue_ws_client.rs
+++ b/crates/bld_sock/src/clients/enqueue_ws_client.rs
@@ -1,61 +1,51 @@
-use actix::io::{SinkWrite, WriteHandler};
-use actix::{Actor, ActorContext, Context, Handler, StreamHandler};
-use actix_codec::Framed;
-use awc::BoxedSocket;
-use awc::error::WsProtocolError;
-use awc::ws::{Codec, Frame, Message};
+use anyhow::Result;
+use awc::ws::Frame;
+use bld_core::logger::Logger;
+use bld_http::WebSock;
 use bld_models::dtos::ServerMessages;
-use futures::stream::SplitSink;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
+
+pub enum EnqueueClientState {
+    Continue,
+    Completed,
+}
 
 pub struct EnqueueClient {
-    writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>,
+    logger: Logger,
+    sock: WebSock,
 }
 
 impl EnqueueClient {
-    pub fn new(writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>) -> Self {
-        Self { writer }
-    }
-}
-
-impl Actor for EnqueueClient {
-    type Context = Context<Self>;
-
-    fn started(&mut self, _ctx: &mut Context<Self>) {
-        debug!("supervisor socket started");
+    pub async fn connect(url: &str, logger: Logger) -> Result<Self> {
+        debug!("establishing web socket connection on {}", url);
+        let mut sock = WebSock::connect(url, None).await?;
+        sock.binary(&ServerMessages::Ack).await?;
+        Ok(Self { logger, sock })
     }
 
-    fn stopped(&mut self, _: &mut Context<Self>) {
-        debug!("supervisor socket stopped");
+    pub async fn send(&mut self, message: &ServerMessages) -> Result<()> {
+        self.sock.binary(message).await
     }
-}
 
-impl Handler<ServerMessages> for EnqueueClient {
-    type Result = ();
-
-    fn handle(&mut self, msg: ServerMessages, _ctx: &mut Self::Context) {
-        if let Ok(bytes) = serde_json::to_vec(&msg) {
-            let _ = self.writer.write(Message::Binary(bytes.into()));
-        }
-    }
-}
-
-impl StreamHandler<Result<Frame, WsProtocolError>> for EnqueueClient {
-    fn handle(&mut self, msg: Result<Frame, WsProtocolError>, ctx: &mut Context<Self>) {
-        match msg {
-            Ok(Frame::Text(bt)) => println!("{}", String::from_utf8_lossy(&bt)),
+    pub async fn next(&mut self) -> EnqueueClientState {
+        match self.sock.next().await {
+            Ok(Frame::Text(bt)) => {
+                let _ = self
+                    .logger
+                    .write_line(String::from_utf8_lossy(&bt).into())
+                    .await
+                    .inspect_err(|e| error!("unable to log line due to {e}"));
+                EnqueueClientState::Continue
+            }
             Ok(Frame::Close(_)) => {
                 info!("web socket connection stopped due to a sent closed frame");
-                ctx.stop();
+                EnqueueClientState::Completed
             }
-            _ => {}
+            Ok(_) => EnqueueClientState::Continue,
+            Err(e) => {
+                error!("{e}");
+                EnqueueClientState::Completed
+            }
         }
     }
-
-    fn finished(&mut self, ctx: &mut Context<Self>) {
-        info!("web socket communication finished");
-        ctx.stop();
-    }
 }
-
-impl WriteHandler<WsProtocolError> for EnqueueClient {}

--- a/crates/bld_sock/src/clients/exec_ws_client.rs
+++ b/crates/bld_sock/src/clients/exec_ws_client.rs
@@ -1,16 +1,12 @@
-use actix::io::{SinkWrite, WriteHandler};
-use actix::{Actor, ActorContext, Context as ActixContext, Handler, StreamHandler};
-use actix_codec::Framed;
-use actix_web::rt::{System, spawn};
+use std::sync::Arc;
+
 use anyhow::Result;
-use awc::BoxedSocket;
-use awc::error::WsProtocolError;
-use awc::ws::{Codec, Frame, Message};
+use awc::ws::Frame;
+use bld_config::BldConfig;
 use bld_core::context::Context;
 use bld_core::logger::Logger;
+use bld_http::WebSock;
 use bld_models::dtos::{ExecClientMessage, ExecServerMessage};
-use futures::stream::SplitSink;
-use std::sync::Arc;
 use tracing::{debug, error};
 
 pub struct ExecClient {
@@ -18,107 +14,81 @@ pub struct ExecClient {
     server: String,
     logger: Arc<Logger>,
     context: Arc<Context>,
-    writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>,
+    sock: WebSock,
 }
 
 impl ExecClient {
-    pub fn new(
+    pub async fn connect(
+        config: Arc<BldConfig>,
         server: String,
         logger: Arc<Logger>,
         context: Arc<Context>,
-        writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let server_config = config.server(&server)?;
+        let auth_path = config.auth_full_path(&server_config.name);
+        let url = format!("{}/v1/ws-exec/", server_config.base_url_ws());
+
+        debug!("establishing web socket connection on {}", url);
+
+        let sock = WebSock::connect(&url, Some(&auth_path)).await?;
+
+        Ok(Self {
             run_id: None,
             server,
             logger,
             context,
-            writer,
-        }
+            sock,
+        })
     }
 
-    fn handle_server_message(&mut self, message: &str) -> Result<()> {
+    pub async fn run(mut self, message: ExecClientMessage) -> Result<()> {
+        debug!("sending message to socket: {:?}", message);
+        self.sock.text(&message).await?;
+
+        loop {
+            let Ok(frame) = self.sock.next().await else {
+                break;
+            };
+            match frame {
+                Frame::Text(bt) => {
+                    let message = String::from_utf8_lossy(&bt[..]);
+                    let _ = self
+                        .handle_server_message(&message)
+                        .await
+                        .map_err(|e| error!("{e}"));
+                }
+                Frame::Close(_) => break,
+                _ => {}
+            }
+        }
+
+        if let Some(run_id) = &self.run_id {
+            let _ = self
+                .context
+                .remove_remote_run(run_id)
+                .await
+                .map_err(|e| error!("{e}"));
+        }
+
+        Ok(())
+    }
+
+    async fn handle_server_message(&mut self, message: &str) -> Result<()> {
         let message: ExecServerMessage = serde_json::from_str(message)?;
 
         match message {
             ExecServerMessage::QueuedRun { run_id } => {
                 self.run_id = Some(run_id.to_owned());
-                let server = self.server.to_owned();
-                let context = self.context.clone();
-
-                spawn(async move {
-                    if let Err(e) = context.add_remote_run(server, run_id).await {
-                        error!("{e}");
-                    }
-                });
+                self.context
+                    .add_remote_run(self.server.to_owned(), run_id)
+                    .await?;
             }
 
             ExecServerMessage::Log { content } => {
-                let logger = self.logger.clone();
-                spawn(async move {
-                    if let Err(e) = logger.write_line(content).await {
-                        error!("{e}");
-                    }
-                });
+                self.logger.write_line(content).await?;
             }
         }
 
         Ok(())
     }
 }
-
-impl Actor for ExecClient {
-    type Context = ActixContext<Self>;
-
-    fn started(&mut self, _ctx: &mut Self::Context) {
-        debug!("exec socket started");
-    }
-
-    fn stopped(&mut self, _ctx: &mut Self::Context) {
-        debug!("exec socket stopped");
-        if let Some(current) = System::try_current() {
-            current.stop();
-        }
-    }
-}
-
-impl Handler<ExecClientMessage> for ExecClient {
-    type Result = ();
-
-    fn handle(&mut self, msg: ExecClientMessage, _ctx: &mut Self::Context) {
-        if let Ok(msg) = serde_json::to_string(&msg) {
-            let _ = self.writer.write(Message::Text(msg.into()));
-        }
-    }
-}
-
-impl StreamHandler<Result<Frame, WsProtocolError>> for ExecClient {
-    fn handle(&mut self, msg: Result<Frame, WsProtocolError>, ctx: &mut Self::Context) {
-        match msg {
-            Ok(Frame::Text(bt)) => {
-                let message = format!("{}", String::from_utf8_lossy(&bt[..]));
-                let _ = self
-                    .handle_server_message(&message)
-                    .map_err(|e| error!("{e}"));
-            }
-            Ok(Frame::Close(_)) => ctx.stop(),
-            _ => {}
-        }
-    }
-
-    fn finished(&mut self, ctx: &mut Self::Context) {
-        if let Some(run_id) = &self.run_id {
-            let context = self.context.clone();
-            let run_id = run_id.clone();
-            spawn(async move {
-                let _ = context
-                    .remove_remote_run(&run_id)
-                    .await
-                    .map_err(|e| error!("{e}"));
-            });
-        }
-        ctx.stop();
-    }
-}
-
-impl WriteHandler<WsProtocolError> for ExecClient {}

--- a/crates/bld_sock/src/clients/login_ws_client.rs
+++ b/crates/bld_sock/src/clients/login_ws_client.rs
@@ -1,59 +1,80 @@
 use std::{
     fmt::Write,
     process::{ExitStatus, Stdio},
-    sync::Arc,
 };
 
-use actix::{
-    Actor, ActorContext, ActorFutureExt, AsyncContext, Context, Handler, StreamHandler, System,
-    fut::WrapFuture,
-    io::{SinkWrite, WriteHandler},
-};
-use actix_codec::Framed;
-use anyhow::Result;
-use awc::{
-    BoxedSocket,
-    error::WsProtocolError,
-    ws::{Codec, Frame, Message},
-};
+use anyhow::{Result, bail};
+use awc::ws::Frame;
 use bld_config::{BldConfig, OSname, os_name};
+use bld_core::logger::Logger;
+use bld_http::WebSock;
 use bld_models::dtos::{LoginClientMessage, LoginServerMessage};
 use bld_utils::fs::write_tokens;
-use futures::stream::SplitSink;
-use futures_util::future::ready;
 use tokio::process::Command;
 use tracing::{debug, error};
 
 pub struct LoginClient {
-    config: Arc<BldConfig>,
+    config: BldConfig,
+    logger: Logger,
     server: String,
-    writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>,
+    sock: WebSock,
 }
 
 impl LoginClient {
-    pub fn new(
-        config: Arc<BldConfig>,
-        server: String,
-        writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>,
-    ) -> Self {
-        Self {
+    pub async fn connect(config: BldConfig, logger: Logger, server: String) -> Result<Self> {
+        let server_config = config.server(&server)?;
+        let auth_path = config.auth_full_path(&server_config.name);
+        let url = format!("{}/v1/ws-login/", server_config.base_url_ws());
+
+        debug!("establishing web socket connection on {}", url);
+
+        let sock = WebSock::connect(&url, Some(&auth_path)).await?;
+
+        Ok(Self {
             config,
+            logger,
             server,
-            writer,
-        }
+            sock,
+        })
     }
 
-    fn handle_server_message(
-        &mut self,
-        message: &str,
-        ctx: &mut <Self as Actor>::Context,
-    ) -> Result<()> {
-        let message: LoginServerMessage = serde_json::from_str(message)?;
+    pub async fn run(mut self) -> Result<()> {
+        self.sock.text(&LoginClientMessage::Init).await?;
+
+        while let Ok(frame) = self.sock.next().await {
+            match frame {
+                Frame::Text(bt) => {
+                    debug!("received text message from server");
+                    let message = String::from_utf8_lossy(&bt[..]);
+                    if self.handle_server_message(&message).await? {
+                        break;
+                    }
+                }
+                Frame::Close(_) => {
+                    debug!("received close message from server");
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_server_message(&self, message: &str) -> Result<bool> {
+        let Ok(message) = serde_json::from_str::<LoginServerMessage>(message)
+            .inspect_err(|e| error!("unable to parse server message, {e}"))
+        else {
+            return Ok(false);
+        };
+
         match message {
             LoginServerMessage::AuthorizationUrl(url) => {
-                debug!("received message to open url for the login process to begin");
+                debug!("Received message to open url for the login process to begin");
                 debug!("Opening browser with url: {url}");
-                println!("Opening a new browser tab to start the login process.");
+                self.logger
+                    .write_line("Opening a new browser tab to start the login process.".to_string())
+                    .await?;
 
                 let (command, args) = match os_name() {
                     OSname::Linux => ("xdg-open", vec![url.as_str()]),
@@ -65,90 +86,44 @@ impl LoginClient {
                 command.stdout(Stdio::null());
                 command.stderr(Stdio::null());
 
-                let status_fut = command.status().into_actor(self).then(move |res, _, _| {
-                    let success = res.as_ref().map(ExitStatus::success).unwrap_or_default();
-                    debug!("browser process was closed with exit status: {res:?}");
-                    if !success {
-                        let mut message = String::new();
-                        let _ = writeln!(
-                            message,
-                            "Couldn't open the browser, please use the below url in order to login:"
-                        );
-                        let _ = write!(message, "{url}");
-                        println!("{message}");
-                    }
-                    ready(())
-                });
-                ctx.spawn(status_fut);
+                let success = command
+                    .status()
+                    .await
+                    .as_ref()
+                    .map(ExitStatus::success)
+                    .unwrap_or_default();
+                if !success {
+                    let mut message = String::new();
+                    let _ = writeln!(
+                        message,
+                        "Couldn't open the browser, please use the below url in order to login:"
+                    );
+                    let _ = write!(message, "{url}");
+                    self.logger.write_line(message).await?;
+                }
+                Ok(false)
             }
 
             LoginServerMessage::Completed(tokens) => {
                 debug!("login process completed writing tokens to disk");
                 let auth_path = self.config.auth_full_path(&self.server);
-                let write_fut = async move { write_tokens(&auth_path, tokens).await }
-                    .into_actor(self)
-                    .then(|res, _, ctx| {
-                        if let Err(e) = res {
-                            error!("unable to write tokens to disk due to: {e}");
-                            println!("Login failed, {e}");
-                        } else {
-                            debug!("wrote tokens to disk successfully");
-                            println!("Login completed successfully!");
-                        }
-                        ctx.stop();
-                        ready(())
-                    });
-
-                ctx.spawn(write_fut);
+                if let Err(e) = write_tokens(&auth_path, tokens).await {
+                    error!("unable to write tokens to disk due to: {e}");
+                    println!("Login failed, {e}");
+                    bail!("login failed, {e}");
+                }
+                debug!("wrote tokens to disk successfully");
+                self.logger
+                    .write_line("Login completed successfully!".to_string())
+                    .await?;
+                Ok(true)
             }
 
             LoginServerMessage::Failed(reason) => {
-                println!("Login failed, {reason}");
-                ctx.stop();
+                let message = format!("Login failed, {reason}");
+                self.logger.write_line(message.clone()).await?;
+                bail!(message)
             }
         }
-        Ok(())
     }
 }
-
-impl Actor for LoginClient {
-    type Context = Context<Self>;
-
-    fn stopped(&mut self, _ctx: &mut Self::Context) {
-        debug!("web socket connection stopped");
-        if let Some(system) = System::try_current() {
-            system.stop();
-        }
-    }
-}
-
-impl Handler<LoginClientMessage> for LoginClient {
-    type Result = ();
-
-    fn handle(&mut self, msg: LoginClientMessage, _ctx: &mut Self::Context) {
-        if let Ok(msg) = serde_json::to_string(&msg) {
-            let _ = self.writer.write(Message::Text(msg.into()));
-        }
-    }
-}
-
-impl StreamHandler<Result<Frame, WsProtocolError>> for LoginClient {
-    fn handle(&mut self, item: Result<Frame, WsProtocolError>, ctx: &mut Self::Context) {
-        match item {
-            Ok(Frame::Text(bt)) => {
-                debug!("received test message from server");
-                let message = String::from_utf8_lossy(&bt[..]);
-                let _ = self
-                    .handle_server_message(&message, ctx)
-                    .map_err(|e| error!("{e}"));
-            }
-            Ok(Frame::Close(_)) => {
-                debug!("received close message from server");
-                ctx.stop();
-            }
-            _ => {}
-        }
-    }
-}
-
-impl WriteHandler<WsProtocolError> for LoginClient {}

--- a/crates/bld_sock/src/clients/monit_ws_client.rs
+++ b/crates/bld_sock/src/clients/monit_ws_client.rs
@@ -1,65 +1,42 @@
-use actix::io::{SinkWrite, WriteHandler};
-use actix::{Actor, ActorContext, Context, Handler, StreamHandler, System};
-use actix_codec::Framed;
-use awc::BoxedSocket;
-use awc::error::WsProtocolError;
-use awc::ws::{Codec, Frame, Message};
+use anyhow::Result;
+use awc::ws::Frame;
+use bld_config::BldConfig;
+use bld_core::logger::Logger;
+use bld_http::WebSock;
 use bld_models::dtos::MonitInfo;
-use futures::stream::SplitSink;
-use tracing::{debug, error};
+use tracing::debug;
 
 pub struct MonitClient {
-    writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>,
+    logger: Logger,
+    sock: WebSock,
 }
 
 impl MonitClient {
-    pub fn new(writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>) -> Self {
-        Self { writer }
-    }
-}
-
-impl Actor for MonitClient {
-    type Context = Context<Self>;
-
-    fn started(&mut self, _ctx: &mut Context<Self>) {
-        debug!("monit socket started");
+    pub async fn connect(config: BldConfig, logger: Logger, server: String) -> Result<Self> {
+        let server_config = config.server(&server)?;
+        let auth_path = config.auth_full_path(&server_config.name);
+        let url = format!("{}/v1/ws-monit/", server_config.base_url_ws());
+        debug!("establishing web socket connection on {}", url);
+        let sock = WebSock::connect(&url, Some(&auth_path)).await?;
+        Ok(Self { logger, sock })
     }
 
-    fn stopped(&mut self, _ctx: &mut Context<Self>) {
-        debug!("monit socket stoppped");
-        if let Some(sys) = System::try_current() {
-            sys.stop();
+    pub async fn run(mut self, info: MonitInfo) -> Result<()> {
+        debug!("sending monit info to socket");
+        self.sock.text(&info).await?;
+
+        while let Ok(frame) = self.sock.next().await {
+            match frame {
+                Frame::Text(bt) => {
+                    self.logger
+                        .write_line(String::from_utf8_lossy(&bt).into())
+                        .await?;
+                }
+                Frame::Close(_) => break,
+                _ => {}
+            }
         }
+
+        Ok(())
     }
 }
-
-impl Handler<MonitInfo> for MonitClient {
-    type Result = ();
-
-    fn handle(&mut self, msg: MonitInfo, ctx: &mut Self::Context) {
-        let Ok(text) = serde_json::to_string(&msg) else {
-            return;
-        };
-        debug!("sending data {text} to socket");
-        if self.writer.write(Message::Text(text.into())).is_err() {
-            error!("encountered error while sending data to socket");
-            ctx.stop();
-        }
-    }
-}
-
-impl StreamHandler<Result<Frame, WsProtocolError>> for MonitClient {
-    fn handle(&mut self, msg: Result<Frame, WsProtocolError>, ctx: &mut Context<Self>) {
-        match msg {
-            Ok(Frame::Text(bt)) => println!("{}", String::from_utf8_lossy(&bt)),
-            Ok(Frame::Close(_)) => ctx.stop(),
-            _ => {}
-        }
-    }
-
-    fn finished(&mut self, ctx: &mut Context<Self>) {
-        ctx.stop();
-    }
-}
-
-impl WriteHandler<WsProtocolError> for MonitClient {}

--- a/crates/bld_sock/src/clients/worker_ws_client.rs
+++ b/crates/bld_sock/src/clients/worker_ws_client.rs
@@ -31,7 +31,12 @@ impl WorkerClient {
 
         loop {
             tokio::select! {
-                Some(msg) = worker_rx.recv() => {
+                msg = worker_rx.recv() => {
+                    // a closed channel means the runner is done, exit instead of
+                    // keeping the process alive until the supervisor closes the socket
+                    let Some(msg) = msg else {
+                        break;
+                    };
                     debug!("sending message to supervisor {:?}", msg);
                     if self.sock.binary(&msg).await.is_err() {
                         break;

--- a/crates/bld_sock/src/clients/worker_ws_client.rs
+++ b/crates/bld_sock/src/clients/worker_ws_client.rs
@@ -1,60 +1,58 @@
-use actix::io::{SinkWrite, WriteHandler};
-use actix::{Actor, ActorContext, Context, Handler, StreamHandler, System};
-use actix_codec::Framed;
-use awc::BoxedSocket;
-use awc::error::WsProtocolError;
-use awc::ws::{Codec, Frame, Message};
+use anyhow::Result;
+use awc::ws::Frame;
+use bld_config::BldConfig;
+use bld_core::logger::Logger;
+use bld_http::WebSock;
 use bld_models::dtos::WorkerMessages;
-use futures::stream::SplitSink;
+use std::sync::Arc;
+use tokio::sync::mpsc::Receiver;
 use tracing::debug;
 
 pub struct WorkerClient {
-    writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>,
+    logger: Logger,
+    sock: WebSock,
 }
 
 impl WorkerClient {
-    pub fn new(writer: SinkWrite<Message, SplitSink<Framed<BoxedSocket, Codec>, Message>>) -> Self {
-        Self { writer }
-    }
-}
-
-impl Actor for WorkerClient {
-    type Context = Context<Self>;
-
-    fn started(&mut self, _ctx: &mut Context<Self>) {
-        debug!("supervisor socket started");
+    pub async fn connect(config: Arc<BldConfig>, logger: Logger) -> Result<Self> {
+        let url = format!("{}/v1/ws-worker/", config.local.supervisor.base_url_ws());
+        debug!("establishing web socket connection on {}", url);
+        let sock = WebSock::connect(&url, None).await?;
+        Ok(Self { logger, sock })
     }
 
-    fn stopped(&mut self, _ctx: &mut Context<Self>) {
-        debug!("supervisor socket stopped");
-        if let Some(sys) = System::try_current() {
-            sys.stop();
+    pub async fn run(mut self, mut worker_rx: Receiver<WorkerMessages>) -> Result<()> {
+        self.sock.binary(&WorkerMessages::Ack).await?;
+        self.sock
+            .binary(&WorkerMessages::WhoAmI {
+                pid: std::process::id(),
+            })
+            .await?;
+
+        loop {
+            tokio::select! {
+                Some(msg) = worker_rx.recv() => {
+                    debug!("sending message to supervisor {:?}", msg);
+                    if self.sock.binary(&msg).await.is_err() {
+                        break;
+                    }
+                }
+                res = self.sock.next() => {
+                    let Ok(frame) = res else {
+                        break;
+                    };
+                    match frame {
+                        Frame::Text(bt) => {
+                            let message = format!("{}", String::from_utf8_lossy(&bt));
+                            self.logger.write_line(message).await?;
+                        }
+                        Frame::Close(_) => break,
+                        _ => {}
+                    }
+                }
+            }
         }
+
+        Ok(())
     }
 }
-
-impl Handler<WorkerMessages> for WorkerClient {
-    type Result = ();
-
-    fn handle(&mut self, msg: WorkerMessages, _ctx: &mut Self::Context) {
-        if let Ok(bytes) = serde_json::to_vec(&msg) {
-            let _ = self.writer.write(Message::Binary(bytes.into()));
-        }
-    }
-}
-
-impl StreamHandler<Result<Frame, WsProtocolError>> for WorkerClient {
-    fn handle(&mut self, msg: Result<Frame, WsProtocolError>, ctx: &mut Context<Self>) {
-        match msg {
-            Ok(Frame::Text(bt)) => println!("{}", String::from_utf8_lossy(&bt)),
-            Ok(Frame::Close(_)) => ctx.stop(),
-            _ => {}
-        }
-    }
-
-    fn finished(&mut self, ctx: &mut Context<Self>) {
-        ctx.stop();
-    }
-}
-
-impl WriteHandler<WsProtocolError> for WorkerClient {}

--- a/crates/bld_sock/src/lib.rs
+++ b/crates/bld_sock/src/lib.rs
@@ -1,3 +1,4 @@
 mod clients;
+pub mod session;
 
 pub use clients::*;

--- a/crates/bld_sock/src/session.rs
+++ b/crates/bld_sock/src/session.rs
@@ -1,0 +1,117 @@
+use std::time::Duration;
+
+use actix_web::{HttpRequest, HttpResponse, Result, web::Payload};
+use actix_ws::{CloseCode, CloseReason, Message, MessageStream, Session};
+use bytes::Bytes;
+use bytestring::ByteString;
+use futures::StreamExt;
+use tokio::time::{self, Instant, Interval};
+use tracing::{debug, error, warn};
+
+const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
+const CLIENT_TIMEOUT_MS: u64 = 15_000;
+
+pub enum WebSocketMessage {
+    Text(ByteString),
+    Binary(Bytes),
+    Continue,
+    Completed,
+}
+
+pub struct WebSocketHandler {
+    session: Session,
+    stream: MessageStream,
+    term_reason: Option<CloseReason>,
+    last_pong: Instant,
+    hb_interval: Interval,
+}
+
+impl WebSocketHandler {
+    pub fn new(session: Session, stream: MessageStream) -> Self {
+        Self {
+            session,
+            stream,
+            term_reason: None,
+            last_pong: Instant::now(),
+            hb_interval: time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS)),
+        }
+    }
+
+    pub fn session(&mut self) -> &mut Session {
+        &mut self.session
+    }
+
+    pub fn error(&mut self) {
+        self.term_reason = Some(CloseCode::Error.into());
+    }
+
+    pub async fn next(&mut self) -> WebSocketMessage {
+        tokio::select! {
+            Some(msg) = self.stream.next() => {
+                let Ok(message) = msg.inspect_err(|e| error!("{e}")) else {
+                    self.error();
+                    return WebSocketMessage::Completed;
+                };
+                match message {
+                    Message::Text(txt) => WebSocketMessage::Text(txt),
+
+                    Message::Binary(data) => WebSocketMessage::Binary(data),
+
+                    Message::Ping(msg) => {
+                        if let Err(e) = self.session.pong(&msg).await {
+                            error!("{e}");
+                            self.error();
+                            WebSocketMessage::Completed
+                        } else {
+                            WebSocketMessage::Continue
+                        }
+                    }
+
+                    Message::Pong(_) => {
+                        self.last_pong = Instant::now();
+                        WebSocketMessage::Continue
+                    }
+
+                    Message::Continuation(_) | Message::Nop => WebSocketMessage::Continue,
+
+                    Message::Close(reason) => {
+                        self.term_reason = reason;
+                        WebSocketMessage::Completed
+                    }
+                }
+            }
+
+            _ = self.hb_interval.tick() => {
+                if Instant::now().duration_since(self.last_pong)
+                    > Duration::from_millis(CLIENT_TIMEOUT_MS)
+                {
+                    self.error();
+                    warn!("client heartbeat timed out, closing session");
+                    return WebSocketMessage::Completed;
+                }
+                if let Err(e) = self.session.ping(b"").await {
+                    self.error();
+                    error!("ping failed: {e}");
+                    return WebSocketMessage::Completed;
+                }
+                WebSocketMessage::Continue
+            }
+        }
+    }
+
+    pub async fn cleanup(self) {
+        let _ = self
+            .session
+            .close(self.term_reason)
+            .await
+            .inspect(|_| debug!("closed session successfully"))
+            .inspect_err(|e| {
+                error!("encountered error while closing websocket session due to {e}")
+            });
+    }
+}
+
+pub fn handle(req: &HttpRequest, body: Payload) -> Result<(HttpResponse, WebSocketHandler)> {
+    let (response, session, msg_stream) = actix_ws::handle(req, body)?;
+    Ok((response, WebSocketHandler::new(session, msg_stream)))
+}

--- a/crates/bld_sock/src/session.rs
+++ b/crates/bld_sock/src/session.rs
@@ -67,9 +67,15 @@ impl WebSocketHandler {
                         }
                     }
 
-                    Message::Pong(_) => {
+                    Message::Pong(msg) => {
                         self.last_pong = Instant::now();
-                        WebSocketMessage::Continue
+                        if let Err(e) = self.session.ping(&msg).await {
+                            error!("{e}");
+                            self.error();
+                            WebSocketMessage::Completed
+                        } else {
+                            WebSocketMessage::Continue
+                        }
                     }
 
                     Message::Continuation(_) | Message::Nop => WebSocketMessage::Continue,

--- a/crates/bld_sock/src/session.rs
+++ b/crates/bld_sock/src/session.rs
@@ -67,15 +67,9 @@ impl WebSocketHandler {
                         }
                     }
 
-                    Message::Pong(msg) => {
+                    Message::Pong(_) => {
                         self.last_pong = Instant::now();
-                        if let Err(e) = self.session.ping(&msg).await {
-                            error!("{e}");
-                            self.error();
-                            WebSocketMessage::Completed
-                        } else {
-                            WebSocketMessage::Continue
-                        }
+                        WebSocketMessage::Continue
                     }
 
                     Message::Continuation(_) | Message::Nop => WebSocketMessage::Continue,

--- a/crates/bld_sock/src/session.rs
+++ b/crates/bld_sock/src/session.rs
@@ -5,7 +5,7 @@ use actix_ws::{CloseCode, CloseReason, Message, MessageStream, Session};
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures::StreamExt;
-use tokio::time::{self, Instant, Interval};
+use tokio::time::{self, Instant, Interval, MissedTickBehavior};
 use tracing::{debug, error, warn};
 
 const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
@@ -28,12 +28,14 @@ pub struct WebSocketHandler {
 
 impl WebSocketHandler {
     pub fn new(session: Session, stream: MessageStream) -> Self {
+        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
+        hb_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {
             session,
             stream,
             term_reason: None,
             last_pong: Instant::now(),
-            hb_interval: time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS)),
+            hb_interval,
         }
     }
 
@@ -47,11 +49,15 @@ impl WebSocketHandler {
 
     pub async fn next(&mut self) -> WebSocketMessage {
         tokio::select! {
+            biased;
+
             Some(msg) = self.stream.next() => {
                 let Ok(message) = msg.inspect_err(|e| error!("{e}")) else {
                     self.error();
                     return WebSocketMessage::Completed;
                 };
+                // any inbound frame proves the peer is alive
+                self.last_pong = Instant::now();
                 match message {
                     Message::Text(txt) => WebSocketMessage::Text(txt),
 
@@ -67,10 +73,7 @@ impl WebSocketHandler {
                         }
                     }
 
-                    Message::Pong(_) => {
-                        self.last_pong = Instant::now();
-                        WebSocketMessage::Continue
-                    }
+                    Message::Pong(_) => WebSocketMessage::Continue,
 
                     Message::Continuation(_) | Message::Nop => WebSocketMessage::Continue,
 

--- a/crates/bld_supervisor/Cargo.toml
+++ b/crates/bld_supervisor/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.13.5"
-actix-codec = "0.5.2"
-actix-http = "3.12.1"
 actix-web = { version = "4.9.0", features = ["rustls"] }
 actix-ws = "0.4.0"
 anyhow = "1.0.93"

--- a/crates/bld_supervisor/Cargo.toml
+++ b/crates/bld_supervisor/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.93"
 bollard = { version = "0.16.1", features = ["ssl"] }
 bld_config = { path = "../bld_config" }
 bld_core = { path = "../bld_core" }
+bld_sock = { path = "../bld_sock" }
 bld_models = { path = "../bld_models", features = ["all"] }
 bld_http = { path = "../bld_http" }
 bld_utils = { path = "../bld_utils" }

--- a/crates/bld_supervisor/Cargo.toml
+++ b/crates/bld_supervisor/Cargo.toml
@@ -10,6 +10,7 @@ actix = "0.13.5"
 actix-codec = "0.5.2"
 actix-http = "3.12.1"
 actix-web = { version = "4.9.0", features = ["rustls"] }
+actix-ws = "0.4.0"
 anyhow = "1.0.93"
 bollard = { version = "0.16.1", features = ["ssl"] }
 bld_config = { path = "../bld_config" }
@@ -26,4 +27,3 @@ tokio = { version = "1.43.1", features = ["full"] }
 tracing = "0.1.40"
 uuid = { version = "1.11.0", features = ["v4"] }
 rustls = "0.20.7"
-actix-ws = "0.4.0"

--- a/crates/bld_supervisor/Cargo.toml
+++ b/crates/bld_supervisor/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2024"
 [dependencies]
 actix = "0.13.5"
 actix-codec = "0.5.2"
-actix-http = "3.9.0"
+actix-http = "3.12.1"
 actix-web = { version = "4.9.0", features = ["rustls"] }
-actix-web-actors = "4.3.0"
 anyhow = "1.0.93"
 bollard = { version = "0.16.1", features = ["ssl"] }
 bld_config = { path = "../bld_config" }
@@ -27,3 +26,4 @@ tokio = { version = "1.43.1", features = ["full"] }
 tracing = "0.1.40"
 uuid = { version = "1.11.0", features = ["v4"] }
 rustls = "0.20.7"
+actix-ws = "0.4.0"

--- a/crates/bld_supervisor/src/sockets/mod.rs
+++ b/crates/bld_supervisor/src/sockets/mod.rs
@@ -1,5 +1,2 @@
-mod server;
-mod worker;
-
-pub use server::*;
-pub use worker::*;
+pub mod server;
+pub mod worker;

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -1,21 +1,15 @@
 use crate::queues::WorkerQueueSender;
-use actix_http::ws::Message;
 use actix_web::{
     HttpRequest, Responder,
-    rt::time,
     web::{self, Bytes, Data},
 };
-use actix_ws::{CloseCode, CloseReason};
 use anyhow::Result;
 use bld_core::workers::Worker;
 use bld_models::dtos::ServerMessages;
+use bld_sock::session::{self, WebSocketMessage};
 use std::env::current_exe;
-use std::time::{Duration, Instant};
 use tokio::process::Command;
-use tracing::{debug, error, info, warn};
-
-const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
-const CLIENT_TIMEOUT_MS: u64 = 15_000;
+use tracing::{debug, error, info};
 
 async fn handle_message(worker_queue_tx: &Data<WorkerQueueSender>, bytes: &Bytes) -> Result<()> {
     let msg: ServerMessages = serde_json::from_slice(&bytes[..])?;
@@ -75,73 +69,29 @@ pub async fn ws(
     body: web::Payload,
     worker_queue_tx: Data<WorkerQueueSender>,
 ) -> actix_web::Result<impl Responder> {
-    let (response, mut session, mut msg_stream) = actix_ws::handle(&req, body)?;
+    let (response, mut handler) = session::handle(&req, body)?;
 
     actix_web::rt::spawn(async move {
-        let mut reason: Option<CloseReason> = None;
-        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
-        let mut last_pong = Instant::now();
-
         loop {
-            tokio::select! {
-                msg = msg_stream.recv() => {
-                    let Some(Ok(message)) = msg else { break; };
-                    match message {
-                        Message::Binary(bytes) => {
-                            debug!("received binary message from server");
-                            if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
-                                reason = Some(CloseCode::Error.into());
-                                let _ = session
-                                    .text("internal server error")
-                                    .await
-                                    .inspect_err(|e| error!("{e}"));
-                                error!("handling message error. {e}");
-                            }
-                        }
-
-                        Message::Ping(msg) => {
-                            if let Err(e) = session.pong(&msg).await {
-                                reason = Some(CloseCode::Error.into());
-                                error!("{e}");
-                                break;
-                            }
-                        }
-
-                        Message::Pong(_) => {
-                            last_pong = Instant::now();
-                        }
-
-                        Message::Continuation(_) | Message::Nop => {}
-
-                        Message::Close(r) => {
-                            reason = r;
-                            break;
-                        }
-
-                        _ => break,
+            match handler.next().await {
+                WebSocketMessage::Binary(bytes) => {
+                    debug!("received binary message from server");
+                    if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
+                        let session = handler.session();
+                        let _ = session
+                            .text("internal server error")
+                            .await
+                            .inspect_err(|e| error!("{e}"));
+                        error!("handling message error. {e}");
+                        handler.error();
                     }
                 }
-
-                _ = hb_interval.tick() => {
-                    if Instant::now().duration_since(last_pong)
-                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
-                    {
-                        warn!("client heartbeat timed out, closing session");
-                        reason = Some(CloseCode::Away.into());
-                        break;
-                    }
-                    if let Err(e) = session.ping(b"").await {
-                        error!("ping failed: {e}");
-                        reason = Some(CloseCode::Error.into());
-                        break;
-                    }
-                }
+                WebSocketMessage::Continue => {}
+                _ => break,
             }
         }
 
-        if let Err(e) = session.close(reason).await {
-            error!("encountered error while closing websocket session due to {e}");
-        }
+        handler.cleanup().await;
     });
 
     Ok(response)

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -82,20 +82,22 @@ pub async fn ws(
                         error!("handling message error. {e}");
                     }
                 }
+
                 Message::Ping(msg) => {
                     if let Err(e) = session.pong(&msg).await {
                         error!("{e}");
                         break;
                     }
                 }
-                Message::Pong(_) => {}
+
+                Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
+
                 Message::Close(r) => {
                     reason = r;
                     break;
                 }
-                _ => {
-                    break;
-                }
+
+                _ => break,
             }
         }
 

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -1,141 +1,108 @@
 use crate::queues::WorkerQueueSender;
-use actix::prelude::*;
+use actix_http::ws::Message;
 use actix_web::{
-    Error, HttpRequest, HttpResponse,
-    web::{Bytes, Data, Payload},
+    HttpRequest, Responder,
+    web::{self, Bytes, Data},
 };
-use actix_web_actors::ws;
+use actix_ws::CloseReason;
 use anyhow::Result;
 use bld_core::workers::Worker;
 use bld_models::dtos::ServerMessages;
-use futures_util::future::ready;
 use std::env::current_exe;
 use tokio::process::Command;
 use tracing::{debug, error, info};
 
-pub struct ServerSocket {
-    worker_queue_tx: Data<WorkerQueueSender>,
-}
+async fn handle_message(worker_queue_tx: &Data<WorkerQueueSender>, bytes: &Bytes) -> Result<()> {
+    let msg: ServerMessages = serde_json::from_slice(&bytes[..])?;
+    match msg {
+        ServerMessages::Ack => info!("a new server connection was acknowledged"),
 
-impl ServerSocket {
-    pub fn new(worker_queue_tx: Data<WorkerQueueSender>) -> Self {
-        Self { worker_queue_tx }
-    }
-
-    fn handle_message(&self, ctx: &mut <Self as Actor>::Context, bytes: &Bytes) -> Result<()> {
-        let msg: ServerMessages = serde_json::from_slice(&bytes[..])?;
-        match msg {
-            ServerMessages::Ack => info!("a new server connection was acknowledged"),
-
-            ServerMessages::Enqueue {
-                pipeline,
-                run_id,
-                inputs,
-                env,
-            } => {
-                info!("server sent an enqueue message for pipeline: {pipeline}");
-                let exe = current_exe().map_err(|e| {
-                    error!("could not get the current executable. {e}");
-                    e
-                })?;
-                let mut command = Command::new(exe);
-                command.arg("worker");
-                command.arg("--pipeline");
-                command.arg(&pipeline);
-                command.arg("--run-id");
-                command.arg(&run_id);
-                if let Some(inputs) = inputs {
-                    for entry in inputs {
-                        command.arg("--input");
-                        command.arg(entry);
-                    }
+        ServerMessages::Enqueue {
+            pipeline,
+            run_id,
+            inputs,
+            env,
+        } => {
+            info!("server sent an enqueue message for pipeline: {pipeline}");
+            let exe = current_exe().map_err(|e| {
+                error!("could not get the current executable. {e}");
+                e
+            })?;
+            let mut command = Command::new(exe);
+            command.arg("worker");
+            command.arg("--pipeline");
+            command.arg(&pipeline);
+            command.arg("--run-id");
+            command.arg(&run_id);
+            if let Some(inputs) = inputs {
+                for entry in inputs {
+                    command.arg("--input");
+                    command.arg(entry);
                 }
-                if let Some(env) = env {
-                    for entry in env {
-                        command.arg("--environment");
-                        command.arg(entry);
-                    }
+            }
+            if let Some(env) = env {
+                for entry in env {
+                    command.arg("--environment");
+                    command.arg(entry);
                 }
-
-                let tx = self.worker_queue_tx.clone();
-
-                let success_msg = format!("worker for pipeline: {pipeline} has been queued");
-                let worker = Box::new(Worker::new(run_id, command));
-                let enqueque_fut = async move { tx.enqueue(worker).await }
-                    .into_actor(self)
-                    .then(move |res, _, _| {
-                        match res {
-                            Ok(_) => info!(success_msg),
-                            Err(e) => error!("{e}"),
-                        }
-                        ready(())
-                    });
-
-                ctx.spawn(enqueque_fut);
             }
 
-            ServerMessages::Stop { run_id } => {
-                info!("server sent a stop message for run_id: {run_id}");
-
-                let tx = self.worker_queue_tx.clone();
-
-                let success_msg = format!("stop signal sent to worker for run_id: {run_id}");
-                let stop_fut = async move { tx.stop(&run_id).await }.into_actor(self).then(
-                    move |res, _, _| {
-                        match res {
-                            Ok(_) => info!(success_msg),
-                            Err(e) => error!("{e}"),
-                        }
-                        ready(())
-                    },
-                );
-
-                ctx.spawn(stop_fut);
-            }
+            let worker = Box::new(Worker::new(run_id, command));
+            worker_queue_tx
+                .enqueue(worker)
+                .await
+                .inspect(|_| info!("worker for pipeline: {pipeline} has been queued"))?;
         }
-        Ok(())
-    }
-}
 
-impl Actor for ServerSocket {
-    type Context = ws::WebsocketContext<Self>;
-
-    fn started(&mut self, _ctx: &mut Self::Context) {
-        debug!("queue socket started");
-    }
-
-    fn stopped(&mut self, _: &mut Self::Context) {
-        info!("server connection stopped");
-    }
-}
-
-impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for ServerSocket {
-    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
-        match msg {
-            Ok(ws::Message::Binary(bytes)) => {
-                debug!("received binary message from server");
-                if let Err(e) = self.handle_message(ctx, &bytes) {
-                    error!("handling message error. {e}");
-                }
-            }
-            Ok(ws::Message::Ping(msg)) => {
-                ctx.pong(&msg);
-            }
-            Ok(ws::Message::Pong(_)) => {}
-            Ok(ws::Message::Close(reason)) => {
-                ctx.close(reason);
-                ctx.stop();
-            }
-            _ => ctx.stop(),
+        ServerMessages::Stop { run_id } => {
+            info!("server sent a stop message for run_id: {run_id}");
+            worker_queue_tx
+                .stop(&run_id)
+                .await
+                .inspect(|_| info!("stop signal sent to worker for run_id: {run_id}"))?;
         }
     }
+    Ok(())
 }
 
-pub async fn ws_server_socket(
+pub async fn ws(
     req: HttpRequest,
-    stream: Payload,
+    body: web::Payload,
     worker_queue_tx: Data<WorkerQueueSender>,
-) -> Result<HttpResponse, Error> {
-    let socket = ServerSocket::new(worker_queue_tx);
-    ws::start(socket, &req, stream)
+) -> actix_web::Result<impl Responder> {
+    let (response, mut session, mut msg_stream) = actix_ws::handle(&req, body)?;
+
+    actix_web::rt::spawn(async move {
+        let mut reason: Option<CloseReason> = None;
+        while let Some(Ok(msg)) = msg_stream.recv().await {
+            match msg {
+                Message::Binary(bytes) => {
+                    debug!("received binary message from server");
+                    if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
+                        error!("handling message error. {e}");
+                    }
+                }
+                Message::Ping(msg) => {
+                    if let Err(e) = session.pong(&msg).await {
+                        error!("{e}");
+                        break;
+                    }
+                }
+                Message::Pong(_) => {}
+                Message::Close(r) => {
+                    reason = r;
+                    break;
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+
+        if let Err(e) = session.close(reason).await {
+            error!("encountered error while closing websocket session due to {e}");
+        }
+    });
+
+    Ok(response)
 }

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -4,7 +4,7 @@ use actix_web::{
     HttpRequest, Responder,
     web::{self, Bytes, Data},
 };
-use actix_ws::CloseReason;
+use actix_ws::{CloseCode, CloseReason};
 use anyhow::Result;
 use bld_core::workers::Worker;
 use bld_models::dtos::ServerMessages;
@@ -79,12 +79,18 @@ pub async fn ws(
                 Message::Binary(bytes) => {
                     debug!("received binary message from server");
                     if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
+                        reason = Some(CloseCode::Error.into());
+                        let _ = session
+                            .text("internal server error")
+                            .await
+                            .inspect_err(|e| error!("{e}"));
                         error!("handling message error. {e}");
                     }
                 }
 
                 Message::Ping(msg) => {
                     if let Err(e) = session.pong(&msg).await {
+                        reason = Some(CloseCode::Error.into());
                         error!("{e}");
                         break;
                     }

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -2,6 +2,7 @@ use crate::queues::WorkerQueueSender;
 use actix_http::ws::Message;
 use actix_web::{
     HttpRequest, Responder,
+    rt::time,
     web::{self, Bytes, Data},
 };
 use actix_ws::{CloseCode, CloseReason};
@@ -9,8 +10,12 @@ use anyhow::Result;
 use bld_core::workers::Worker;
 use bld_models::dtos::ServerMessages;
 use std::env::current_exe;
+use std::time::{Duration, Instant};
 use tokio::process::Command;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
+
+const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
+const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 async fn handle_message(worker_queue_tx: &Data<WorkerQueueSender>, bytes: &Bytes) -> Result<()> {
     let msg: ServerMessages = serde_json::from_slice(&bytes[..])?;
@@ -74,36 +79,63 @@ pub async fn ws(
 
     actix_web::rt::spawn(async move {
         let mut reason: Option<CloseReason> = None;
-        while let Some(Ok(msg)) = msg_stream.recv().await {
-            match msg {
-                Message::Binary(bytes) => {
-                    debug!("received binary message from server");
-                    if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
-                        reason = Some(CloseCode::Error.into());
-                        let _ = session
-                            .text("internal server error")
-                            .await
-                            .inspect_err(|e| error!("{e}"));
-                        error!("handling message error. {e}");
+        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
+        let mut last_pong = Instant::now();
+
+        loop {
+            tokio::select! {
+                msg = msg_stream.recv() => {
+                    let Some(Ok(message)) = msg else { break; };
+                    match message {
+                        Message::Binary(bytes) => {
+                            debug!("received binary message from server");
+                            if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
+                                reason = Some(CloseCode::Error.into());
+                                let _ = session
+                                    .text("internal server error")
+                                    .await
+                                    .inspect_err(|e| error!("{e}"));
+                                error!("handling message error. {e}");
+                            }
+                        }
+
+                        Message::Ping(msg) => {
+                            if let Err(e) = session.pong(&msg).await {
+                                reason = Some(CloseCode::Error.into());
+                                error!("{e}");
+                                break;
+                            }
+                        }
+
+                        Message::Pong(_) => {
+                            last_pong = Instant::now();
+                        }
+
+                        Message::Continuation(_) | Message::Nop => {}
+
+                        Message::Close(r) => {
+                            reason = r;
+                            break;
+                        }
+
+                        _ => break,
                     }
                 }
 
-                Message::Ping(msg) => {
-                    if let Err(e) = session.pong(&msg).await {
+                _ = hb_interval.tick() => {
+                    if Instant::now().duration_since(last_pong)
+                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
+                    {
+                        warn!("client heartbeat timed out, closing session");
+                        reason = Some(CloseCode::Away.into());
+                        break;
+                    }
+                    if let Err(e) = session.ping(b"").await {
+                        error!("ping failed: {e}");
                         reason = Some(CloseCode::Error.into());
-                        error!("{e}");
                         break;
                     }
                 }
-
-                Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
-
-                Message::Close(r) => {
-                    reason = r;
-                    break;
-                }
-
-                _ => break,
             }
         }
 

--- a/crates/bld_supervisor/src/sockets/server.rs
+++ b/crates/bld_supervisor/src/sockets/server.rs
@@ -8,7 +8,7 @@ use bld_core::workers::Worker;
 use bld_models::dtos::ServerMessages;
 use bld_sock::session::{self, WebSocketMessage};
 use std::env::current_exe;
-use tokio::process::Command;
+use tokio::{process::Command, sync::mpsc};
 use tracing::{debug, error, info};
 
 async fn handle_message(worker_queue_tx: &Data<WorkerQueueSender>, bytes: &Bytes) -> Result<()> {
@@ -70,20 +70,30 @@ pub async fn ws(
     worker_queue_tx: Data<WorkerQueueSender>,
 ) -> actix_web::Result<impl Responder> {
     let (response, mut handler) = session::handle(&req, body)?;
+    let (tx, mut rx) = mpsc::channel::<Bytes>(4096);
+    let mut session = handler.session().clone();
+
+    // process messages in a separate task so the read loop keeps
+    // serving heartbeats while the worker queue is busy
+    let processor = actix_web::rt::spawn(async move {
+        while let Some(bytes) = rx.recv().await {
+            if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
+                let _ = session
+                    .text("internal server error")
+                    .await
+                    .inspect_err(|e| error!("{e}"));
+                error!("handling message error. {e}");
+            }
+        }
+    });
 
     actix_web::rt::spawn(async move {
         loop {
             match handler.next().await {
                 WebSocketMessage::Binary(bytes) => {
                     debug!("received binary message from server");
-                    if let Err(e) = handle_message(&worker_queue_tx, &bytes).await {
-                        let session = handler.session();
-                        let _ = session
-                            .text("internal server error")
-                            .await
-                            .inspect_err(|e| error!("{e}"));
-                        error!("handling message error. {e}");
-                        handler.error();
+                    if tx.send(bytes).await.is_err() {
+                        break;
                     }
                 }
                 WebSocketMessage::Continue => {}
@@ -91,6 +101,8 @@ pub async fn ws(
             }
         }
 
+        drop(tx);
+        let _ = processor.await;
         handler.cleanup().await;
     });
 

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -50,7 +50,7 @@ pub async fn ws(
         while let Some(Ok(msg)) = msg_stream.recv().await {
             match msg {
                 Message::Binary(bytes) => {
-                    debug!("received binary message from server");
+                    debug!("received binary message");
                     match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
                         Ok(true) => break,
                         Ok(false) => {}

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -72,7 +72,6 @@ pub async fn ws(
                     break;
                 }
 
-
                 _ => {
                     break;
                 }

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -57,21 +57,34 @@ pub async fn ws(
                         Err(e) => error!("handling message error. {e}"),
                     }
                 }
+
                 Message::Ping(msg) => {
                     if let Err(e) = session.pong(&msg).await {
                         error!("{e}");
                         break;
                     }
                 }
-                Message::Pong(_) => {}
+
+                Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
+
                 Message::Close(r) => {
                     reason = r;
                     break;
                 }
+
+
                 _ => {
                     break;
                 }
             }
+        }
+
+        if let Some(pid) = worker_pid {
+            debug!("dequeue of worker with pid: {}", pid);
+            let _ = worker_queue_tx
+                .dequeue(pid)
+                .await
+                .inspect_err(|e| error!("{e}"));
         }
 
         if let Err(e) = session.close(reason).await {

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -4,7 +4,7 @@ use actix_web::{
     rt::spawn,
     web::{self, Bytes, Data},
 };
-use actix_ws::{CloseReason, Message, handle};
+use actix_ws::{CloseCode, CloseReason, Message, handle};
 use anyhow::Result;
 use bld_models::dtos::WorkerMessages;
 use tracing::{debug, error, info};
@@ -54,12 +54,20 @@ pub async fn ws(
                     match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
                         Ok(true) => break,
                         Ok(false) => {}
-                        Err(e) => error!("handling message error. {e}"),
+                        Err(e) => {
+                            reason = Some(CloseCode::Error.into());
+                            let _ = session
+                                .text("internal server error")
+                                .await
+                                .inspect_err(|e| error!("{e}"));
+                            error!("handling message error. {e}")
+                        }
                     }
                 }
 
                 Message::Ping(msg) => {
                     if let Err(e) = session.pong(&msg).await {
+                        reason = Some(CloseCode::Error.into());
                         error!("{e}");
                         break;
                     }

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -1,17 +1,13 @@
 use crate::queues::WorkerQueueSender;
 use actix_web::{
     HttpRequest, Responder,
-    rt::{spawn, time},
+    rt::spawn,
     web::{self, Bytes, Data},
 };
-use actix_ws::{CloseCode, CloseReason, Message, handle};
 use anyhow::Result;
 use bld_models::dtos::WorkerMessages;
-use std::time::{Duration, Instant};
-use tracing::{debug, error, info, warn};
-
-const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
-const CLIENT_TIMEOUT_MS: u64 = 15_000;
+use bld_sock::session::{self, WebSocketMessage};
+use tracing::{debug, error, info};
 
 async fn handle_message(
     bytes: &Bytes,
@@ -46,74 +42,31 @@ pub async fn ws(
     body: web::Payload,
     worker_queue_tx: Data<WorkerQueueSender>,
 ) -> actix_web::Result<impl Responder> {
-    let (response, mut session, mut msg_stream) = handle(&req, body)?;
+    let (response, mut handler) = session::handle(&req, body)?;
 
     spawn(async move {
-        let mut reason: Option<CloseReason> = None;
         let mut worker_pid: Option<u32> = None;
-        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
-        let mut last_pong = Instant::now();
 
-        'outer: loop {
-            tokio::select! {
-                msg = msg_stream.recv() => {
-                    let Some(Ok(message)) = msg else { break; };
-                    match message {
-                        Message::Binary(bytes) => {
-                            debug!("received binary message");
-                            match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
-                                Ok(true) => break 'outer,
-                                Ok(false) => {}
-                                Err(e) => {
-                                    reason = Some(CloseCode::Error.into());
-                                    let _ = session
-                                        .text("internal server error")
-                                        .await
-                                        .inspect_err(|e| error!("{e}"));
-                                    error!("handling message error. {e}")
-                                }
-                            }
-                        }
-
-                        Message::Ping(msg) => {
-                            if let Err(e) = session.pong(&msg).await {
-                                reason = Some(CloseCode::Error.into());
-                                error!("{e}");
-                                break;
-                            }
-                        }
-
-                        Message::Pong(_) => {
-                            last_pong = Instant::now();
-                        }
-
-                        Message::Continuation(_) | Message::Nop => {}
-
-                        Message::Close(r) => {
-                            reason = r;
-                            break;
-                        }
-
-                        _ => {
-                            break;
+        loop {
+            match handler.next().await {
+                WebSocketMessage::Binary(bytes) => {
+                    debug!("received binary message");
+                    match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
+                        Ok(true) => break,
+                        Ok(false) => {}
+                        Err(e) => {
+                            let session = handler.session();
+                            let _ = session
+                                .text("internal server error")
+                                .await
+                                .inspect_err(|e| error!("{e}"));
+                            error!("handling message error. {e}");
+                            handler.error();
                         }
                     }
                 }
-
-                _ = hb_interval.tick() => {
-                    if Instant::now().duration_since(last_pong)
-                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
-                    {
-                        warn!("client heartbeat timed out, closing session");
-                        reason = Some(CloseCode::Away.into());
-                        break;
-                    }
-                    if let Err(e) = session.ping(b"").await {
-                        error!("ping failed: {e}");
-                        reason = Some(CloseCode::Error.into());
-                        break;
-                    }
-                }
+                WebSocketMessage::Continue => {}
+                _ => break,
             }
         }
 
@@ -125,9 +78,7 @@ pub async fn ws(
                 .inspect_err(|e| error!("{e}"));
         }
 
-        if let Err(e) = session.close(reason).await {
-            error!("encountered error while closing websocket session due to {e}");
-        }
+        handler.cleanup().await;
     });
 
     Ok(response)

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -1,13 +1,17 @@
 use crate::queues::WorkerQueueSender;
 use actix_web::{
     HttpRequest, Responder,
-    rt::spawn,
+    rt::{spawn, time},
     web::{self, Bytes, Data},
 };
 use actix_ws::{CloseCode, CloseReason, Message, handle};
 use anyhow::Result;
 use bld_models::dtos::WorkerMessages;
-use tracing::{debug, error, info};
+use std::time::{Duration, Instant};
+use tracing::{debug, error, info, warn};
+
+const HEARTBEAT_INTERVAL_MS: u64 = 5_000;
+const CLIENT_TIMEOUT_MS: u64 = 15_000;
 
 async fn handle_message(
     bytes: &Bytes,
@@ -47,41 +51,68 @@ pub async fn ws(
     spawn(async move {
         let mut reason: Option<CloseReason> = None;
         let mut worker_pid: Option<u32> = None;
-        while let Some(Ok(msg)) = msg_stream.recv().await {
-            match msg {
-                Message::Binary(bytes) => {
-                    debug!("received binary message");
-                    match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
-                        Ok(true) => break,
-                        Ok(false) => {}
-                        Err(e) => {
-                            reason = Some(CloseCode::Error.into());
-                            let _ = session
-                                .text("internal server error")
-                                .await
-                                .inspect_err(|e| error!("{e}"));
-                            error!("handling message error. {e}")
+        let mut hb_interval = time::interval(Duration::from_millis(HEARTBEAT_INTERVAL_MS));
+        let mut last_pong = Instant::now();
+
+        'outer: loop {
+            tokio::select! {
+                msg = msg_stream.recv() => {
+                    let Some(Ok(message)) = msg else { break; };
+                    match message {
+                        Message::Binary(bytes) => {
+                            debug!("received binary message");
+                            match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
+                                Ok(true) => break 'outer,
+                                Ok(false) => {}
+                                Err(e) => {
+                                    reason = Some(CloseCode::Error.into());
+                                    let _ = session
+                                        .text("internal server error")
+                                        .await
+                                        .inspect_err(|e| error!("{e}"));
+                                    error!("handling message error. {e}")
+                                }
+                            }
+                        }
+
+                        Message::Ping(msg) => {
+                            if let Err(e) = session.pong(&msg).await {
+                                reason = Some(CloseCode::Error.into());
+                                error!("{e}");
+                                break;
+                            }
+                        }
+
+                        Message::Pong(_) => {
+                            last_pong = Instant::now();
+                        }
+
+                        Message::Continuation(_) | Message::Nop => {}
+
+                        Message::Close(r) => {
+                            reason = r;
+                            break;
+                        }
+
+                        _ => {
+                            break;
                         }
                     }
                 }
 
-                Message::Ping(msg) => {
-                    if let Err(e) = session.pong(&msg).await {
-                        reason = Some(CloseCode::Error.into());
-                        error!("{e}");
+                _ = hb_interval.tick() => {
+                    if Instant::now().duration_since(last_pong)
+                        > Duration::from_millis(CLIENT_TIMEOUT_MS)
+                    {
+                        warn!("client heartbeat timed out, closing session");
+                        reason = Some(CloseCode::Away.into());
                         break;
                     }
-                }
-
-                Message::Continuation(_) | Message::Pong(_) | Message::Nop => {}
-
-                Message::Close(r) => {
-                    reason = r;
-                    break;
-                }
-
-                _ => {
-                    break;
+                    if let Err(e) = session.ping(b"").await {
+                        error!("ping failed: {e}");
+                        reason = Some(CloseCode::Error.into());
+                        break;
+                    }
                 }
             }
         }

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -1,93 +1,80 @@
 use crate::queues::WorkerQueueSender;
-use actix::prelude::*;
-use actix_web::rt::spawn;
-use actix_web::web::{Bytes, Data, Payload};
-use actix_web::{Error, HttpRequest, HttpResponse};
-use actix_web_actors::ws;
+use actix_web::web::{self, Bytes, Data};
+use actix_web::{HttpRequest, Responder};
+use actix_ws::{CloseReason, Message};
 use anyhow::Result;
 use bld_models::dtos::WorkerMessages;
 use tracing::{debug, error, info};
 
-pub struct WorkerSocket {
-    worker_pid: Option<u32>,
+async fn handle_message(
+    bytes: &Bytes,
     worker_queue_tx: Data<WorkerQueueSender>,
+    worker_pid: &mut Option<u32>,
+) -> Result<bool> {
+    let msg: WorkerMessages = serde_json::from_slice(&bytes[..])?;
+    let completed = match msg {
+        WorkerMessages::Ack => {
+            info!("a new worker connection was acknowledged");
+            false
+        }
+        WorkerMessages::WhoAmI { pid } => {
+            info!("worker with pid: {pid} sent a whoami message");
+            worker_pid.replace(pid);
+            false
+        }
+        WorkerMessages::Completed => {
+            info!("worker just completed, starting cleanup");
+            if let Some(pid) = worker_pid {
+                debug!("dequeue of worker with pid: {}", pid);
+                worker_queue_tx.dequeue(*pid).await?;
+            }
+            true
+        }
+    };
+    Ok(completed)
 }
 
-impl WorkerSocket {
-    pub fn new(worker_queue_tx: Data<WorkerQueueSender>) -> Self {
-        Self {
-            worker_pid: None,
-            worker_queue_tx,
-        }
-    }
-
-    fn handle_message(&mut self, bytes: &Bytes, ctx: &mut <Self as Actor>::Context) -> Result<()> {
-        let msg: WorkerMessages = serde_json::from_slice(&bytes[..])?;
-        match msg {
-            WorkerMessages::Ack => info!("a new worker connection was acknowledged"),
-            WorkerMessages::WhoAmI { pid } => {
-                info!("worker with pid: {pid} sent a whoami message");
-                self.worker_pid = Some(pid);
-            }
-            WorkerMessages::Completed => {
-                info!("worker just completed, starting cleanup");
-                self.cleanup(ctx);
-            }
-        }
-        Ok(())
-    }
-
-    fn cleanup(&self, ctx: &mut <Self as Actor>::Context) {
-        if let Some(pid) = self.worker_pid {
-            debug!("dequeue of worker with pid: {}", pid);
-            let tx = self.worker_queue_tx.clone();
-            spawn(async move {
-                let _ = tx.dequeue(pid).await.map_err(|e| {
-                    error!("{e}");
-                    e
-                });
-            });
-        }
-        ctx.stop();
-    }
-}
-
-impl Actor for WorkerSocket {
-    type Context = ws::WebsocketContext<Self>;
-
-    fn started(&mut self, _ctx: &mut Self::Context) {
-        debug!("active worker socket started");
-    }
-
-    fn stopped(&mut self, ctx: &mut Self::Context) {
-        self.cleanup(ctx);
-        debug!("active worker socket stopped");
-    }
-}
-
-impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WorkerSocket {
-    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
-        match msg {
-            Ok(ws::Message::Binary(bytes)) => {
-                let _ = self.handle_message(&bytes, ctx);
-            }
-            Ok(ws::Message::Ping(msg)) => {
-                ctx.pong(&msg);
-            }
-            Ok(ws::Message::Close(reason)) => {
-                debug!("worker socket closed with reason: {reason:?}");
-                self.cleanup(ctx);
-            }
-            _ => {}
-        }
-    }
-}
-
-pub async fn ws_worker_socket(
+pub async fn ws(
     req: HttpRequest,
-    stream: Payload,
+    body: web::Payload,
     worker_queue_tx: Data<WorkerQueueSender>,
-) -> Result<HttpResponse, Error> {
-    let socket = WorkerSocket::new(worker_queue_tx);
-    ws::start(socket, &req, stream)
+) -> actix_web::Result<impl Responder> {
+    let (response, mut session, mut msg_stream) = actix_ws::handle(&req, body)?;
+
+    actix_web::rt::spawn(async move {
+        let mut reason: Option<CloseReason> = None;
+        let mut worker_pid: Option<u32> = None;
+        while let Some(Ok(msg)) = msg_stream.recv().await {
+            match msg {
+                Message::Binary(bytes) => {
+                    debug!("received binary message from server");
+                    match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
+                        Ok(true) => break,
+                        Ok(false) => {}
+                        Err(e) => error!("handling message error. {e}"),
+                    }
+                }
+                Message::Ping(msg) => {
+                    if let Err(e) = session.pong(&msg).await {
+                        error!("{e}");
+                        break;
+                    }
+                }
+                Message::Pong(_) => {}
+                Message::Close(r) => {
+                    reason = r;
+                    break;
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+
+        if let Err(e) = session.close(reason).await {
+            error!("encountered error while closing websocket session due to {e}");
+        }
+    });
+
+    Ok(response)
 }

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -1,7 +1,10 @@
 use crate::queues::WorkerQueueSender;
-use actix_web::web::{self, Bytes, Data};
-use actix_web::{HttpRequest, Responder};
-use actix_ws::{CloseReason, Message};
+use actix_web::{
+    HttpRequest, Responder,
+    rt::spawn,
+    web::{self, Bytes, Data},
+};
+use actix_ws::{CloseReason, Message, handle};
 use anyhow::Result;
 use bld_models::dtos::WorkerMessages;
 use tracing::{debug, error, info};
@@ -39,9 +42,9 @@ pub async fn ws(
     body: web::Payload,
     worker_queue_tx: Data<WorkerQueueSender>,
 ) -> actix_web::Result<impl Responder> {
-    let (response, mut session, mut msg_stream) = actix_ws::handle(&req, body)?;
+    let (response, mut session, mut msg_stream) = handle(&req, body)?;
 
-    actix_web::rt::spawn(async move {
+    spawn(async move {
         let mut reason: Option<CloseReason> = None;
         let mut worker_pid: Option<u32> = None;
         while let Some(Ok(msg)) = msg_stream.recv().await {

--- a/crates/bld_supervisor/src/sockets/worker.rs
+++ b/crates/bld_supervisor/src/sockets/worker.rs
@@ -9,11 +9,7 @@ use bld_models::dtos::WorkerMessages;
 use bld_sock::session::{self, WebSocketMessage};
 use tracing::{debug, error, info};
 
-async fn handle_message(
-    bytes: &Bytes,
-    worker_queue_tx: Data<WorkerQueueSender>,
-    worker_pid: &mut Option<u32>,
-) -> Result<bool> {
+async fn handle_message(bytes: &Bytes, worker_pid: &mut Option<u32>) -> Result<bool> {
     let msg: WorkerMessages = serde_json::from_slice(&bytes[..])?;
     let completed = match msg {
         WorkerMessages::Ack => {
@@ -27,10 +23,6 @@ async fn handle_message(
         }
         WorkerMessages::Completed => {
             info!("worker just completed, starting cleanup");
-            if let Some(pid) = worker_pid {
-                debug!("dequeue of worker with pid: {}", pid);
-                worker_queue_tx.dequeue(*pid).await?;
-            }
             true
         }
     };
@@ -51,7 +43,7 @@ pub async fn ws(
             match handler.next().await {
                 WebSocketMessage::Binary(bytes) => {
                     debug!("received binary message");
-                    match handle_message(&bytes, worker_queue_tx.clone(), &mut worker_pid).await {
+                    match handle_message(&bytes, &mut worker_pid).await {
                         Ok(true) => break,
                         Ok(false) => {}
                         Err(e) => {

--- a/crates/bld_supervisor/src/supervisor.rs
+++ b/crates/bld_supervisor/src/supervisor.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::queues::worker_queue_channel;
-use crate::sockets::{ws_server_socket, ws_worker_socket};
+use crate::sockets::{server, worker};
 use actix_web::web::{get, resource};
 use actix_web::{App, HttpServer};
 use anyhow::{Result, anyhow};
@@ -32,8 +32,8 @@ pub async fn start(config: BldConfig) -> Result<()> {
             .app_data(config_clone.clone())
             .app_data(conn.clone())
             .app_data(worker_queue_sender.clone())
-            .service(resource("/v1/ws-server/").route(get().to(ws_server_socket)))
-            .service(resource("/v1/ws-worker/").route(get().to(ws_worker_socket)))
+            .service(resource("/v1/ws-server/").route(get().to(server::ws)))
+            .service(resource("/v1/ws-worker/").route(get().to(worker::ws)))
     });
 
     server = match &config.local.supervisor.tls {


### PR DESCRIPTION
### In this PR:
- The project now uses actix_ws
- Web socket have been rewritten to use the new crate with manual handling for hearbeats.
- The web socket clients have been updated to use an awc connection directly and not rely on actors.