### PR TITLE
Add support for yml file extension

### DIFF
--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -25,6 +25,7 @@ pub const TOOL_DEFAULT_PIPELINE: &str = "default";
 pub const TOOL_DEFAULT_PIPELINE_FILE: &str = "default.yaml";
 pub const TOOL_DEFAULT_CONFIG: &str = "config";
 pub const TOOL_DEFAULT_CONFIG_FILE: &str = "config.yaml";
+pub const TOOL_DEFAULT_CONFIG_FILE_YML: &str = "config.yml";
 
 pub const LOCAL_SERVER_HOST: &str = "127.0.0.1";
 pub const LOCAL_SERVER_PORT: i64 = 6080;

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -65,18 +65,23 @@ impl BldConfig {
         let yaml = path![dir, TOOL_DEFAULT_CONFIG_FILE];
         let yml = path![dir, TOOL_DEFAULT_CONFIG_FILE_YML];
 
-        match (yaml.is_file(), yml.is_file()) {
-            (true, true) => {
-                eprintln!(
-                    "warning: both {TOOL_DEFAULT_CONFIG_FILE} and {TOOL_DEFAULT_CONFIG_FILE_YML} found in {}, loading {TOOL_DEFAULT_CONFIG_FILE}",
-                    dir.display()
-                );
-                Some(yaml)
-            }
-            (true, false) => Some(yaml),
-            (false, true) => Some(yml),
-            (false, false) => None,
+        if yaml.is_file() && yml.is_file() {
+            eprintln!(
+                "warning: both {TOOL_DEFAULT_CONFIG_FILE} and {TOOL_DEFAULT_CONFIG_FILE_YML} found in {}, loading {TOOL_DEFAULT_CONFIG_FILE}",
+                dir.display()
+            );
+            return Some(yaml);
         }
+
+        if yaml.is_file() {
+            return Some(yaml);
+        }
+
+        if yml.is_file() {
+            return Some(yml);
+        }
+
+        None
     }
 
     pub fn path() -> Result<PathBuf> {

--- a/crates/bld_config/src/lib.rs
+++ b/crates/bld_config/src/lib.rs
@@ -22,14 +22,14 @@ pub use tls::*;
 
 use crate::definitions::{
     LOCAL_DEFAULT_DB_DIR, LOCAL_DEFAULT_DB_NAME, LOCAL_MACHINE_TMP_DIR, LOCAL_SERVER_HOST,
-    LOCAL_SERVER_PORT, REMOTE_SERVER_AUTH, TOOL_DEFAULT_CONFIG_FILE, TOOL_DIR,
-    WEB_CLIENT_DEBUG_ORIGIN,
+    LOCAL_SERVER_PORT, REMOTE_SERVER_AUTH, TOOL_DEFAULT_CONFIG_FILE, TOOL_DEFAULT_CONFIG_FILE_YML,
+    TOOL_DIR, WEB_CLIENT_DEBUG_ORIGIN,
 };
 use anyhow::{Error, Result, anyhow};
 use openidconnect::core::CoreClient;
 use serde::{Deserialize, Serialize};
 use std::env::current_dir;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[cfg(feature = "tokio")]
 use tokio::fs::read_to_string;
@@ -61,24 +61,37 @@ pub struct BldConfig {
 }
 
 impl BldConfig {
+    fn config_file_in_dir(dir: &Path) -> Option<PathBuf> {
+        let yaml = path![dir, TOOL_DEFAULT_CONFIG_FILE];
+        let yml = path![dir, TOOL_DEFAULT_CONFIG_FILE_YML];
+
+        match (yaml.is_file(), yml.is_file()) {
+            (true, true) => {
+                eprintln!(
+                    "warning: both {TOOL_DEFAULT_CONFIG_FILE} and {TOOL_DEFAULT_CONFIG_FILE_YML} found in {}, loading {TOOL_DEFAULT_CONFIG_FILE}",
+                    dir.display()
+                );
+                Some(yaml)
+            }
+            (true, false) => Some(yaml),
+            (false, true) => Some(yml),
+            (false, false) => None,
+        }
+    }
+
     pub fn path() -> Result<PathBuf> {
         let mut current = current_dir()?;
         loop {
-            let cfg_file = path![
-                &current,
-                definitions::TOOL_DIR,
-                format!("{}.yaml", definitions::TOOL_DEFAULT_CONFIG)
-            ];
+            let bld_dir = path![&current, TOOL_DIR];
 
-            if !cfg_file.exists() {
-                current = current
-                    .parent()
-                    .map(|p| p.to_path_buf())
-                    .ok_or_else(|| anyhow!(".bld directory not found"))?;
-                continue;
+            if let Some(cfg_file) = Self::config_file_in_dir(&bld_dir) {
+                return Ok(cfg_file);
             }
 
-            return Ok(cfg_file);
+            current = current
+                .parent()
+                .map(|p| p.to_path_buf())
+                .ok_or_else(|| anyhow!(".bld directory not found"))?;
         }
     }
 
@@ -207,7 +220,8 @@ impl BldConfig {
     }
 
     pub fn config_full_path(&self) -> PathBuf {
-        path![&self.root_dir, TOOL_DEFAULT_CONFIG_FILE]
+        Self::config_file_in_dir(Path::new(&self.root_dir))
+            .unwrap_or_else(|| path![&self.root_dir, TOOL_DEFAULT_CONFIG_FILE])
     }
 
     pub fn full_path(&self, name: &str) -> PathBuf {
@@ -224,5 +238,64 @@ impl BldConfig {
 
     pub fn artifact_full_path(&self, run_id: &str, name: &str) -> PathBuf {
         path![self.artifacts_run_dir(run_id), format!("{name}.tar.gz")]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{File, create_dir_all, remove_dir_all};
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path = path![std::env::temp_dir(), format!("bld_config_test_{name}")];
+            let _ = remove_dir_all(&path);
+            create_dir_all(&path).expect("unable to create temp dir");
+            Self(path)
+        }
+
+        fn touch(&self, name: &str) -> PathBuf {
+            let path = path![&self.0, name];
+            File::create(&path).expect("unable to create file");
+            path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn config_file_in_dir_finds_yaml() {
+        let dir = TempDir::new("finds_yaml");
+        let expected = dir.touch(TOOL_DEFAULT_CONFIG_FILE);
+        assert_eq!(BldConfig::config_file_in_dir(&dir.0), Some(expected));
+    }
+
+    #[test]
+    fn config_file_in_dir_finds_yml() {
+        let dir = TempDir::new("finds_yml");
+        let expected = dir.touch(TOOL_DEFAULT_CONFIG_FILE_YML);
+        assert_eq!(BldConfig::config_file_in_dir(&dir.0), Some(expected));
+    }
+
+    #[test]
+    fn config_file_in_dir_prefers_yaml_over_yml() {
+        let dir = TempDir::new("prefers_yaml");
+        let expected = dir.touch(TOOL_DEFAULT_CONFIG_FILE);
+        dir.touch(TOOL_DEFAULT_CONFIG_FILE_YML);
+        assert_eq!(BldConfig::config_file_in_dir(&dir.0), Some(expected));
+    }
+
+    #[test]
+    fn config_file_in_dir_ignores_other_files() {
+        let dir = TempDir::new("ignores_others");
+        dir.touch("config.json");
+        dir.touch("default.yaml");
+        assert_eq!(BldConfig::config_file_in_dir(&dir.0), None);
     }
 }

--- a/crates/bld_utils/src/fs.rs
+++ b/crates/bld_utils/src/fs.rs
@@ -16,7 +16,7 @@ impl IsYaml for Path {
     fn valid_path(&self) -> bool {
         match self.extension() {
             Some(ext) => {
-                if ext != "yaml" {
+                if ext != "yaml" && ext != "yml" {
                     return false;
                 }
             }
@@ -25,7 +25,10 @@ impl IsYaml for Path {
 
         match self.file_name() {
             Some(name) => {
-                if name.to_string_lossy() == format!("{TOOL_DEFAULT_CONFIG}.yaml") {
+                let name = name.to_string_lossy();
+                if name == format!("{TOOL_DEFAULT_CONFIG}.yaml")
+                    || name == format!("{TOOL_DEFAULT_CONFIG}.yml")
+                {
                     return false;
                 }
             }
@@ -56,7 +59,9 @@ impl IsYaml for DirEntry {
     fn valid_path(&self) -> bool {
         let name = self.file_name();
         let name = name.to_string_lossy();
-        name.ends_with(".yaml") && name != format!("{TOOL_DEFAULT_CONFIG}.yaml")
+        (name.ends_with(".yaml") || name.ends_with(".yml"))
+            && name != format!("{TOOL_DEFAULT_CONFIG}.yaml")
+            && name != format!("{TOOL_DEFAULT_CONFIG}.yml")
     }
 
     fn is_yaml(&self) -> bool {
@@ -87,4 +92,41 @@ pub async fn write_tokens<T: Serialize>(path: &Path, tokens: T) -> Result<()> {
     let data = serde_json::to_vec(&tokens)?;
     File::create(path).await?.write_all(&data).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn valid_path_accepts_both_yaml_extensions() {
+        for name in ["pipeline.yaml", "pipeline.yml", "nested/pipeline.yml"] {
+            assert!(Path::new(name).valid_path(), "{name} should be valid");
+        }
+    }
+
+    #[test]
+    pub fn valid_path_rejects_other_extensions() {
+        for name in ["pipeline.json", "pipeline.toml", "pipeline", "pipeline.ym"] {
+            assert!(!Path::new(name).valid_path(), "{name} should be invalid");
+        }
+    }
+
+    #[test]
+    pub fn valid_path_rejects_config_files() {
+        for name in ["config.yaml", "config.yml"] {
+            assert!(!Path::new(name).valid_path(), "{name} should be invalid");
+        }
+    }
+
+    #[test]
+    pub fn valid_path_is_case_sensitive() {
+        for name in ["Config.yaml", "Config.yml", "CONFIG.yml"] {
+            assert!(Path::new(name).valid_path(), "{name} should be valid");
+        }
+
+        for name in ["pipeline.YAML", "pipeline.YML"] {
+            assert!(!Path::new(name).valid_path(), "{name} should be invalid");
+        }
+    }
 }


### PR DESCRIPTION
### In this PR:
- Added support for yml file extension on files
- Added support for yml files for config with the caveat that when 2 config files with different file extensions exist a warning is printed and the yaml extension one is chosen.
- Added tests

Closes #330 