### PR TITLE
fix(runner): Stop rejecting comparisons of step outputs during validation

### DIFF
--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -76,6 +76,11 @@ pub enum ExprValue<'a> {
     Number(f64),
     Text(ExprText<'a>),
     Array(Vec<ExprValue<'a>>),
+    /// Placeholder used only during validation, when the real value of a
+    /// step output is not known yet. It is compatible with every
+    /// comparison, so a validation-time expression that compares a step
+    /// output does not fail due to a type mismatch.
+    Unknown,
 }
 
 impl<'a, 'b> ExprValue<'a> {
@@ -85,10 +90,15 @@ impl<'a, 'b> ExprValue<'a> {
             Self::Number(_) => "number",
             Self::Text(_) => "text",
             Self::Array(_) => "array",
+            Self::Unknown => "unknown",
         }
     }
 
     pub fn try_eq(&self, other: &'a Self) -> Result<ExprValue<'b>> {
+        if matches!(self, Self::Unknown) || matches!(other, Self::Unknown) {
+            return Ok(ExprValue::<'b>::Boolean(true));
+        }
+
         let value = match (self, other) {
             (Self::Boolean(l), Self::Boolean(r)) => l == r,
             (Self::Number(l), Self::Number(r)) => l == r,
@@ -127,6 +137,10 @@ impl<'a, 'b> ExprValue<'a> {
     }
 
     pub fn try_ord(&self, other: &'a Self) -> Result<ExprValue<'b>> {
+        if matches!(self, Self::Unknown) || matches!(other, Self::Unknown) {
+            return Ok(ExprValue::<'b>::Boolean(true));
+        }
+
         let value = match (self, other) {
             (Self::Number(l), Self::Number(r)) => l > r,
             (Self::Text(l), Self::Text(r)) => l.inner() > r.inner(),
@@ -141,6 +155,10 @@ impl<'a, 'b> ExprValue<'a> {
     }
 
     pub fn try_and(&self, other: &'a Self) -> Result<ExprValue<'b>> {
+        if matches!(self, Self::Unknown) || matches!(other, Self::Unknown) {
+            return Ok(ExprValue::<'b>::Boolean(true));
+        }
+
         let value = match (self, other) {
             (Self::Boolean(l), Self::Boolean(r)) => *l && *r,
             _ => bail!(
@@ -153,6 +171,10 @@ impl<'a, 'b> ExprValue<'a> {
     }
 
     pub fn try_or(&self, other: &'a Self) -> Result<ExprValue<'b>> {
+        if matches!(self, Self::Unknown) || matches!(other, Self::Unknown) {
+            return Ok(ExprValue::<'b>::Boolean(true));
+        }
+
         let value = match (self, other) {
             (Self::Boolean(l), Self::Boolean(r)) => *l || *r,
             _ => bail!(
@@ -229,6 +251,7 @@ impl Display for ExprValue<'_> {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
+            Self::Unknown => "unknown".to_string(),
         };
         f.write_str(&value)
     }

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -339,6 +339,7 @@ mod tests {
     use bld_pkg::PackageManager;
     use bld_utils::sync::IntoArc;
     use mockall::predicate;
+    use std::collections::HashMap;
 
     use crate::{
         action::v3::Action,
@@ -350,6 +351,7 @@ mod tests {
         job::v3::Job,
         pipeline::v3::Pipeline,
         step::v3::{ShellCommand, Step},
+        strategy::v3::{MatrixValue, Strategy},
         validator::v3::{CommonValidator, ConsumeValidator, ValidatorWritableRuntimeExprContext},
     };
 
@@ -848,5 +850,89 @@ mod tests {
         let result = validate_action(&action).await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn condition_with_step_output_text_comparison_passes_validation() {
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "build".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo \"value=ok\" >> $BLD_OUTPUTS".to_string(),
+            condition: None,
+            strategy: None,
+        })));
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "after".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo done".to_string(),
+            condition: Some(r#"${{ steps.build.outputs.value == "ok" }}"#.to_string()),
+            strategy: None,
+        })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn condition_with_step_output_number_comparison_passes_validation() {
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "build".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo \"count=5\" >> $BLD_OUTPUTS".to_string(),
+            condition: None,
+            strategy: None,
+        })));
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "after".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo done".to_string(),
+            condition: Some("${{ steps.build.outputs.count > 3 }}".to_string()),
+            strategy: None,
+        })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn strategy_matrix_from_step_output_passes_validation() {
+        let mut matrix = HashMap::new();
+        matrix.insert(
+            "os".to_string(),
+            MatrixValue::Expr("${{ steps.build.outputs.oses }}".to_string()),
+        );
+
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "build".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo \"oses=[linux, windows]\" >> $BLD_OUTPUTS".to_string(),
+            condition: None,
+            strategy: None,
+        })));
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "after".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo ${{ matrix.os }}".to_string(),
+            condition: None,
+            strategy: Some(Strategy {
+                matrix,
+                fail_fast: None,
+            }),
+        })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
     }
 }

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -49,7 +49,7 @@ impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> 
     }
 
     fn get_output<'b>(&'b self, _id: &str, _name: &str) -> Result<ExprValue<'b>> {
-        Ok(ExprValue::Array(vec![]))
+        Ok(ExprValue::Unknown)
     }
 
     fn set_output(&mut self, _id: &str, name: String, value: String) -> Result<()> {
@@ -137,7 +137,9 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
         let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, wctx);
         for entry in self.expr_regex.find_iter(value) {
             match expr_exec.eval(entry.as_str()) {
-                Ok(ExprValue::Array(_)) => {}
+                // The value of a step output isn't known during validation, so an
+                // expression that uses one can't be checked against the array type.
+                Ok(ExprValue::Array(_) | ExprValue::Unknown) => {}
                 Ok(other) => {
                     let section = self.section_txt();
                     let _ = writeln!(


### PR DESCRIPTION
### In this PR

- Added an `ExprValue::Unknown` variant that represents a value whose type is not known before a run.
- Made `try_eq`, `try_not_eq`, `try_ord`, `try_and` and `try_or` treat `Unknown` as compatible with every other type instead of failing with a type mismatch.
- Returned `Unknown` for step outputs from the validator's substitute runtime context, so a step condition can compare an output with text or a number.
- Accepted `Unknown` in the array expression validation, so a step level matrix that comes from a step output is not reported as a non array value.
- Kept the existing error for a step output used at the start of a run, for example in `runs_on` or in an input default.
- Added validation tests for a text comparison, a number comparison and a matrix that uses a step output.

Closes #349
