### PR TITLE
fix(bld_runner): Dispose the platform of a failed or skipped v3 job

### DIFF
--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -19,7 +19,7 @@ use bld_sock::ExecClient;
 use bld_utils::sync::IntoArc;
 use regex::Regex;
 use tokio::task::JoinHandle;
-use tracing::debug;
+use tracing::{debug, error};
 
 use crate::{
     RunnerBuilder,
@@ -56,7 +56,7 @@ pub struct JobRunnerOptions<S: RootState> {
 
 pub struct JobRunner<S: RootState> {
     pub options: JobRunnerOptions<S>,
-    pub platform: Arc<Platform>,
+    pub platform: Option<Arc<Platform>>,
     pub runs_on: RunsOn,
     pub working_dir: Option<String>,
     pub outputs: HashMap<String, String>,
@@ -82,20 +82,9 @@ impl<S: RootState> JobRunner<S> {
         // Evaluate the runs_on value before building the job platform
         let runs_on = Self::resolve_runs_on(job, &options)?;
 
-        let platform = build_platform(
-            &runs_on,
-            options.config.clone(),
-            options.logger.clone(),
-            options.run_ctx.clone(),
-            options.expr_rctx.clone(),
-        )
-        .await?;
-
-        let working_dir = job.working_dir.clone();
-
         Ok(JobRunner {
             options,
-            platform,
+            platform: None,
             runs_on,
             working_dir,
             outputs: HashMap::new(),
@@ -128,6 +117,16 @@ impl<S: RootState> JobRunner<S> {
         Ok(expr_rctx)
     }
 
+    fn platform(&self) -> Result<&Arc<Platform>> {
+        self.platform
+            .as_ref()
+            .ok_or_else(|| anyhow!("the job's platform hasn't been built yet"))
+    }
+
+    pub fn is_skipped(&self) -> bool {
+        matches!(self.options.state.get_state(), State::Skipped)
+    }
+
     fn resolve_runs_on(job: &Job, options: &JobRunnerOptions<S>) -> Result<RunsOn> {
         let exec = CommonExprExecutor::new(
             options.pipeline.as_ref(),
@@ -152,33 +151,51 @@ impl<S: RootState> JobRunner<S> {
                 })
             })?;
 
+        if !self.job_condition(job.condition.as_deref())? {
+            debug!("condition failed, skiping job");
+            self.options.state.update_state(State::Skipped);
+            return Ok(self);
+        }
+
         self.info().await?;
 
-        if !self.job_condition(job.condition.as_deref())? {
-            debug!("condition failed, skiping step");
-            return Ok(self);
+        if self.platform.is_none() {
+            let platform = build_platform(
+                &self.runs_on,
+                self.options.config.clone(),
+                self.options.logger.clone(),
+                self.options.run_ctx.clone(),
+                self.options.expr_rctx.clone(),
+            )
+            .await?;
+            self.platform = Some(platform);
         }
 
         self.options.state.update_state(State::Running);
 
         debug!("starting execution of pipeline steps");
-        self.run_job_steps(job).await.inspect_err(|e| {
-            self.options.state.update_state(State::Failed {
-                error: e.to_string(),
+
+        let result = self.runs_job_steps(job).await.and_then(|_| {
+
+            self.resolve_outputs(job).inspect(|x| self.outputs = x)
+        });
+
+
+
+        // Remove the platform for a successful job and for a job that fails, so a failing
+        // step never leaves a container running.
+        if let Err(e) = self.dispose_platform(job).await {
+            error!("unable to dispose the platform: {e}");
+        }
+
+        result
+            .map(|_| self)
+            .inspect(|_| self.options.state.update_state(State::Completed))
+            .inspect_err(|_| {
+                self.options.state.update_state(State::Failed {
+                    error: e.to_string(),
+                })
             })
-        })?;
-
-        let outputs = self.resolve_outputs(job).inspect_err(|e| {
-            self.options.state.update_state(State::Failed {
-                error: e.to_string(),
-            })
-        })?;
-        self.outputs = outputs;
-
-        self.options.state.update_state(State::Completed);
-
-        self.dispose_platform(job).await?;
-        Ok(self)
     }
 
     fn resolve_outputs(&mut self, job: &Job) -> Result<HashMap<String, String>> {
@@ -345,7 +362,7 @@ impl<S: RootState> JobRunner<S> {
         let local_path = self.eval_all_expr(&download.to)?;
         self.options
             .artifacts
-            .download(self.platform.clone(), &download.download, &local_path)
+            .download(self.platform()?.clone(), &download.download, &local_path)
             .await
     }
 
@@ -353,7 +370,7 @@ impl<S: RootState> JobRunner<S> {
         let local_path = self.eval_all_expr(&upload.upload)?;
         self.options
             .artifacts
-            .upload(self.platform.clone(), &upload.name, &local_path)
+            .upload(self.platform()?.clone(), &upload.name, &local_path)
             .await
     }
 
@@ -373,7 +390,7 @@ impl<S: RootState> JobRunner<S> {
             .env(env.into_arc())
             .inputs(inputs.into_arc())
             .context(self.options.run_ctx.clone())
-            .platform(self.platform.clone())
+            .platform(self.platform()?.clone())
             .regex_cache(self.options.regex_cache.clone())
             .package_manager(self.options.package_manager.clone())
             .artifacts(self.options.artifacts.clone())
@@ -452,7 +469,7 @@ impl<S: RootState> JobRunner<S> {
 
         debug!("sending command to platform");
         let outputs = self
-            .platform
+            .platform()?
             .shell(self.options.logger.clone(), &working_dir, &command)
             .await?;
 
@@ -515,14 +532,14 @@ impl<S: RootState> JobRunner<S> {
     async fn dispose_platform(&self, job: &Job) -> Result<()> {
         if job.dispose {
             debug!("executing dispose operations for platform");
-            self.platform.dispose(self.options.is_child).await?;
+            self.platform()?.dispose(self.options.is_child).await?;
         } else {
             debug!("keeping platform alive");
-            self.platform.keep_alive().await?;
+            self.platform()?.keep_alive().await?;
         }
         self.options
             .run_ctx
-            .remove_platform(self.platform.id())
+            .remove_platform(self.platform()?.id())
             .await
     }
 }
@@ -664,7 +681,11 @@ pub async fn build_platform(
 mod tests {
     use bld_config::BldConfig;
     use bld_core::{
-        artifacts::Artifacts, context::Context, fs::FileSystem, logger::Logger, platform::Platform,
+        artifacts::Artifacts,
+        context::{Context, local::LocalContextMessage},
+        fs::FileSystem,
+        logger::Logger,
+        platform::Platform,
         regex::RegexCache,
     };
     use bld_pkg::PackageManager;
@@ -727,7 +748,7 @@ mod tests {
         };
         let job = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -844,7 +865,7 @@ mod tests {
         };
         let mut job = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1239,7 +1260,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1309,7 +1330,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1375,7 +1396,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1451,7 +1472,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1525,7 +1546,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1599,7 +1620,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1609,6 +1630,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+<<<<<<< HEAD
     const ACTION_WITH_OUTPUT: &str = r#"
 version: 3
 type: action
@@ -1681,29 +1703,55 @@ steps:
 
     #[tokio::test]
     pub async fn download_artifact_step_with_false_condition_is_skipped() {
+=======
+    #[tokio::test]
+    pub async fn dispose_platform_runs_after_step_failure() {
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let job_name = "main".to_string();
         let config = BldConfig::default().into_arc();
         let logger = Logger::mock().into_arc();
         let fs = FileSystem::local(config.clone()).into_arc();
+<<<<<<< HEAD
         let run_ctx = Context::mock().into_arc();
         let platform = Platform::mock().into_arc();
+=======
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let run_ctx = Context::Local(tx).into_arc();
+        let platform = Platform::mock().into_arc();
+        let platform_id = platform.id().to_string();
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let artifacts = Artifacts::mock().into_arc();
         let regex_cache = RegexCache::mock().into_arc();
         let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
         let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
         let mut state = JobState::new(&job_name);
+<<<<<<< HEAD
         state.add_node("download");
+=======
+        state.add_node("build");
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
 
         let mut pipeline = Pipeline::default();
         pipeline.jobs.insert(
             job_name.clone(),
             Job {
+<<<<<<< HEAD
                 steps: vec![Step::DownloadArtifact(Box::new(DownloadArtifact {
                     id: "download".to_string(),
                     download: "artifact-name".to_string(),
                     to: "some/path".to_string(),
                     condition: Some("${{ false }}".to_string()),
+=======
+                dispose: true,
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "build".to_string(),
+                    run: "echo hello".to_string(),
+                    // More than one expression in a condition is rejected, so the step
+                    // errors out without needing to run any real shell command.
+                    condition: Some("${{ 1 }} ${{ 2 }}".to_string()),
+                    ..Default::default()
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
                 }))],
                 ..Default::default()
             },
@@ -1726,6 +1774,7 @@ steps:
         };
         let runner = JobRunner {
             options,
+<<<<<<< HEAD
             platform,
             runs_on: RunsOn::default(),
             working_dir: None,
@@ -1744,29 +1793,66 @@ steps:
 
     #[tokio::test]
     pub async fn download_artifact_step_with_true_condition_runs() {
+=======
+            platform: Some(platform),
+            runs_on: RunsOn::default(),
+        };
+
+        let result = runner.run().await;
+        assert!(result.is_err(), "expected the failing step to error out");
+
+        let message = rx
+            .try_recv()
+            .expect("expected the platform to be removed from the run context");
+        assert!(
+            matches!(message, LocalContextMessage::RemovePlatform(id) if id == platform_id),
+            "expected a RemovePlatform message for the job's platform"
+        );
+    }
+
+    #[tokio::test]
+    pub async fn condition_false_job_never_builds_a_platform() {
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let job_name = "main".to_string();
         let config = BldConfig::default().into_arc();
         let logger = Logger::mock().into_arc();
         let fs = FileSystem::local(config.clone()).into_arc();
+<<<<<<< HEAD
         let run_ctx = Context::mock().into_arc();
         let platform = Platform::mock().into_arc();
+=======
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let run_ctx = Context::Local(tx).into_arc();
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let artifacts = Artifacts::mock().into_arc();
         let regex_cache = RegexCache::mock().into_arc();
         let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
         let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
         let mut state = JobState::new(&job_name);
+<<<<<<< HEAD
         state.add_node("download");
+=======
+        state.add_node("s");
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
 
         let mut pipeline = Pipeline::default();
         pipeline.jobs.insert(
             job_name.clone(),
             Job {
+<<<<<<< HEAD
                 steps: vec![Step::DownloadArtifact(Box::new(DownloadArtifact {
                     id: "download".to_string(),
                     download: "artifact-name".to_string(),
                     to: "some/path".to_string(),
                     condition: Some("${{ true }}".to_string()),
+=======
+                condition: Some("${{ false }}".to_string()),
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "s".to_string(),
+                    run: "echo not run".to_string(),
+                    ..Default::default()
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
                 }))],
                 ..Default::default()
             },
@@ -1787,6 +1873,7 @@ steps:
             is_child: false,
             state,
         };
+<<<<<<< HEAD
         let runner = JobRunner {
             options,
             platform,
@@ -2055,6 +2142,20 @@ steps:
         assert!(
             error.contains("version") && error.contains("build"),
             "{error}"
+=======
+
+        let runner = JobRunner::new(options).await.unwrap();
+        let runner = runner.run().await.unwrap();
+
+        assert!(
+            runner.platform.is_none(),
+            "expected a skipped job to never build a platform"
+        );
+        assert!(runner.is_skipped());
+        assert!(
+            rx.try_recv().is_err(),
+            "expected no platform to be registered with the run context"
+>>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         );
     }
 }

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -82,6 +82,10 @@ impl<S: RootState> JobRunner<S> {
         // Evaluate the runs_on value before building the job platform
         let runs_on = Self::resolve_runs_on(job, &options)?;
 
+        let working_dir = job.working_dir.clone();
+
+        // The platform is built once the job's condition is known to be true, see `run`.
+        // This keeps a skipped job from ever starting a container.
         Ok(JobRunner {
             options,
             platform: None,
@@ -175,27 +179,23 @@ impl<S: RootState> JobRunner<S> {
 
         debug!("starting execution of pipeline steps");
 
-        let result = self.runs_job_steps(job).await.and_then(|_| {
+        let result = self
+            .run_job_steps(job)
+            .await
+            .and_then(|_| self.resolve_outputs(job).map(|x| self.outputs = x));
 
-            self.resolve_outputs(job).inspect(|x| self.outputs = x)
-        });
-
-
-
-        // Remove the platform for a successful job and for a job that fails, so a failing
-        // step never leaves a container running.
         if let Err(e) = self.dispose_platform(job).await {
             error!("unable to dispose the platform: {e}");
         }
 
         result
-            .map(|_| self)
             .inspect(|_| self.options.state.update_state(State::Completed))
-            .inspect_err(|_| {
+            .inspect_err(|e| {
                 self.options.state.update_state(State::Failed {
                     error: e.to_string(),
                 })
             })
+            .map(|_| self)
     }
 
     fn resolve_outputs(&mut self, job: &Job) -> Result<HashMap<String, String>> {
@@ -804,7 +804,7 @@ mod tests {
         };
         let job = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -942,7 +942,7 @@ mod tests {
 
         JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             outputs: HashMap::new(),
             working_dir: None,
@@ -1630,7 +1630,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-<<<<<<< HEAD
     const ACTION_WITH_OUTPUT: &str = r#"
 version: 3
 type: action
@@ -1694,7 +1693,7 @@ steps:
         };
         JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1703,55 +1702,29 @@ steps:
 
     #[tokio::test]
     pub async fn download_artifact_step_with_false_condition_is_skipped() {
-=======
-    #[tokio::test]
-    pub async fn dispose_platform_runs_after_step_failure() {
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let job_name = "main".to_string();
         let config = BldConfig::default().into_arc();
         let logger = Logger::mock().into_arc();
         let fs = FileSystem::local(config.clone()).into_arc();
-<<<<<<< HEAD
         let run_ctx = Context::mock().into_arc();
         let platform = Platform::mock().into_arc();
-=======
-        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
-        let run_ctx = Context::Local(tx).into_arc();
-        let platform = Platform::mock().into_arc();
-        let platform_id = platform.id().to_string();
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let artifacts = Artifacts::mock().into_arc();
         let regex_cache = RegexCache::mock().into_arc();
         let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
         let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
         let mut state = JobState::new(&job_name);
-<<<<<<< HEAD
         state.add_node("download");
-=======
-        state.add_node("build");
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
 
         let mut pipeline = Pipeline::default();
         pipeline.jobs.insert(
             job_name.clone(),
             Job {
-<<<<<<< HEAD
                 steps: vec![Step::DownloadArtifact(Box::new(DownloadArtifact {
                     id: "download".to_string(),
                     download: "artifact-name".to_string(),
                     to: "some/path".to_string(),
                     condition: Some("${{ false }}".to_string()),
-=======
-                dispose: true,
-                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
-                    id: "build".to_string(),
-                    run: "echo hello".to_string(),
-                    // More than one expression in a condition is rejected, so the step
-                    // errors out without needing to run any real shell command.
-                    condition: Some("${{ 1 }} ${{ 2 }}".to_string()),
-                    ..Default::default()
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
                 }))],
                 ..Default::default()
             },
@@ -1774,8 +1747,7 @@ steps:
         };
         let runner = JobRunner {
             options,
-<<<<<<< HEAD
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1793,66 +1765,29 @@ steps:
 
     #[tokio::test]
     pub async fn download_artifact_step_with_true_condition_runs() {
-=======
-            platform: Some(platform),
-            runs_on: RunsOn::default(),
-        };
-
-        let result = runner.run().await;
-        assert!(result.is_err(), "expected the failing step to error out");
-
-        let message = rx
-            .try_recv()
-            .expect("expected the platform to be removed from the run context");
-        assert!(
-            matches!(message, LocalContextMessage::RemovePlatform(id) if id == platform_id),
-            "expected a RemovePlatform message for the job's platform"
-        );
-    }
-
-    #[tokio::test]
-    pub async fn condition_false_job_never_builds_a_platform() {
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let job_name = "main".to_string();
         let config = BldConfig::default().into_arc();
         let logger = Logger::mock().into_arc();
         let fs = FileSystem::local(config.clone()).into_arc();
-<<<<<<< HEAD
         let run_ctx = Context::mock().into_arc();
         let platform = Platform::mock().into_arc();
-=======
-        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
-        let run_ctx = Context::Local(tx).into_arc();
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         let artifacts = Artifacts::mock().into_arc();
         let regex_cache = RegexCache::mock().into_arc();
         let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
         let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
         let mut state = JobState::new(&job_name);
-<<<<<<< HEAD
         state.add_node("download");
-=======
-        state.add_node("s");
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
 
         let mut pipeline = Pipeline::default();
         pipeline.jobs.insert(
             job_name.clone(),
             Job {
-<<<<<<< HEAD
                 steps: vec![Step::DownloadArtifact(Box::new(DownloadArtifact {
                     id: "download".to_string(),
                     download: "artifact-name".to_string(),
                     to: "some/path".to_string(),
                     condition: Some("${{ true }}".to_string()),
-=======
-                condition: Some("${{ false }}".to_string()),
-                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
-                    id: "s".to_string(),
-                    run: "echo not run".to_string(),
-                    ..Default::default()
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
                 }))],
                 ..Default::default()
             },
@@ -1873,10 +1808,9 @@ steps:
             is_child: false,
             state,
         };
-<<<<<<< HEAD
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -1890,6 +1824,136 @@ steps:
             runner.options.state.get_node_state("download"),
             Some(State::Completed)
         ));
+    }
+
+    #[tokio::test]
+    pub async fn dispose_platform_runs_after_step_failure() {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let run_ctx = Context::Local(tx).into_arc();
+        let platform = Platform::mock().into_arc();
+        let platform_id = platform.id().to_string();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let mut state = JobState::new(&job_name);
+        state.add_node("build");
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.clone(),
+            Job {
+                dispose: true,
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "build".to_string(),
+                    run: "echo hello".to_string(),
+                    // More than one expression in a condition is rejected, so the step
+                    // errors out without needing to run any real shell command.
+                    condition: Some("${{ 1 }} ${{ 2 }}".to_string()),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+        let runner = JobRunner {
+            options,
+            platform: Some(platform),
+            runs_on: RunsOn::default(),
+            working_dir: None,
+            outputs: HashMap::new(),
+        };
+
+        let result = runner.run().await;
+        assert!(result.is_err(), "expected the failing step to error out");
+
+        let message = rx
+            .try_recv()
+            .expect("expected the platform to be removed from the run context");
+        assert!(
+            matches!(message, LocalContextMessage::RemovePlatform(id) if id == platform_id),
+            "expected a RemovePlatform message for the job's platform"
+        );
+    }
+
+    #[tokio::test]
+    pub async fn condition_false_job_never_builds_a_platform() {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let run_ctx = Context::Local(tx).into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let mut state = JobState::new(&job_name);
+        state.add_node("s");
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.clone(),
+            Job {
+                condition: Some("${{ false }}".to_string()),
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "s".to_string(),
+                    run: "echo not run".to_string(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+
+        let runner = JobRunner::new(options).await.unwrap();
+        let runner = runner.run().await.unwrap();
+
+        assert!(
+            runner.platform.is_none(),
+            "expected a skipped job to never build a platform"
+        );
+        assert!(runner.is_skipped());
+        assert!(
+            rx.try_recv().is_err(),
+            "expected no platform to be registered with the run context"
+        );
     }
 
     #[actix_web::test]
@@ -2023,7 +2087,7 @@ steps:
         };
         JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
             working_dir: None,
             outputs: HashMap::new(),
@@ -2142,20 +2206,6 @@ steps:
         assert!(
             error.contains("version") && error.contains("build"),
             "{error}"
-=======
-
-        let runner = JobRunner::new(options).await.unwrap();
-        let runner = runner.run().await.unwrap();
-
-        assert!(
-            runner.platform.is_none(),
-            "expected a skipped job to never build a platform"
-        );
-        assert!(runner.is_skipped());
-        assert!(
-            rx.try_recv().is_err(),
-            "expected no platform to be registered with the run context"
->>>>>>> de8cdde (fix(bld_runner): Dispose the platform of a failed or skipped v3 job)
         );
     }
 }

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -19,7 +19,7 @@ use bld_sock::ExecClient;
 use bld_utils::sync::IntoArc;
 use regex::Regex;
 use tokio::task::JoinHandle;
-use tracing::debug;
+use tracing::{debug, error};
 
 use crate::{
     RunnerBuilder,
@@ -56,7 +56,7 @@ pub struct JobRunnerOptions<S: RootState> {
 
 pub struct JobRunner<S: RootState> {
     pub options: JobRunnerOptions<S>,
-    pub platform: Arc<Platform>,
+    pub platform: Option<Arc<Platform>>,
     pub runs_on: RunsOn,
 }
 
@@ -78,20 +78,23 @@ impl<S: RootState> JobRunner<S> {
         // run, so its expressions are limited to the start of run context.
         let runs_on = Self::resolve_runs_on(job, &options)?;
 
-        let platform = build_platform(
-            &runs_on,
-            options.config.clone(),
-            options.logger.clone(),
-            options.run_ctx.clone(),
-            options.expr_rctx.clone(),
-        )
-        .await?;
-
+        // The platform is built once the job's condition is known to be true, see `run`.
+        // This keeps a skipped job from ever starting a container.
         Ok(JobRunner {
             options,
-            platform,
+            platform: None,
             runs_on,
         })
+    }
+
+    fn platform(&self) -> Result<&Arc<Platform>> {
+        self.platform
+            .as_ref()
+            .ok_or_else(|| anyhow!("the job's platform hasn't been built yet"))
+    }
+
+    pub fn is_skipped(&self) -> bool {
+        matches!(self.options.state.get_state(), State::Skipped)
     }
 
     fn resolve_runs_on(job: &Job, options: &JobRunnerOptions<S>) -> Result<RunsOn> {
@@ -118,11 +121,24 @@ impl<S: RootState> JobRunner<S> {
                 })
             })?;
 
+        if !self.job_condition(job.condition.as_deref())? {
+            debug!("condition failed, skiping job");
+            self.options.state.update_state(State::Skipped);
+            return Ok(self);
+        }
+
         self.info().await?;
 
-        if !self.job_condition(job.condition.as_deref())? {
-            debug!("condition failed, skiping step");
-            return Ok(self);
+        if self.platform.is_none() {
+            let platform = build_platform(
+                &self.runs_on,
+                self.options.config.clone(),
+                self.options.logger.clone(),
+                self.options.run_ctx.clone(),
+                self.options.expr_rctx.clone(),
+            )
+            .await?;
+            self.platform = Some(platform);
         }
 
         self.options.state.update_state(State::Running);
@@ -136,9 +152,14 @@ impl<S: RootState> JobRunner<S> {
                 error: e.to_string(),
             }),
         }
-        result?;
 
-        self.dispose_platform(job).await?;
+        // Remove the platform for a successful job and for a job that fails, so a failing
+        // step never leaves a container running.
+        if let Err(e) = self.dispose_platform(job).await {
+            error!("unable to dispose the platform: {e}");
+        }
+
+        result?;
         Ok(self)
     }
 
@@ -293,7 +314,7 @@ impl<S: RootState> JobRunner<S> {
         let local_path = self.eval_all_expr(&download.to)?;
         self.options
             .artifacts
-            .download(self.platform.clone(), &download.download, &local_path)
+            .download(self.platform()?.clone(), &download.download, &local_path)
             .await
     }
 
@@ -301,7 +322,7 @@ impl<S: RootState> JobRunner<S> {
         let local_path = self.eval_all_expr(&upload.upload)?;
         self.options
             .artifacts
-            .upload(self.platform.clone(), &upload.name, &local_path)
+            .upload(self.platform()?.clone(), &upload.name, &local_path)
             .await
     }
 
@@ -321,7 +342,7 @@ impl<S: RootState> JobRunner<S> {
             .env(env.into_arc())
             .inputs(inputs.into_arc())
             .context(self.options.run_ctx.clone())
-            .platform(self.platform.clone())
+            .platform(self.platform()?.clone())
             .regex_cache(self.options.regex_cache.clone())
             .package_manager(self.options.package_manager.clone())
             .artifacts(self.options.artifacts.clone())
@@ -393,7 +414,7 @@ impl<S: RootState> JobRunner<S> {
 
         debug!("sending command to platform");
         let outputs = self
-            .platform
+            .platform()?
             .shell(self.options.logger.clone(), &working_dir, &command)
             .await?;
 
@@ -456,14 +477,14 @@ impl<S: RootState> JobRunner<S> {
     async fn dispose_platform(&self, job: &Job) -> Result<()> {
         if job.dispose {
             debug!("executing dispose operations for platform");
-            self.platform.dispose(self.options.is_child).await?;
+            self.platform()?.dispose(self.options.is_child).await?;
         } else {
             debug!("keeping platform alive");
-            self.platform.keep_alive().await?;
+            self.platform()?.keep_alive().await?;
         }
         self.options
             .run_ctx
-            .remove_platform(self.platform.id())
+            .remove_platform(self.platform()?.id())
             .await
     }
 }
@@ -605,7 +626,11 @@ pub async fn build_platform(
 mod tests {
     use bld_config::BldConfig;
     use bld_core::{
-        artifacts::Artifacts, context::Context, fs::FileSystem, logger::Logger, platform::Platform,
+        artifacts::Artifacts,
+        context::{Context, local::LocalContextMessage},
+        fs::FileSystem,
+        logger::Logger,
+        platform::Platform,
         regex::RegexCache,
     };
     use bld_pkg::PackageManager;
@@ -661,7 +686,7 @@ mod tests {
         };
         let job = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
@@ -723,7 +748,7 @@ mod tests {
         };
         let mut job = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
@@ -997,7 +1022,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
@@ -1065,7 +1090,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
@@ -1129,7 +1154,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
@@ -1203,7 +1228,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
@@ -1280,7 +1305,7 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
@@ -1357,11 +1382,139 @@ mod tests {
         };
         let runner = JobRunner {
             options,
-            platform,
+            platform: Some(platform),
             runs_on: RunsOn::default(),
         };
 
         let result = runner.run().await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    pub async fn dispose_platform_runs_after_step_failure() {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let run_ctx = Context::Local(tx).into_arc();
+        let platform = Platform::mock().into_arc();
+        let platform_id = platform.id().to_string();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let mut state = JobState::new(&job_name);
+        state.add_node("build");
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.clone(),
+            Job {
+                dispose: true,
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "build".to_string(),
+                    run: "echo hello".to_string(),
+                    // More than one expression in a condition is rejected, so the step
+                    // errors out without needing to run any real shell command.
+                    condition: Some("${{ 1 }} ${{ 2 }}".to_string()),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+        let runner = JobRunner {
+            options,
+            platform: Some(platform),
+            runs_on: RunsOn::default(),
+        };
+
+        let result = runner.run().await;
+        assert!(result.is_err(), "expected the failing step to error out");
+
+        let message = rx
+            .try_recv()
+            .expect("expected the platform to be removed from the run context");
+        assert!(
+            matches!(message, LocalContextMessage::RemovePlatform(id) if id == platform_id),
+            "expected a RemovePlatform message for the job's platform"
+        );
+    }
+
+    #[tokio::test]
+    pub async fn condition_false_job_never_builds_a_platform() {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let run_ctx = Context::Local(tx).into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let mut state = JobState::new(&job_name);
+        state.add_node("s");
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.clone(),
+            Job {
+                condition: Some("${{ false }}".to_string()),
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "s".to_string(),
+                    run: "echo not run".to_string(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+
+        let runner = JobRunner::new(options).await.unwrap();
+        let runner = runner.run().await.unwrap();
+
+        assert!(
+            runner.platform.is_none(),
+            "expected a skipped job to never build a platform"
+        );
+        assert!(runner.is_skipped());
+        assert!(
+            rx.try_recv().is_err(),
+            "expected no platform to be registered with the run context"
+        );
     }
 }

--- a/crates/bld_runner/src/runner/v3/pipeline.rs
+++ b/crates/bld_runner/src/runner/v3/pipeline.rs
@@ -210,6 +210,9 @@ impl PipelineRunner {
                     let handle_result = running_job.handle.await.map_err(|e| anyhow!(e))?;
 
                     let message = match &handle_result {
+                        Ok(runner) if runner.is_skipped() => {
+                            format!("{:<15}: {}", "Skipped job", running_job.name)
+                        }
                         Ok(runner) => {
                             collected.insert(running_job.name.clone(), runner.outputs.clone());
                             format!("{:<15}: {}", "Completed job", running_job.name)

--- a/crates/bld_runner/src/runner/v3/pipeline.rs
+++ b/crates/bld_runner/src/runner/v3/pipeline.rs
@@ -210,12 +210,13 @@ impl PipelineRunner {
                     let handle_result = running_job.handle.await.map_err(|e| anyhow!(e))?;
 
                     let message = match &handle_result {
-                        Ok(runner) if runner.is_skipped() => {
-                            format!("{:<15}: {}", "Skipped job", running_job.name)
-                        }
                         Ok(runner) => {
                             collected.insert(running_job.name.clone(), runner.outputs.clone());
-                            format!("{:<15}: {}", "Completed job", running_job.name)
+                            if runner.is_skipped() {
+                                format!("{:<15}: {}", "Skipped job", running_job.name)
+                            } else {
+                                format!("{:<15}: {}", "Completed job", running_job.name)
+                            }
                         }
                         Err(e) => {
                             errors.push(format!("[{}] {e}", running_job.name));

--- a/crates/bld_runner/src/runner/v3/pipeline.rs
+++ b/crates/bld_runner/src/runner/v3/pipeline.rs
@@ -196,6 +196,9 @@ impl PipelineRunner {
                     let handle_result = running_job.handle.await.map_err(|e| anyhow!(e))?;
 
                     let message = match &handle_result {
+                        Ok(runner) if runner.is_skipped() => {
+                            format!("{:<15}: {}", "Skipped job", running_job.name)
+                        }
                         Ok(_) => format!("{:<15}: {}", "Completed job", running_job.name),
                         Err(e) => {
                             errors.push(format!("[{}] {e}", running_job.name));

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -28,6 +28,7 @@ pub enum State {
     Default,
     Running,
     Completed,
+    Skipped,
     Failed {
         error: String,
     },


### PR DESCRIPTION
### In this PR

- The v3 job runner builds its platform lazily in `run`, after the job's condition evaluates to true, so a skipped job no longer starts a container or registers one in the run context.
- `dispose_platform` now runs for a job whose steps failed as well as for one that succeeded, so a failing step no longer leaks a container. A dispose error is logged and the result of the steps is still returned.
- `JobRunner::platform` became an `Option` with an accessor that errors instead of handing out a platform that hasn't been built.
- Added `State::Skipped` and `JobRunner::is_skipped`, and the pipeline runner prints `Skipped job` for such a job instead of `Completed job`.
- Added tests covering that a failing step still removes the platform from the run context and that a job skipped by its condition never builds one.

Closes #350
