### PR TITLE
fix(bld_runner): Give `&&` a higher precedence than `||` and short circuit both

### DIFF
--- a/crates/bld_runner/grammar/expr_v3.pest
+++ b/crates/bld_runner/grammar/expr_v3.pest
@@ -83,7 +83,9 @@ LessEquals = { Symbol ~ LessEqualsOperator ~ Symbol }
 ExpressionInner = { Equals | NotEquals | Greater | GreaterEquals | Less | LessEquals | Symbol }
 Expression = { ("(" ~ " "* ~ (LogicalExpression | ExpressionInner) ~ " "* ~ ")") | ExpressionInner }
 
-LogicalExpression = {  Expression ~ ((AndOperator | OrOperator) ~ Expression)+ }
+AndExpression = { Expression ~ (AndOperator ~ Expression)+ }
+AndTerm = { AndExpression | Expression }
+LogicalExpression = { AndTerm ~ (OrOperator ~ AndTerm)* }
 
 //
 // Define full grammar

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -77,6 +77,60 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
         Ok(ExprValue::Array(items))
     }
 
+    fn eval_and_term(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
+        let Rule::AndTerm = expr.as_rule() else {
+            bail!("expected and term rule, found {:?}", expr.as_rule());
+        };
+
+        let inner = expr
+            .into_inner()
+            .next()
+            .ok_or_else(|| anyhow!("no expression found in and term"))?;
+
+        match inner.as_rule() {
+            Rule::AndExpression => self.eval_and_expr(inner),
+            Rule::Expression => self.eval_expr(inner),
+            _ => bail!("unexpected rule: {:?}", inner.as_rule()),
+        }
+    }
+
+    fn eval_and_expr(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
+        let Rule::AndExpression = expr.as_rule() else {
+            bail!("expected and expression rule, found {:?}", expr.as_rule());
+        };
+
+        let mut inner = expr.into_inner();
+
+        let first = inner
+            .next()
+            .ok_or_else(|| anyhow!("no left operand found for and expression"))?;
+        let mut result = self.eval_expr(first)?;
+
+        while let Some(operator) = inner.next() {
+            let Rule::AndOperator = operator.as_rule() else {
+                bail!(
+                    "invalid operator encountered during evaluation of and expression: {:?}",
+                    operator.as_rule()
+                );
+            };
+
+            let right = inner
+                .next()
+                .ok_or_else(|| anyhow!("no right operand found for and expression"))?;
+
+            // short circuit: once the left side is false the overall result is
+            // false, so the right side must not be evaluated at all.
+            if matches!(result, ExprValue::Boolean(false)) {
+                continue;
+            }
+
+            let value = self.eval_expr(right)?;
+            result = result.try_and(&value)?;
+        }
+
+        Ok(result)
+    }
+
     fn eval_index(&self, object: Pair<'a, Rule>, value: ExprValue<'a>) -> Result<ExprValue<'a>> {
         let Some(index) = object
             .into_inner()
@@ -252,57 +306,36 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
             );
         };
 
-        let expr_inner = expr.into_inner();
-        let mut result: Option<ExprValue<'a>> = None;
-        let mut operator: Option<Rule> = None;
+        let mut inner = expr.into_inner();
 
-        for inner in expr_inner {
-            match inner.as_rule() {
-                Rule::Expression => {
-                    let value = self.eval_expr(inner)?;
+        let first = inner
+            .next()
+            .ok_or_else(|| anyhow!("no left operand found for logical expression"))?;
+        let mut result = self.eval_and_term(first)?;
 
-                    // this is the case of starting the evaluation of the logical expression
-                    // during the rest of the evaluation there should always be a result value and
-                    // an operator.
-                    let Some(operator) = operator else {
-                        result = Some(value);
-                        continue;
-                    };
+        while let Some(operator) = inner.next() {
+            let Rule::OrOperator = operator.as_rule() else {
+                bail!(
+                    "invalid operator encountered during evaluation of logical expression: {:?}",
+                    operator.as_rule()
+                );
+            };
 
-                    match operator {
-                        Rule::AndOperator => {
-                            if let Some(res) = result {
-                                result = Some(res.try_and(&value)?);
-                            }
-                        }
+            let right = inner
+                .next()
+                .ok_or_else(|| anyhow!("no right operand found for logical expression"))?;
 
-                        Rule::OrOperator => {
-                            if let Some(res) = result {
-                                result = Some(res.try_or(&value)?);
-                            }
-                        }
-
-                        _ => bail!(
-                            "invalid operator encountered during evaluation of logical expression"
-                        ),
-                    }
-                }
-
-                Rule::AndOperator => {
-                    operator = Some(Rule::AndOperator);
-                }
-
-                Rule::OrOperator => {
-                    operator = Some(Rule::OrOperator);
-                }
-
-                _ => {
-                    bail!("invalid expression encountered during evaluation of logical expression")
-                }
+            // short circuit: once the left side is true the overall result is
+            // true, so the right side must not be evaluated at all.
+            if matches!(result, ExprValue::Boolean(true)) {
+                continue;
             }
+
+            let value = self.eval_and_term(right)?;
+            result = result.try_or(&value)?;
         }
 
-        result.ok_or_else(|| anyhow!("no value was computed during logical expression evaluation"))
+        Ok(result)
     }
 
     fn eval(&self, expr: &'a str) -> Result<ExprValue<'a>> {
@@ -1232,6 +1265,114 @@ mod tests {
             if expected.is_err() && value.is_ok() {
                 panic!("invalid result after eval");
             }
+        }
+    }
+
+    #[test]
+    pub fn and_has_higher_precedence_than_or_eval_success() {
+        let data: Vec<(&str, Result<ExprValue>)> = vec![
+            // true || (false && false) == true, not (true || false) && false == false
+            (
+                "${{ true || false && false }}",
+                Ok(ExprValue::Boolean(true)),
+            ),
+            // (false && true) || true == true
+            ("${{ false && true || true }}", Ok(ExprValue::Boolean(true))),
+            // explicit parens force the opposite grouping and change the result
+            (
+                "${{ (true || false) && false }}",
+                Ok(ExprValue::Boolean(false)),
+            ),
+            // true || (true && false) == true, a left fold would give false
+            ("${{ true || true && false }}", Ok(ExprValue::Boolean(true))),
+            // false || (true && true) || (false && false) == true, a left fold
+            // would give false
+            (
+                "${{ false || true && true || false && false }}",
+                Ok(ExprValue::Boolean(true)),
+            ),
+            // the same precedence applies to comparisons used as operands
+            (
+                "${{ 1 == 1 || 2 == 2 && 3 == 4 }}",
+                Ok(ExprValue::Boolean(true)),
+            ),
+        ];
+
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        for (expr, expected) in data {
+            let value = exec.eval(expr);
+
+            if let Ok(expected) = expected {
+                let Ok(value) = value else {
+                    panic!("invalid result after eval for expr: {expr}");
+                };
+                assert!(
+                    matches!(value.try_eq(&expected), Ok(ExprValue::Boolean(true))),
+                    "unexpected result for expr: {expr}"
+                );
+                continue;
+            }
+
+            if expected.is_err() && value.is_ok() {
+                panic!("invalid result after eval for expr: {expr}");
+            }
+        }
+    }
+
+    #[test]
+    pub fn logical_operators_short_circuit_eval_success() {
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        // the right side of `&&` references a missing step output, which would
+        // normally error. since the left side is false, the right side must
+        // never be evaluated, so no error should be raised.
+        let value = exec
+            .eval("${{ false && steps.x.outputs.missing == \"1\" }}")
+            .expect("expected the short circuited && expression to evaluate without error");
+        assert!(matches!(
+            value.try_eq(&ExprValue::Boolean(false)),
+            Ok(ExprValue::Boolean(true))
+        ));
+
+        // the right side of `||` references a missing step output, which would
+        // normally error. since the left side is true, the right side must
+        // never be evaluated, so no error should be raised.
+        let value = exec
+            .eval("${{ true || steps.x.outputs.missing == \"1\" }}")
+            .expect("expected the short circuited || expression to evaluate without error");
+        assert!(matches!(
+            value.try_eq(&ExprValue::Boolean(true)),
+            Ok(ExprValue::Boolean(true))
+        ));
+    }
+
+    #[test]
+    pub fn non_boolean_logical_operand_eval_failure() {
+        let data = [
+            "${{ true && 100 }}",
+            "${{ 100 && true }}",
+            "${{ false || \"hello\" }}",
+            "${{ \"hello\" || true }}",
+            "${{ true && true && 100 }}",
+        ];
+
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        for expr in data {
+            assert!(
+                exec.eval(expr).is_err(),
+                "expected an error for expr: {expr}"
+            );
         }
     }
 

--- a/crates/bld_runner/src/expr/v3/parser.rs
+++ b/crates/bld_runner/src/expr/v3/parser.rs
@@ -778,17 +778,32 @@ mod tests {
             for pair in pairs {
                 let mut pair_inner = pair.into_inner();
 
-                let Some(left) = pair_inner.next() else {
+                let Some(and_term) = pair_inner.next() else {
+                    panic!("parsed value doesn't contain an and term");
+                };
+                assert_eq!(and_term.as_rule(), Rule::AndTerm);
+                assert!(pair_inner.next().is_none());
+
+                let mut and_term_inner = and_term.into_inner();
+
+                let Some(and_expr) = and_term_inner.next() else {
+                    panic!("parsed value doesn't contain an and expression");
+                };
+                assert_eq!(and_expr.as_rule(), Rule::AndExpression);
+
+                let mut and_expr_inner = and_expr.into_inner();
+
+                let Some(left) = and_expr_inner.next() else {
                     panic!("parsed value doesn't contain a left operand");
                 };
                 assert_eq!(left.as_rule(), Rule::Expression);
 
-                let Some(operator) = pair_inner.next() else {
+                let Some(operator) = and_expr_inner.next() else {
                     panic!("parsed value doesn't contain an operator");
                 };
                 assert_eq!(operator.as_rule(), Rule::AndOperator);
 
-                let Some(right) = pair_inner.next() else {
+                let Some(right) = and_expr_inner.next() else {
                     panic!("parsed value doesn't contain a right operand");
                 };
                 assert_eq!(right.as_rule(), Rule::Expression);
@@ -835,9 +850,13 @@ mod tests {
                 let mut pair_inner = pair.into_inner();
 
                 let Some(left) = pair_inner.next() else {
-                    panic!("parsed value doesn't contain a left operand");
+                    panic!("parsed value doesn't contain a left and term");
                 };
-                assert_eq!(left.as_rule(), Rule::Expression);
+                assert_eq!(left.as_rule(), Rule::AndTerm);
+                assert_eq!(
+                    left.into_inner().next().map(|p| p.as_rule()),
+                    Some(Rule::Expression)
+                );
 
                 let Some(operator) = pair_inner.next() else {
                     panic!("parsed value doesn't contain an operator");
@@ -845,9 +864,47 @@ mod tests {
                 assert_eq!(operator.as_rule(), Rule::OrOperator);
 
                 let Some(right) = pair_inner.next() else {
-                    panic!("parsed value doesn't contain a right operand");
+                    panic!("parsed value doesn't contain a right and term");
                 };
-                assert_eq!(right.as_rule(), Rule::Expression);
+                assert_eq!(right.as_rule(), Rule::AndTerm);
+                assert_eq!(
+                    right.into_inner().next().map(|p| p.as_rule()),
+                    Some(Rule::Expression)
+                );
+            }
+        }
+    }
+
+    fn assert_valid_expression(expr: pest::iterators::Pair<Rule>) {
+        assert_eq!(expr.as_rule(), Rule::Expression);
+        let expr_inner = expr.into_inner();
+
+        for inner in expr_inner {
+            match inner.as_rule() {
+                Rule::ExpressionInner => {
+                    let mut body = inner.into_inner();
+                    assert_eq!(body.len(), 1);
+
+                    let body_inner = body.next().unwrap();
+                    assert!(
+                        body_inner.as_rule() == Rule::Equals
+                            || body_inner.as_rule() == Rule::NotEquals
+                            || body_inner.as_rule() == Rule::Greater
+                            || body_inner.as_rule() == Rule::GreaterEquals
+                            || body_inner.as_rule() == Rule::Less
+                            || body_inner.as_rule() == Rule::LessEquals
+                            || body_inner.as_rule() == Rule::Symbol
+                    );
+                }
+
+                // a parenthesized group inside the expression is parsed as a
+                // nested logical expression, which is validated separately.
+                Rule::LogicalExpression => {}
+
+                _ => panic!(
+                    "unexpected rule found inside expression: {:?}",
+                    inner.as_rule()
+                ),
             }
         }
     }
@@ -862,32 +919,27 @@ mod tests {
             for logical in pairs {
                 let logical_inner = logical.into_inner();
 
-                for expr in logical_inner {
-                    match expr.as_rule() {
-                        Rule::Expression => {
-                            let expr_inner = expr.into_inner();
+                for term in logical_inner {
+                    match term.as_rule() {
+                        Rule::AndTerm => {
+                            let and_term_inner = term.into_inner().next().unwrap();
 
-                            for inner in expr_inner {
-                                assert_eq!(inner.as_rule(), Rule::ExpressionInner);
-
-                                let mut body = inner.into_inner();
-                                assert_eq!(body.len(), 1);
-
-                                let body_inner = body.next().unwrap();
-                                assert!(
-                                    body_inner.as_rule() == Rule::Equals
-                                        || body_inner.as_rule() == Rule::NotEquals
-                                        || body_inner.as_rule() == Rule::Greater
-                                        || body_inner.as_rule() == Rule::GreaterEquals
-                                        || body_inner.as_rule() == Rule::Less
-                                        || body_inner.as_rule() == Rule::LessEquals
-                                        || body_inner.as_rule() == Rule::LogicalExpression
-                                        || body_inner.as_rule() == Rule::Symbol
-                                );
+                            match and_term_inner.as_rule() {
+                                Rule::AndExpression => {
+                                    for part in and_term_inner.into_inner() {
+                                        match part.as_rule() {
+                                            Rule::Expression => assert_valid_expression(part),
+                                            Rule::AndOperator => {}
+                                            _ => panic!("parsed value is not a valid rule"),
+                                        }
+                                    }
+                                }
+                                Rule::Expression => assert_valid_expression(and_term_inner),
+                                _ => panic!("parsed value is not a valid rule"),
                             }
                         }
 
-                        Rule::AndOperator | Rule::OrOperator => {}
+                        Rule::OrOperator => {}
 
                         _ => panic!("parsed value is not a valid rule"),
                     }
@@ -942,6 +994,22 @@ mod tests {
                     assert!(expr_rule == Rule::Expression || expr_rule == Rule::LogicalExpression);
                 }
             }
+        }
+    }
+
+    #[test]
+    fn parse_full_expression_with_dangling_logical_operator_failure() {
+        let data = [
+            "${{ true && }}",
+            "${{ true || }}",
+            "${{ && true }}",
+            "${{ true && false || }}",
+        ];
+        for expr in data {
+            assert!(
+                ExprParser::parse(Rule::Full, expr).is_err(),
+                "expected a parse error for: {expr}"
+            );
         }
     }
 }


### PR DESCRIPTION
### In this PR

- Split the flat `LogicalExpression` grammar rule into an `AndExpression` level and an `OrOperator` level, so `&&` binds tighter than `||`.
- Rewrote `eval_logical_expr` to evaluate the `&&` terms first and combine their results with `||`, replacing the previous left fold.
- Added short circuiting: `&&` stops at a `false` left side and `||` stops at a `true` left side, so an unresolvable operand no longer fails an expression whose result is already decided.
- Kept the existing error for a non boolean operand when that operand is actually evaluated.
- Note that the validator shares this executor, so operands behind a short circuit are no longer checked at validation time.
- Updated the parser tests for the new rule nesting and added tests for precedence, short circuiting, non boolean operands and dangling logical operators.

Closes #351
