### PR TITLE
feat(runner): Support the if key on every v3 step type

### DIFF
--- a/crates/bld_runner/src/artifacts/v3/download.rs
+++ b/crates/bld_runner/src/artifacts/v3/download.rs
@@ -54,7 +54,11 @@ impl<'a> Validate<'a> for DownloadArtifact {
         ctx.validate_expressions(&self.to, ExprScope::Runtime);
         ctx.pop_section();
 
-        debug!("Validating artifact's if condition");
-        ctx.validate_condition(self.condition.as_deref());
+        if let Some(condition) = &self.condition {
+            debug!("Validating artifact's if condition");
+            ctx.push_section("if");
+            ctx.validate_condition(condition, ExprScope::Runtime);
+            ctx.pop_section();
+        }
     }
 }

--- a/crates/bld_runner/src/artifacts/v3/download.rs
+++ b/crates/bld_runner/src/artifacts/v3/download.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 #[cfg(feature = "all")]
 use {
-    crate::validator::v3::{ExprScope, Validate, ValidatorContext},
+    crate::validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
     bld_core::artifacts::validate_artifact_name,
     tracing::debug,
 };
@@ -14,6 +14,8 @@ pub struct DownloadArtifact {
     pub id: String,
     pub download: String,
     pub to: String,
+    #[serde(rename = "if")]
+    pub condition: Option<String>,
 }
 
 impl DownloadArtifact {
@@ -28,6 +30,7 @@ impl Default for DownloadArtifact {
             id: Self::default_id(),
             download: String::new(),
             to: String::new(),
+            condition: None,
         }
     }
 }
@@ -50,5 +53,8 @@ impl<'a> Validate<'a> for DownloadArtifact {
         ctx.push_section("to");
         ctx.validate_expressions(&self.to, ExprScope::Runtime);
         ctx.pop_section();
+
+        debug!("Validating artifact's if condition");
+        validate_condition(ctx, self.condition.as_deref());
     }
 }

--- a/crates/bld_runner/src/artifacts/v3/download.rs
+++ b/crates/bld_runner/src/artifacts/v3/download.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 #[cfg(feature = "all")]
 use {
-    crate::validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
+    crate::validator::v3::{ExprScope, Validate, ValidatorContext},
     bld_core::artifacts::validate_artifact_name,
     tracing::debug,
 };
@@ -55,6 +55,6 @@ impl<'a> Validate<'a> for DownloadArtifact {
         ctx.pop_section();
 
         debug!("Validating artifact's if condition");
-        validate_condition(ctx, self.condition.as_deref());
+        ctx.validate_condition(self.condition.as_deref());
     }
 }

--- a/crates/bld_runner/src/artifacts/v3/upload.rs
+++ b/crates/bld_runner/src/artifacts/v3/upload.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 #[cfg(feature = "all")]
 use {
-    crate::validator::v3::{ExprScope, Validate, ValidatorContext},
+    crate::validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
     bld_core::artifacts::validate_artifact_name,
     tracing::debug,
 };
@@ -14,6 +14,8 @@ pub struct UploadArtifact {
     pub id: String,
     pub upload: String,
     pub name: String,
+    #[serde(rename = "if")]
+    pub condition: Option<String>,
 }
 
 impl UploadArtifact {
@@ -28,6 +30,7 @@ impl Default for UploadArtifact {
             id: Self::default_id(),
             upload: String::new(),
             name: String::new(),
+            condition: None,
         }
     }
 }
@@ -50,5 +53,8 @@ impl<'a> Validate<'a> for UploadArtifact {
             ctx.append_error(&e.to_string());
         }
         ctx.pop_section();
+
+        debug!("Validating artifact's if condition");
+        validate_condition(ctx, self.condition.as_deref());
     }
 }

--- a/crates/bld_runner/src/artifacts/v3/upload.rs
+++ b/crates/bld_runner/src/artifacts/v3/upload.rs
@@ -54,7 +54,11 @@ impl<'a> Validate<'a> for UploadArtifact {
         }
         ctx.pop_section();
 
-        debug!("Validating artifact's if condition");
-        ctx.validate_condition(self.condition.as_deref());
+        if let Some(condition) = &self.condition {
+            debug!("Validating artifact's if condition");
+            ctx.push_section("if");
+            ctx.validate_condition(condition, ExprScope::Runtime);
+            ctx.pop_section();
+        }
     }
 }

--- a/crates/bld_runner/src/artifacts/v3/upload.rs
+++ b/crates/bld_runner/src/artifacts/v3/upload.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 #[cfg(feature = "all")]
 use {
-    crate::validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
+    crate::validator::v3::{ExprScope, Validate, ValidatorContext},
     bld_core::artifacts::validate_artifact_name,
     tracing::debug,
 };
@@ -55,6 +55,6 @@ impl<'a> Validate<'a> for UploadArtifact {
         ctx.pop_section();
 
         debug!("Validating artifact's if condition");
-        validate_condition(ctx, self.condition.as_deref());
+        ctx.validate_condition(self.condition.as_deref());
     }
 }

--- a/crates/bld_runner/src/external/v3.rs
+++ b/crates/bld_runner/src/external/v3.rs
@@ -134,8 +134,12 @@ impl<'a> Validate<'a> for External {
         ctx.validate_env(&self.env, ExprScope::Runtime);
         ctx.pop_section();
 
-        debug!("Validating external's if condition");
-        ctx.validate_condition(self.condition.as_deref());
+        if let Some(condition) = &self.condition {
+            debug!("Validating external's if condition");
+            ctx.push_section("if");
+            ctx.validate_condition(condition, ExprScope::Runtime);
+            ctx.pop_section();
+        }
     }
 }
 

--- a/crates/bld_runner/src/external/v3.rs
+++ b/crates/bld_runner/src/external/v3.rs
@@ -14,7 +14,7 @@ use {
                 WritableRuntimeExprContext,
             },
         },
-        validator::v3::{ExprScope, Validate, ValidatorContext},
+        validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
     },
     anyhow::{Result, bail},
     pest::iterators::Pairs,
@@ -37,6 +37,9 @@ pub struct External {
     pub env: HashMap<String, String>,
 
     pub strategy: Option<Strategy>,
+
+    #[serde(rename = "if")]
+    pub condition: Option<String>,
 }
 
 impl External {
@@ -130,6 +133,9 @@ impl<'a> Validate<'a> for External {
         ctx.push_section("env");
         ctx.validate_env(&self.env, ExprScope::Runtime);
         ctx.pop_section();
+
+        debug!("Validating external's if condition");
+        validate_condition(ctx, self.condition.as_deref());
     }
 }
 

--- a/crates/bld_runner/src/external/v3.rs
+++ b/crates/bld_runner/src/external/v3.rs
@@ -14,7 +14,7 @@ use {
                 WritableRuntimeExprContext,
             },
         },
-        validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
+        validator::v3::{ExprScope, Validate, ValidatorContext},
     },
     anyhow::{Result, bail},
     pest::iterators::Pairs,
@@ -135,7 +135,7 @@ impl<'a> Validate<'a> for External {
         ctx.pop_section();
 
         debug!("Validating external's if condition");
-        validate_condition(ctx, self.condition.as_deref());
+        ctx.validate_condition(self.condition.as_deref());
     }
 }
 

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -192,14 +192,10 @@ impl<'a> Validate<'a> for Job {
             ctx.pop_section();
         }
 
-        if let Some(condition) = self.condition.as_ref() {
+        if let Some(condition) = &self.condition {
             debug!("Validating job's {} if condition", self.id);
             ctx.push_section("if");
-            if ctx.expression_count(condition) > 1 {
-                ctx.append_error("Condition must contain at most one expression");
-            } else {
-                ctx.validate_condition_expression(condition, ExprScope::StartOfRun);
-            }
+            ctx.validate_condition(condition, ExprScope::Runtime);
             validate_matrix_refs(ctx, condition, &HashSet::new());
             ctx.pop_section();
         }

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -195,7 +195,7 @@ impl<'a> Validate<'a> for Job {
         if let Some(condition) = &self.condition {
             debug!("Validating job's {} if condition", self.id);
             ctx.push_section("if");
-            ctx.validate_condition(condition, ExprScope::Runtime);
+            ctx.validate_condition(condition, ExprScope::StartOfRun);
             validate_matrix_refs(ctx, condition, &HashSet::new());
             ctx.pop_section();
         }

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -410,7 +410,7 @@ mod tests {
 
         fn validate_array_expression(&mut self, _symbol: &'a str, _scope: ExprScope) {}
 
-        fn validate_condition_expression(&mut self, _symbol: &'a str, _scope: ExprScope) {}
+        fn validate_condition(&mut self, _condition: Option<&'a str>) {}
 
         fn matrix_refs(&self, _value: &str) -> Vec<String> {
             vec![]

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -410,7 +410,7 @@ mod tests {
 
         fn validate_array_expression(&mut self, _symbol: &'a str, _scope: ExprScope) {}
 
-        fn validate_condition(&mut self, _condition: Option<&'a str>) {}
+        fn validate_condition(&mut self, _condition: &'a str, _scope: ExprScope) {}
 
         fn matrix_refs(&self, _value: &str) -> Vec<String> {
             vec![]

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -145,32 +145,37 @@ impl<S: RootState> ActionRunner<S> {
     }
 
     async fn run_step(&mut self, step: &Step) -> Result<()> {
-        self.state.update_node_state(step.id(), State::Running);
-        match step {
-            Step::ComplexSh(complex) => self.complex_shell(complex).await,
-            Step::ExternalFile(external) => self.external(external).await,
-            Step::DownloadArtifact(download) => self.download_artifact(download).await,
-            Step::UploadArtifact(upload) => self.upload_artifact(upload).await,
-        }
-        .inspect(|_| self.state.update_node_state(step.id(), State::Completed))
-        .inspect_err(|e| {
-            self.state.update_node_state(
-                step.id(),
-                State::Failed {
-                    error: e.to_string(),
-                },
-            )
-        })
+        let condition = self.condition(step.condition());
+        let result = match condition {
+            Ok(false) => {
+                debug!("condition failed, skiping step");
+                return Ok(());
+            }
+            Err(e) => Err(e),
+            Ok(true) => {
+                self.state.update_node_state(step.id(), State::Running);
+                match step {
+                    Step::ComplexSh(complex) => self.complex_shell(complex).await,
+                    Step::ExternalFile(external) => self.external(external).await,
+                    Step::DownloadArtifact(download) => self.download_artifact(download).await,
+                    Step::UploadArtifact(upload) => self.upload_artifact(upload).await,
+                }
+            }
+        };
+
+        result
+            .inspect(|_| self.state.update_node_state(step.id(), State::Completed))
+            .inspect_err(|e| {
+                self.state.update_node_state(
+                    step.id(),
+                    State::Failed {
+                        error: e.to_string(),
+                    },
+                )
+            })
     }
 
     async fn complex_shell(&mut self, complex: &ShellCommand) -> Result<()> {
-        let condition = complex.condition.as_deref();
-
-        if !self.condition(condition)? {
-            debug!("condition failed, skiping step");
-            return Ok(());
-        }
-
         if let Some(name) = complex.name.as_ref() {
             let mut message = String::new();
             writeln!(message, "{:<15}: {name}", "Step")?;
@@ -577,6 +582,7 @@ mod tests {
                 id: "download".to_string(),
                 download: "artifact-name".to_string(),
                 to: "${{ inputs.region }}/artifact".to_string(),
+                condition: None,
             })));
         action
             .steps
@@ -584,6 +590,7 @@ mod tests {
                 id: "upload".to_string(),
                 upload: "${{ inputs.region }}/artifact".to_string(),
                 name: "artifact-name".to_string(),
+                condition: None,
             })));
 
         let mut state = ActionState::default();
@@ -676,6 +683,73 @@ mod tests {
     }
 
     #[tokio::test]
+    pub async fn artifact_steps_respect_condition_and_still_run_remaining_steps() {
+        // Arrange
+        let logger = Logger::mock().into_arc();
+        let mut action = Action::default();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex = Regex::new(EXPR_REGEX).unwrap();
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let config = BldConfig::default().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        action
+            .steps
+            .push(Step::DownloadArtifact(Box::new(DownloadArtifact {
+                id: "skipped".to_string(),
+                download: "artifact-name".to_string(),
+                to: "some/path".to_string(),
+                condition: Some("${{ false }}".to_string()),
+            })));
+        action
+            .steps
+            .push(Step::UploadArtifact(Box::new(UploadArtifact {
+                id: "executed".to_string(),
+                upload: "some/path".to_string(),
+                name: "artifact-name".to_string(),
+                condition: Some("${{ true }}".to_string()),
+            })));
+
+        let mut state = ActionState::default();
+        for step in &action.steps {
+            state.add_node(step.id());
+        }
+
+        let mut runner = ActionRunner {
+            logger,
+            action,
+            platform,
+            artifacts,
+            expr_regex: regex,
+            expr_rctx: rctx,
+            state,
+            config,
+            fs,
+            run_ctx,
+            regex_cache,
+            package_manager,
+        };
+
+        // Act
+        let result = runner.steps().await;
+
+        // Assert
+        assert!(result.is_ok(), "error: {:?}", result.err());
+        assert!(matches!(
+            runner.state.get_node_state("skipped"),
+            Some(State::Default)
+        ));
+        assert!(matches!(
+            runner.state.get_node_state("executed"),
+            Some(State::Completed)
+        ));
+    }
+
+    #[tokio::test]
     pub async fn step_level_matrix_expansion_runs_all_combinations_success() {
         let logger = Logger::mock().into_arc();
         let mut action = Action::default();
@@ -747,11 +821,6 @@ mod tests {
         state.expect_set_matrix().returning(|_| ());
         state
             .expect_update_node_state()
-            .withf(|_, state| matches!(state, State::Running))
-            .times(1)
-            .returning(|_, _| ());
-        state
-            .expect_update_node_state()
             .withf(|_, state| matches!(state, State::Failed { .. }))
             .times(1)
             .returning(|_, _| ());
@@ -810,11 +879,6 @@ mod tests {
         let mut state = MockRootState::new();
         state.expect_update_state().returning(|_| ());
         state.expect_set_matrix().returning(|_| ());
-        state
-            .expect_update_node_state()
-            .withf(|_, state| matches!(state, State::Running))
-            .times(3)
-            .returning(|_, _| ());
         state
             .expect_update_node_state()
             .withf(|_, state| matches!(state, State::Failed { .. }))

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -145,13 +145,7 @@ impl<S: RootState> ActionRunner<S> {
     }
 
     async fn run_step(&mut self, step: &Step) -> Result<()> {
-        let condition = self.condition(step.condition());
-        let result = match condition {
-            Ok(false) => {
-                debug!("condition failed, skiping step");
-                return Ok(());
-            }
-            Err(e) => Err(e),
+        let result = match self.condition(step.condition()) {
             Ok(true) => {
                 self.state.update_node_state(step.id(), State::Running);
                 match step {
@@ -161,6 +155,11 @@ impl<S: RootState> ActionRunner<S> {
                     Step::UploadArtifact(upload) => self.upload_artifact(upload).await,
                 }
             }
+            Ok(false) => {
+                debug!("condition failed, skiping step");
+                return Ok(());
+            }
+            Err(e) => Err(e),
         };
 
         result

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -246,13 +246,7 @@ impl<S: RootState> JobRunner<S> {
     }
 
     async fn step(&mut self, step: &Step) -> Result<()> {
-        let condition = self.condition(step.condition());
-        let result = match condition {
-            Ok(false) => {
-                debug!("condition failed, skiping step");
-                return Ok(());
-            }
-            Err(e) => Err(e),
+        let result = match self.condition(step.condition()) {
             Ok(true) => {
                 self.options
                     .state
@@ -264,7 +258,13 @@ impl<S: RootState> JobRunner<S> {
                     Step::UploadArtifact(upload) => self.upload_artifact(upload).await,
                 }
             }
+            Ok(false) => {
+                debug!("condition failed, skiping step");
+                return Ok(());
+            }
+            Err(e) => Err(e),
         };
+
         result
             .inspect(|_| {
                 self.options

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -246,14 +246,24 @@ impl<S: RootState> JobRunner<S> {
     }
 
     async fn step(&mut self, step: &Step) -> Result<()> {
-        self.options
-            .state
-            .update_node_state(step.id(), State::Running);
-        let result = match step {
-            Step::ComplexSh(complex) => self.complex_shell(complex).await,
-            Step::ExternalFile(external) => self.external(external).await,
-            Step::DownloadArtifact(download) => self.download_artifact(download).await,
-            Step::UploadArtifact(upload) => self.upload_artifact(upload).await,
+        let condition = self.condition(step.condition());
+        let result = match condition {
+            Ok(false) => {
+                debug!("condition failed, skiping step");
+                return Ok(());
+            }
+            Err(e) => Err(e),
+            Ok(true) => {
+                self.options
+                    .state
+                    .update_node_state(step.id(), State::Running);
+                match step {
+                    Step::ComplexSh(complex) => self.complex_shell(complex).await,
+                    Step::ExternalFile(external) => self.external(external).await,
+                    Step::DownloadArtifact(download) => self.download_artifact(download).await,
+                    Step::UploadArtifact(upload) => self.upload_artifact(upload).await,
+                }
+            }
         };
         result
             .inspect(|_| {
@@ -272,13 +282,6 @@ impl<S: RootState> JobRunner<S> {
     }
 
     async fn complex_shell(&mut self, complex: &ShellCommand) -> Result<()> {
-        let condition = complex.condition.as_deref();
-
-        if !self.condition(condition)? {
-            debug!("condition failed, skiping step");
-            return Ok(());
-        }
-
         if let Some(name) = complex.name.as_ref() {
             let mut message = String::new();
             writeln!(message, "{:<15}: {name}", "Step")?;
@@ -640,6 +643,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::{
+        artifacts::v3::DownloadArtifact,
         expr::v3::{
             context::CommonReadonlyRuntimeExprContext,
             parser::EXPR_REGEX,
@@ -1317,11 +1321,6 @@ mod tests {
         state.expect_set_matrix().returning(|_| ());
         state
             .expect_update_node_state()
-            .withf(|_, state| matches!(state, State::Running))
-            .times(1)
-            .returning(|_, _| ());
-        state
-            .expect_update_node_state()
             .withf(|_, state| matches!(state, State::Failed { .. }))
             .times(1)
             .returning(|_, _| ());
@@ -1393,11 +1392,6 @@ mod tests {
         let mut state = MockRootState::new();
         state.expect_update_state().returning(|_| ());
         state.expect_set_matrix().returning(|_| ());
-        state
-            .expect_update_node_state()
-            .withf(|_, state| matches!(state, State::Running))
-            .times(3)
-            .returning(|_, _| ());
         state
             .expect_update_node_state()
             .withf(|_, state| matches!(state, State::Failed { .. }))
@@ -1521,6 +1515,130 @@ steps:
             runs_on: RunsOn::default(),
             outputs: HashMap::new(),
         }
+    }
+
+    #[tokio::test]
+    pub async fn download_artifact_step_with_false_condition_is_skipped() {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let mut state = JobState::new(&job_name);
+        state.add_node("download");
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.clone(),
+            Job {
+                steps: vec![Step::DownloadArtifact(Box::new(DownloadArtifact {
+                    id: "download".to_string(),
+                    download: "artifact-name".to_string(),
+                    to: "some/path".to_string(),
+                    condition: Some("${{ false }}".to_string()),
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+        let runner = JobRunner {
+            options,
+            platform,
+            runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
+        };
+
+        let result = runner.run().await;
+        assert!(result.is_ok(), "error: {:?}", result.err());
+
+        let runner = result.unwrap();
+        assert!(matches!(
+            runner.options.state.get_node_state("download"),
+            Some(State::Default)
+        ));
+    }
+
+    #[tokio::test]
+    pub async fn download_artifact_step_with_true_condition_runs() {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let mut state = JobState::new(&job_name);
+        state.add_node("download");
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.clone(),
+            Job {
+                steps: vec![Step::DownloadArtifact(Box::new(DownloadArtifact {
+                    id: "download".to_string(),
+                    download: "artifact-name".to_string(),
+                    to: "some/path".to_string(),
+                    condition: Some("${{ true }}".to_string()),
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+        let runner = JobRunner {
+            options,
+            platform,
+            runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
+        };
+
+        let result = runner.run().await;
+        assert!(result.is_ok(), "error: {:?}", result.err());
+
+        let runner = result.unwrap();
+        assert!(matches!(
+            runner.options.state.get_node_state("download"),
+            Some(State::Completed)
+        ));
     }
 
     #[actix_web::test]

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -18,7 +18,7 @@ use {
             },
         },
         strategy::v3::validate_matrix_refs,
-        validator::v3::{ExprScope, Validate, ValidatorContext},
+        validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
     },
     anyhow::{Result, bail},
     bld_core::fs::FileSystem,
@@ -93,6 +93,15 @@ impl Step {
         }
     }
 
+    pub fn condition(&self) -> Option<&str> {
+        match self {
+            Self::ComplexSh(cmd) => cmd.condition.as_deref(),
+            Self::ExternalFile(ext) => ext.condition.as_deref(),
+            Self::DownloadArtifact(download) => download.condition.as_deref(),
+            Self::UploadArtifact(upload) => upload.condition.as_deref(),
+        }
+    }
+
     #[cfg(feature = "all")]
     pub async fn validate_matrix<'a, C: ValidatorContext<'a>>(
         &'a self,
@@ -164,12 +173,27 @@ impl Step {
                 }
                 values.extend(ext.with.values().map(|x| x.as_str()));
                 values.extend(ext.env.values().map(|x| x.as_str()));
+                if let Some(cond) = ext.condition.as_deref() {
+                    values.push(cond);
+                }
                 values
             }
 
-            Step::DownloadArtifact(download) => vec![download.to.as_str()],
+            Step::DownloadArtifact(download) => {
+                let mut values = vec![download.to.as_str()];
+                if let Some(cond) = download.condition.as_deref() {
+                    values.push(cond);
+                }
+                values
+            }
 
-            Step::UploadArtifact(upload) => vec![upload.upload.as_str()],
+            Step::UploadArtifact(upload) => {
+                let mut values = vec![upload.upload.as_str()];
+                if let Some(cond) = upload.condition.as_deref() {
+                    values.push(cond);
+                }
+                values
+            }
         }
     }
 }
@@ -286,19 +310,8 @@ impl<'a> Validate<'a> for Step {
                     ctx.pop_section();
                 }
 
-                if let Some(condition) = complex.condition.as_ref() {
-                    debug!("Validating step's if condition");
-                    ctx.push_section("if");
-                    let expr_count = ctx.expression_count(condition);
-                    if expr_count == 0 {
-                        ctx.append_error("Condition must contain exactly one expression");
-                    } else if expr_count > 1 {
-                        ctx.append_error("Condition must contain at most one expression");
-                    } else {
-                        ctx.validate_condition_expression(condition, ExprScope::Runtime);
-                    }
-                    ctx.pop_section();
-                }
+                debug!("Validating step's if condition");
+                validate_condition(ctx, complex.condition.as_deref());
 
                 debug!("Validating step's run command");
                 ctx.push_section("run");
@@ -346,6 +359,7 @@ mod tests {
 
     use crate::{
         action::v3::Action,
+        artifacts::v3::{DownloadArtifact, UploadArtifact},
         expr::v3::{
             context::CommonReadonlyRuntimeExprContext,
             exec::CommonExprExecutor,
@@ -801,6 +815,54 @@ mod tests {
         }
     }
 
+    #[test]
+    pub fn external_step_deserializes_if_key() {
+        let step: Step = serde_yaml_ng::from_str(
+            "uses: actions/deploy.yaml\nif: '${{ inputs.environment == \"production\" }}'",
+        )
+        .unwrap();
+
+        let Step::ExternalFile(external) = step else {
+            panic!("expected an external step, got {step:?}");
+        };
+        assert_eq!(
+            external.condition.as_deref(),
+            Some(r#"${{ inputs.environment == "production" }}"#)
+        );
+    }
+
+    #[test]
+    pub fn upload_artifact_step_deserializes_if_key() {
+        let step: Step = serde_yaml_ng::from_str(
+            "upload: report.xml\nname: test-report\nif: '${{ inputs.upload_report }}'",
+        )
+        .unwrap();
+
+        let Step::UploadArtifact(upload) = step else {
+            panic!("expected an upload step, got {step:?}");
+        };
+        assert_eq!(
+            upload.condition.as_deref(),
+            Some("${{ inputs.upload_report }}")
+        );
+    }
+
+    #[test]
+    pub fn download_artifact_step_deserializes_if_key() {
+        let step: Step = serde_yaml_ng::from_str(
+            "download: test-report\nto: reports\nif: '${{ inputs.download_report }}'",
+        )
+        .unwrap();
+
+        let Step::DownloadArtifact(download) = step else {
+            panic!("expected a download step, got {step:?}");
+        };
+        assert_eq!(
+            download.condition.as_deref(),
+            Some("${{ inputs.download_report }}")
+        );
+    }
+
     async fn validate_action(action: &Action) -> anyhow::Result<()> {
         let config = BldConfig::default().into_arc();
         let fs = FileSystem::local(config.clone()).into_arc();
@@ -862,6 +924,57 @@ mod tests {
         let result = validate_action(&action).await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn artifact_condition_with_multiple_expressions_fails_validation() {
+        let mut action = Action::default();
+        action
+            .steps
+            .push(Step::UploadArtifact(Box::new(UploadArtifact {
+                id: "upload".to_string(),
+                upload: "report.xml".to_string(),
+                name: "test-report".to_string(),
+                condition: Some("${{ true }} ${{ false }}".to_string()),
+            })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    pub async fn artifact_condition_with_unknown_step_output_fails_validation() {
+        let mut action = Action::default();
+        action
+            .steps
+            .push(Step::DownloadArtifact(Box::new(DownloadArtifact {
+                id: "download".to_string(),
+                download: "test-report".to_string(),
+                to: "reports".to_string(),
+                condition: Some("${{ steps.missing.outputs.value }}".to_string()),
+            })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    pub async fn artifact_condition_with_single_expression_passes_validation() {
+        let mut action = Action::default();
+        action
+            .steps
+            .push(Step::DownloadArtifact(Box::new(DownloadArtifact {
+                id: "download".to_string(),
+                download: "test-report".to_string(),
+                to: "reports".to_string(),
+                condition: Some("${{ true }}".to_string()),
+            })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
     }
 
     #[tokio::test]

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -18,7 +18,7 @@ use {
             },
         },
         strategy::v3::validate_matrix_refs,
-        validator::v3::{ExprScope, Validate, ValidatorContext, validate_condition},
+        validator::v3::{ExprScope, Validate, ValidatorContext},
     },
     anyhow::{Result, bail},
     bld_core::fs::FileSystem,
@@ -311,7 +311,7 @@ impl<'a> Validate<'a> for Step {
                 }
 
                 debug!("Validating step's if condition");
-                validate_condition(ctx, complex.condition.as_deref());
+                ctx.validate_condition(complex.condition.as_deref());
 
                 debug!("Validating step's run command");
                 ctx.push_section("run");

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -310,8 +310,12 @@ impl<'a> Validate<'a> for Step {
                     ctx.pop_section();
                 }
 
-                debug!("Validating step's if condition");
-                ctx.validate_condition(complex.condition.as_deref());
+                if let Some(condition) = &complex.condition {
+                    debug!("Validating step's if condition");
+                    ctx.push_section("if");
+                    ctx.validate_condition(condition, ExprScope::Runtime);
+                    ctx.pop_section();
+                }
 
                 debug!("Validating step's run command");
                 ctx.push_section("run");

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -298,18 +298,6 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
         }
     }
 
-    fn validate_condition_expression(&mut self, value: &'a str, scope: ExprScope) {
-        match scope {
-            ExprScope::StartOfRun => self.eval_condition_expression(value, &START_OF_RUN_WCTX),
-            ExprScope::Runtime => {
-                let Some(expr_wctx) = self.runtime_wctx() else {
-                    return;
-                };
-                self.eval_condition_expression(value, expr_wctx)
-            }
-        }
-    }
-
     fn matrix_refs(&self, value: &str) -> Vec<String> {
         let mut result = Vec::new();
         for entry in self.expr_regex.find_iter(value) {
@@ -371,21 +359,25 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
         }
     }
 
-    fn validate_condition(&mut self, condition: Option<&'a str>) {
-        let Some(condition) = condition else {
-            return;
-        };
-
-        self.push_section("if");
+    fn validate_condition(&mut self, condition: &'a str, scope: ExprScope) {
         let expr_count = self.expression_count(condition);
         if expr_count == 0 {
             self.append_error("Condition must contain exactly one expression");
         } else if expr_count > 1 {
             self.append_error("Condition must contain at most one expression");
         } else {
-            self.validate_expressions(condition, ExprScope::Runtime);
+            match scope {
+                ExprScope::StartOfRun => {
+                    self.eval_condition_expression(condition, &START_OF_RUN_WCTX)
+                }
+                ExprScope::Runtime => {
+                    let Some(expr_wctx) = self.runtime_wctx() else {
+                        return;
+                    };
+                    self.eval_condition_expression(condition, expr_wctx)
+                }
+            }
         }
-        self.pop_section();
     }
 }
 

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -370,23 +370,23 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
             self.section.pop();
         }
     }
-}
 
-pub fn validate_condition<'a, C: ValidatorContext<'a>>(ctx: &mut C, condition: Option<&'a str>) {
-    let Some(condition) = condition else {
-        return;
-    };
+    fn validate_condition(&mut self, condition: Option<&'a str>) {
+        let Some(condition) = condition else {
+            return;
+        };
 
-    ctx.push_section("if");
-    let expr_count = ctx.expression_count(condition);
-    if expr_count == 0 {
-        ctx.append_error("Condition must contain exactly one expression");
-    } else if expr_count > 1 {
-        ctx.append_error("Condition must contain at most one expression");
-    } else {
-        ctx.validate_expressions(condition, ExprScope::Runtime);
+        self.push_section("if");
+        let expr_count = self.expression_count(condition);
+        if expr_count == 0 {
+            self.append_error("Condition must contain exactly one expression");
+        } else if expr_count > 1 {
+            self.append_error("Condition must contain at most one expression");
+        } else {
+            self.validate_expressions(condition, ExprScope::Runtime);
+        }
+        self.pop_section();
     }
-    ctx.pop_section();
 }
 
 impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ConsumeValidator for CommonValidator<'a, V> {

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -372,6 +372,23 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
     }
 }
 
+pub fn validate_condition<'a, C: ValidatorContext<'a>>(ctx: &mut C, condition: Option<&'a str>) {
+    let Some(condition) = condition else {
+        return;
+    };
+
+    ctx.push_section("if");
+    let expr_count = ctx.expression_count(condition);
+    if expr_count == 0 {
+        ctx.append_error("Condition must contain exactly one expression");
+    } else if expr_count > 1 {
+        ctx.append_error("Condition must contain at most one expression");
+    } else {
+        ctx.validate_expressions(condition, ExprScope::Runtime);
+    }
+    ctx.pop_section();
+}
+
 impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ConsumeValidator for CommonValidator<'a, V> {
     async fn validate(mut self) -> Result<()> {
         self.validatable.validate(&mut self).await;

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -30,6 +30,7 @@ pub trait ValidatorContext<'a> {
     fn job_output_refs(&self, value: &str) -> Vec<String>;
     fn validate_file_path(&mut self, value: &'a str);
     fn validate_env(&mut self, env: &'a HashMap<String, String>, scope: ExprScope);
+    fn validate_condition(&mut self, condition: Option<&'a str>);
 }
 
 pub trait ConsumeValidator {

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use anyhow::Result;
 use bld_config::BldConfig;
@@ -25,12 +28,11 @@ pub trait ValidatorContext<'a> {
     fn contains_expressions(&mut self, value: &str) -> bool;
     fn validate_expressions(&mut self, symbol: &'a str, scope: ExprScope);
     fn validate_array_expression(&mut self, symbol: &'a str, scope: ExprScope);
-    fn validate_condition_expression(&mut self, symbol: &'a str, scope: ExprScope);
     fn matrix_refs(&self, value: &str) -> Vec<String>;
     fn job_output_refs(&self, value: &str) -> Vec<String>;
     fn validate_file_path(&mut self, value: &'a str);
     fn validate_env(&mut self, env: &'a HashMap<String, String>, scope: ExprScope);
-    fn validate_condition(&mut self, condition: Option<&'a str>);
+    fn validate_condition(&mut self, condition: &'a str, scope: ExprScope);
 }
 
 pub trait ConsumeValidator {

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use bld_config::BldConfig;


### PR DESCRIPTION
### In this PR

- Added the `if` key to the external, upload and download step types of a version 3 file, matching the shell step.
- Added `Step::condition` so the runner can read the condition of any step type, following the existing `id` and `strategy` accessors.
- Moved the condition check out of the shell step and into the step dispatch of both the pipeline runner and the action runner, so it happens once per runner and before the step's state is set to `Running`.
- Kept a step whose condition fails to evaluate marked as `Failed`, with the remaining steps of the job unaffected by a skipped step.
- Extracted the condition validation of the shell step into a shared `validate_condition` helper and applied it to all four step types, keeping the single expression and run time scope rules.
- Added tests for skipping and running a non shell step in both runners, for deserializing the `if` key on each new step type and for validating conditions on artifact steps.

Closes #372
