### PR TITLE
fix(bld_runner): Accept text true and false in a v3 condition

### DIFF
--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -100,19 +100,6 @@ impl<'a, 'b> ExprValue<'a> {
         }
     }
 
-    /// Checks the value of a condition during validation. The value of an input or of a
-    /// step output is not known yet, and both are text, so every text value is accepted
-    /// here and only a type that can never be a condition is reported.
-    pub fn validate_as_condition(&self) -> Result<()> {
-        match self {
-            Self::Boolean(_) | Self::Text(_) | Self::Unknown => Ok(()),
-            other => bail!(
-                "a condition must give a boolean value, but it gives {}",
-                other.type_as_string()
-            ),
-        }
-    }
-
     pub fn try_eq(&self, other: &'a Self) -> Result<ExprValue<'b>> {
         if matches!(self, Self::Unknown) || matches!(other, Self::Unknown) {
             return Ok(ExprValue::<'b>::Boolean(true));
@@ -424,28 +411,5 @@ pub mod tests {
     fn arbitrary_text_gives_an_error() {
         let res: Result<bool> = ExprValue::Text(ExprText::Owned("yes".to_string())).try_into();
         assert!(res.unwrap_err().to_string().contains("text"));
-    }
-
-    #[test]
-    fn validation_accepts_every_text_and_an_unknown_value() {
-        assert!(
-            ExprValue::Text(ExprText::Owned(String::new()))
-                .validate_as_condition()
-                .is_ok()
-        );
-        assert!(
-            ExprValue::Text(ExprText::Owned("yes".to_string()))
-                .validate_as_condition()
-                .is_ok()
-        );
-        assert!(ExprValue::Unknown.validate_as_condition().is_ok());
-        assert!(ExprValue::Boolean(false).validate_as_condition().is_ok());
-    }
-
-    #[test]
-    fn validation_rejects_a_number_and_an_array() {
-        let err = expr_number(1.0).validate_as_condition().unwrap_err();
-        assert!(err.to_string().contains("number"));
-        assert!(ExprValue::Array(vec![]).validate_as_condition().is_err());
     }
 }

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -100,22 +100,6 @@ impl<'a, 'b> ExprValue<'a> {
         }
     }
 
-    /// Interprets the value of a condition (a job's or a step's `if`). A boolean value
-    /// is used as is. A text value of `"true"` or `"false"` is accepted too, since an
-    /// input is always given as text. Any other value is an error, so a condition that
-    /// cannot be true or false does not silently skip a step.
-    pub fn try_as_condition(&self) -> Result<bool> {
-        match self {
-            Self::Boolean(value) => Ok(*value),
-            Self::Text(text) if text.inner() == "true" => Ok(true),
-            Self::Text(text) if text.inner() == "false" => Ok(false),
-            other => bail!(
-                "a condition must give a boolean value, but it gives {}",
-                other.type_as_string()
-            ),
-        }
-    }
-
     /// Checks the value of a condition during validation. The value of an input or of a
     /// step output is not known yet, and both are text, so every text value is accepted
     /// here and only a type that can never be a condition is reported.
@@ -268,6 +252,22 @@ impl<'b> TryFrom<&'b str> for ExprValue<'_> {
     }
 }
 
+impl TryInto<bool> for ExprValue<'_> {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<bool> {
+        match self {
+            Self::Boolean(value) => Ok(value),
+            Self::Text(text) if text.inner() == "true" => Ok(true),
+            Self::Text(text) if text.inner() == "false" => Ok(false),
+            other => bail!(
+                "a condition must give a boolean value, but it gives {}",
+                other.type_as_string()
+            ),
+        }
+    }
+}
+
 impl TryFrom<String> for ExprValue<'_> {
     type Error = anyhow::Error;
 
@@ -343,6 +343,7 @@ pub trait EvalExpr<'a> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use anyhow::Result;
 
     pub fn expr_number<'a>(value: f64) -> ExprValue<'a> {
         ExprValue::Number {
@@ -391,41 +392,37 @@ pub mod tests {
 
     #[test]
     fn boolean_true_and_false_are_used_as_is() {
-        assert!(ExprValue::Boolean(true).try_as_condition().unwrap());
-        assert!(!ExprValue::Boolean(false).try_as_condition().unwrap());
+        assert!(TryInto::<bool>::try_into(ExprValue::Boolean(true)).unwrap());
+        assert!(!TryInto::<bool>::try_into(ExprValue::Boolean(false)).unwrap());
     }
 
     #[test]
     fn text_true_and_false_are_accepted_since_inputs_are_always_text() {
         assert!(
-            ExprValue::Text(ExprText::Owned("true".to_string()))
-                .try_as_condition()
+            TryInto::<bool>::try_into(ExprValue::Text(ExprText::Owned("true".to_string())))
                 .unwrap()
         );
         assert!(
-            !ExprValue::Text(ExprText::Owned("false".to_string()))
-                .try_as_condition()
+            !TryInto::<bool>::try_into(ExprValue::Text(ExprText::Owned("false".to_string())))
                 .unwrap()
         );
     }
 
     #[test]
     fn number_gives_an_error_naming_the_type() {
-        let err = ExprValue::Number(1.0).try_as_condition().unwrap_err();
-        assert!(err.to_string().contains("number"));
+        let res: Result<bool> = ExprValue::Number(1.0).try_into();
+        assert!(res.unwrap_err().to_string().contains("number"));
     }
 
     #[test]
     fn array_gives_an_error() {
-        assert!(ExprValue::Array(vec![]).try_as_condition().is_err());
+        assert!(TryInto::<bool>::try_into(ExprValue::Array(vec![])).is_err());
     }
 
     #[test]
     fn arbitrary_text_gives_an_error() {
-        let err = ExprValue::Text(ExprText::Owned("yes".to_string()))
-            .try_as_condition()
-            .unwrap_err();
-        assert!(err.to_string().contains("text"));
+        let res: Result<bool> = ExprValue::Text(ExprText::Owned("yes".to_string())).try_into();
+        assert!(res.unwrap_err().to_string().contains("text"));
     }
 
     #[test]

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -100,6 +100,35 @@ impl<'a, 'b> ExprValue<'a> {
         }
     }
 
+    /// Interprets the value of a condition (a job's or a step's `if`). A boolean value
+    /// is used as is. A text value of `"true"` or `"false"` is accepted too, since an
+    /// input is always given as text. Any other value is an error, so a condition that
+    /// cannot be true or false does not silently skip a step.
+    pub fn try_as_condition(&self) -> Result<bool> {
+        match self {
+            Self::Boolean(value) => Ok(*value),
+            Self::Text(text) if text.inner() == "true" => Ok(true),
+            Self::Text(text) if text.inner() == "false" => Ok(false),
+            other => bail!(
+                "a condition must give a boolean value, but it gives {}",
+                other.type_as_string()
+            ),
+        }
+    }
+
+    /// Checks the value of a condition during validation. The value of an input or of a
+    /// step output is not known yet, and both are text, so every text value is accepted
+    /// here and only a type that can never be a condition is reported.
+    pub fn validate_as_condition(&self) -> Result<()> {
+        match self {
+            Self::Boolean(_) | Self::Text(_) | Self::Unknown => Ok(()),
+            other => bail!(
+                "a condition must give a boolean value, but it gives {}",
+                other.type_as_string()
+            ),
+        }
+    }
+
     pub fn try_eq(&self, other: &'a Self) -> Result<ExprValue<'b>> {
         if matches!(self, Self::Unknown) || matches!(other, Self::Unknown) {
             return Ok(ExprValue::<'b>::Boolean(true));
@@ -359,5 +388,66 @@ pub mod tests {
             panic!("expected boolean");
         };
         assert!(greater);
+
+    #[test]
+    fn boolean_true_and_false_are_used_as_is() {
+        assert!(ExprValue::Boolean(true).try_as_condition().unwrap());
+        assert!(!ExprValue::Boolean(false).try_as_condition().unwrap());
+    }
+
+    #[test]
+    fn text_true_and_false_are_accepted_since_inputs_are_always_text() {
+        assert!(
+            ExprValue::Text(ExprText::Owned("true".to_string()))
+                .try_as_condition()
+                .unwrap()
+        );
+        assert!(
+            !ExprValue::Text(ExprText::Owned("false".to_string()))
+                .try_as_condition()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn number_gives_an_error_naming_the_type() {
+        let err = ExprValue::Number(1.0).try_as_condition().unwrap_err();
+        assert!(err.to_string().contains("number"));
+    }
+
+    #[test]
+    fn array_gives_an_error() {
+        assert!(ExprValue::Array(vec![]).try_as_condition().is_err());
+    }
+
+    #[test]
+    fn arbitrary_text_gives_an_error() {
+        let err = ExprValue::Text(ExprText::Owned("yes".to_string()))
+            .try_as_condition()
+            .unwrap_err();
+        assert!(err.to_string().contains("text"));
+    }
+
+    #[test]
+    fn validation_accepts_every_text_and_an_unknown_value() {
+        assert!(
+            ExprValue::Text(ExprText::Owned(String::new()))
+                .validate_as_condition()
+                .is_ok()
+        );
+        assert!(
+            ExprValue::Text(ExprText::Owned("yes".to_string()))
+                .validate_as_condition()
+                .is_ok()
+        );
+        assert!(ExprValue::Unknown.validate_as_condition().is_ok());
+        assert!(ExprValue::Boolean(false).validate_as_condition().is_ok());
+    }
+
+    #[test]
+    fn validation_rejects_a_number_and_an_array() {
+        let err = ExprValue::Number(1.0).validate_as_condition().unwrap_err();
+        assert!(err.to_string().contains("number"));
+        assert!(ExprValue::Array(vec![]).validate_as_condition().is_err());
     }
 }

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -389,6 +389,7 @@ pub mod tests {
             panic!("expected boolean");
         };
         assert!(greater);
+    }
 
     #[test]
     fn boolean_true_and_false_are_used_as_is() {
@@ -410,7 +411,7 @@ pub mod tests {
 
     #[test]
     fn number_gives_an_error_naming_the_type() {
-        let res: Result<bool> = ExprValue::Number(1.0).try_into();
+        let res: Result<bool> = expr_number(1.0).try_into();
         assert!(res.unwrap_err().to_string().contains("number"));
     }
 
@@ -443,7 +444,7 @@ pub mod tests {
 
     #[test]
     fn validation_rejects_a_number_and_an_array() {
-        let err = ExprValue::Number(1.0).validate_as_condition().unwrap_err();
+        let err = expr_number(1.0).validate_as_condition().unwrap_err();
         assert!(err.to_string().contains("number"));
         assert!(ExprValue::Array(vec![]).validate_as_condition().is_err());
     }

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -198,7 +198,7 @@ impl<'a> Validate<'a> for Job {
             if ctx.expression_count(condition) > 1 {
                 ctx.append_error("Condition must contain at most one expression");
             } else {
-                ctx.validate_expressions(condition, ExprScope::StartOfRun);
+                ctx.validate_condition_expression(condition, ExprScope::StartOfRun);
             }
             validate_matrix_refs(ctx, condition, &HashSet::new());
             ctx.pop_section();

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -410,6 +410,8 @@ mod tests {
 
         fn validate_array_expression(&mut self, _symbol: &'a str, _scope: ExprScope) {}
 
+        fn validate_condition_expression(&mut self, _symbol: &'a str, _scope: ExprScope) {}
+
         fn matrix_refs(&self, _value: &str) -> Vec<String> {
             vec![]
         }
@@ -503,6 +505,32 @@ mod tests {
                     id: "build".to_string(),
                     run: "echo ${{ inputs.worktree_dir }}".to_string(),
                     working_dir: Some("${{ inputs.worktree_dir }}".to_string()),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let result = validate_pipeline(pipeline).await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    /// An input is always text and validation stands in an empty value for it, so a
+    /// condition that uses an input can only be checked when the run evaluates it.
+    #[tokio::test]
+    pub async fn condition_that_uses_an_input_validation_success() {
+        let mut pipeline = Pipeline::default();
+        pipeline
+            .inputs
+            .insert("flag".to_string(), complex_input("true"));
+        pipeline.jobs.insert(
+            "main".to_string(),
+            Job {
+                condition: Some("${{ inputs.flag }}".to_string()),
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "a".to_string(),
+                    run: "echo A RAN".to_string(),
+                    condition: Some("${{ inputs.flag }}".to_string()),
                     ..Default::default()
                 }))],
                 ..Default::default()

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -77,7 +77,7 @@ impl<S: RootState> ActionRunner<S> {
 
         let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &self.state);
         let value = expr_exec.eval(condition)?;
-        value.try_as_condition()
+        value.try_into()
     }
 
     fn resolve_working_dir(&mut self, working_dir: &Option<String>) -> Result<Option<String>> {

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -77,7 +77,7 @@ impl<S: RootState> ActionRunner<S> {
 
         let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &self.state);
         let value = expr_exec.eval(condition)?;
-        Ok(matches!(value, ExprValue::Boolean(true)))
+        value.try_as_condition()
     }
 
     fn resolve_working_dir(&mut self, working_dir: &Option<String>) -> Result<Option<String>> {

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -20,7 +20,7 @@ use crate::{
     expr::v3::{
         context::CommonReadonlyRuntimeExprContext,
         exec::{CommonExprExecutor, eval_all_expressions, eval_all_expressions_map},
-        traits::{EvalExpr, ExprValue},
+        traits::EvalExpr,
     },
     external::v3::External,
     runner::v3::state::{ActionState, RootState, State},

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -27,7 +27,7 @@ use crate::{
     expr::v3::{
         context::{CommonReadonlyRuntimeExprContext, START_OF_RUN_WCTX},
         exec::{CommonExprExecutor, eval_all_expressions, eval_all_expressions_map},
-        traits::{EvalExpr, ExprValue},
+        traits::EvalExpr,
     },
     external::v3::External,
     job::v3::Job,
@@ -241,7 +241,7 @@ impl<S: RootState> JobRunner<S> {
         debug!("printing job informantion");
         self.options
             .logger
-            .write_line(format!("{:<15}: {}", "Runs on", &self.runs_on))
+            .write_line(format!("{:<15}: {}", "Runs on", self.runs_on))
             .await
     }
 
@@ -747,6 +747,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         // A text value of "true" starts the step, mirroring an input whose value is "true".

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -463,7 +463,7 @@ impl<S: RootState> JobRunner<S> {
         };
 
         let value = expr_exec.eval(condition)?;
-        value.try_as_condition()
+        value.try_into()
     }
 
     fn eval_all_expr(&mut self, value: &str) -> Result<String> {

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -463,7 +463,7 @@ impl<S: RootState> JobRunner<S> {
         };
 
         let value = expr_exec.eval(condition)?;
-        Ok(matches!(value, ExprValue::Boolean(true)))
+        value.try_as_condition()
     }
 
     fn eval_all_expr(&mut self, value: &str) -> Result<String> {
@@ -710,6 +710,57 @@ mod tests {
             job.condition(Some("hello world ${{ true == \"James\" }}"))
                 .is_err()
         );
+    }
+
+    #[test]
+    pub fn condition_eval_accepts_text_true_and_false() {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let state = JobState::default();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let pipeline = Pipeline::default().into_arc();
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline,
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+        let job = JobRunner {
+            options,
+            platform,
+            runs_on: RunsOn::default(),
+        };
+
+        // A text value of "true" starts the step, mirroring an input whose value is "true".
+        assert!(matches!(job.condition(Some("${{ \"true\" }}")), Ok(true)));
+
+        // A text value of "false" skips the step, mirroring an input whose value is "false".
+        assert!(matches!(job.condition(Some("${{ \"false\" }}")), Ok(false)));
+
+        // A number is not a valid condition value and must produce an error naming the type.
+        let number_err = job.condition(Some("${{ 1 }}")).unwrap_err();
+        assert!(number_err.to_string().contains("number"));
+
+        // An array is not a valid condition value and must produce an error.
+        assert!(job.condition(Some("${{ [1, 2] }}")).is_err());
     }
 
     #[test]

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -475,7 +475,7 @@ mod tests {
         }
 
         for (name, value) in &data {
-            let actual = state.get_output(&id, name).unwrap();
+            let actual = state.get_output(OutputScope::Step, &id, name).unwrap();
             assert_eq!(
                 actual.to_string(),
                 *value,

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -295,7 +295,7 @@ impl<'a> Validate<'a> for Step {
                     } else if expr_count > 1 {
                         ctx.append_error("Condition must contain at most one expression");
                     } else {
-                        ctx.validate_expressions(condition, ExprScope::Runtime);
+                        ctx.validate_condition_expression(condition, ExprScope::Runtime);
                     }
                     ctx.pop_section();
                 }
@@ -912,6 +912,66 @@ mod tests {
         let result = validate_action(&action).await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn condition_with_text_true_or_false_passes_validation() {
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "first".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo hello".to_string(),
+            condition: Some("${{ \"true\" }}".to_string()),
+            strategy: None,
+        })));
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "second".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo hello".to_string(),
+            condition: Some("${{ \"false\" }}".to_string()),
+            strategy: None,
+        })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn condition_with_number_fails_validation_with_type_in_message() {
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "first".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo hello".to_string(),
+            condition: Some("${{ 1 }}".to_string()),
+            strategy: None,
+        })));
+
+        let result = validate_action(&action).await;
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("number"));
+    }
+
+    #[tokio::test]
+    pub async fn condition_with_array_fails_validation() {
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "first".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo hello".to_string(),
+            condition: Some("${{ [1, 2] }}".to_string()),
+            strategy: None,
+        })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -195,6 +195,28 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
             }
         }
     }
+
+    fn eval_condition_expression<W: WritableRuntimeExprContext>(
+        &mut self,
+        value: &'a str,
+        wctx: &'a W,
+    ) {
+        let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, wctx);
+        for entry in self.expr_regex.find_iter(value) {
+            match expr_exec.eval(entry.as_str()) {
+                Ok(value) => {
+                    if let Err(e) = value.validate_as_condition() {
+                        let section = self.section_txt();
+                        let _ = writeln!(self.errors, "[{section}] {}", e);
+                    }
+                }
+                Err(e) => {
+                    let section = self.section_txt();
+                    let _ = writeln!(self.errors, "[{section}] {}", e);
+                }
+            }
+        }
+    }
 }
 
 impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for CommonValidator<'a, V> {
@@ -269,6 +291,18 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
                     return;
                 };
                 self.eval_array_expression(value, expr_wctx)
+            }
+        }
+    }
+
+    fn validate_condition_expression(&mut self, value: &'a str, scope: ExprScope) {
+        match scope {
+            ExprScope::StartOfRun => self.eval_condition_expression(value, &START_OF_RUN_WCTX),
+            ExprScope::Runtime => {
+                let Some(expr_wctx) = self.runtime_wctx() else {
+                    return;
+                };
+                self.eval_condition_expression(value, expr_wctx)
             }
         }
     }

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -204,11 +204,14 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
         let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, wctx);
         for entry in self.expr_regex.find_iter(value) {
             match expr_exec.eval(entry.as_str()) {
+                Ok(ExprValue::Boolean(_)) | Ok(ExprValue::Text(_)) | Ok(ExprValue::Unknown) => {}
                 Ok(value) => {
-                    if let Err(e) = value.validate_as_condition() {
-                        let section = self.section_txt();
-                        let _ = writeln!(self.errors, "[{section}] {}", e);
-                    }
+                    let section = self.section_txt();
+                    let _ = writeln!(
+                        self.errors,
+                        "[{section}] a condition must give a boolean value, but it gives {}",
+                        value.type_as_string()
+                    );
                 }
                 Err(e) => {
                     let section = self.section_txt();

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -25,6 +25,7 @@ pub trait ValidatorContext<'a> {
     fn contains_expressions(&mut self, value: &str) -> bool;
     fn validate_expressions(&mut self, symbol: &'a str, scope: ExprScope);
     fn validate_array_expression(&mut self, symbol: &'a str, scope: ExprScope);
+    fn validate_condition_expression(&mut self, symbol: &'a str, scope: ExprScope);
     fn matrix_refs(&self, value: &str) -> Vec<String>;
     fn job_output_refs(&self, value: &str) -> Vec<String>;
     fn validate_file_path(&mut self, value: &'a str);


### PR DESCRIPTION
### In this PR

- A condition (`if`) of a v3 job or step now accepts a boolean value and the text values `"true"` and `"false"`, so `if: ${{ inputs.flag }}` works as users expect.
- Any other value of a condition, such as a number, an array or arbitrary text, now fails the run with the type in the message instead of skipping the step without a message.
- The validator reports a condition whose type can never be a condition, a number or an array, for both a job's and a step's `if`.
- The validator still accepts a text condition, since it stands in an empty value for every input and cannot know the value a run will supply.
- Tests cover the accepted and rejected values of a condition, at the level of the value, of the job runner and of validation, including a pipeline that uses an input as a condition.

Closes #353
