### PR TITLE
feat(runner): Add an outputs key to version 3 actions

### DIFF
--- a/crates/bld_commands/src/run/adapter.rs
+++ b/crates/bld_commands/src/run/adapter.rs
@@ -208,7 +208,7 @@ impl RunAdapter {
             .await?;
 
         debug!("starting run");
-        let result = runner.run().await;
+        let result = runner.run().await.map(|_| ());
         debug!("finished run");
 
         cmd_signals.stop().await?;

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     inputs::v3::Input,
+    outputs::v3::Output,
     step::v3::Step,
     traits::{IntoVariables, Variables},
 };
@@ -47,7 +48,7 @@ pub struct Action {
     pub steps: Vec<Step>,
 
     #[serde(default)]
-    pub outputs: HashMap<String, String>,
+    pub outputs: HashMap<String, Output>,
 }
 
 impl Action {
@@ -78,6 +79,13 @@ impl Action {
         } else {
             None
         }
+    }
+
+    pub fn outputs_map(&self) -> HashMap<String, String> {
+        self.outputs
+            .iter()
+            .map(|(name, output)| (name.to_owned(), output.value().to_owned()))
+            .collect()
     }
 }
 
@@ -241,10 +249,10 @@ impl<'a> Validate<'a> for Action {
 
         debug!("Validating action's outputs section");
         ctx.push_section("outputs");
-        for (name, expr) in self.outputs.iter() {
+        for (name, output) in self.outputs.iter() {
             debug!("Validating output: {}", name);
             ctx.push_section(name);
-            ctx.validate_expressions(expr, ExprScope::Runtime);
+            output.validate(ctx).await;
             ctx.pop_section();
         }
         ctx.pop_section();

--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -45,6 +45,9 @@ pub struct Action {
 
     #[serde(default)]
     pub steps: Vec<Step>,
+
+    #[serde(default)]
+    pub outputs: HashMap<String, String>,
 }
 
 impl Action {
@@ -233,6 +236,16 @@ impl<'a> Validate<'a> for Action {
             }
             step.validate(ctx).await;
             step.validate_matrix(ctx, None).await;
+        }
+        ctx.pop_section();
+
+        debug!("Validating action's outputs section");
+        ctx.push_section("outputs");
+        for (name, expr) in self.outputs.iter() {
+            debug!("Validating output: {}", name);
+            ctx.push_section(name);
+            ctx.validate_expressions(expr, ExprScope::Runtime);
+            ctx.pop_section();
         }
         ctx.pop_section();
     }

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -24,9 +24,6 @@ pub fn eval_all_expressions<'a, E: EvalExpr<'a>>(
     Ok(result)
 }
 
-/// Resolves a map of name to expression against the current runtime scope. Used both to
-/// resolve the `with`/`env` values sent into a child pipeline or action, and to resolve the
-/// `outputs` of an action once all of its steps have completed.
 pub fn eval_all_expressions_map<'a, E: EvalExpr<'a>>(
     exec: &E,
     regex: &Regex,

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::expr::v3::parser::{ExprParser, Rule};
 
 use super::traits::{
@@ -18,6 +20,21 @@ pub fn eval_all_expressions<'a, E: EvalExpr<'a>>(
         let entry = entry.as_str();
         let evaluated = exec.eval(entry)?.to_string();
         result = result.replace(entry, &evaluated);
+    }
+    Ok(result)
+}
+
+/// Resolves a map of name to expression against the current runtime scope. Used both to
+/// resolve the `with`/`env` values sent into a child pipeline or action, and to resolve the
+/// `outputs` of an action once all of its steps have completed.
+pub fn eval_all_expressions_map<'a, E: EvalExpr<'a>>(
+    exec: &E,
+    regex: &Regex,
+    values: &'a HashMap<String, String>,
+) -> Result<HashMap<String, String>> {
+    let mut result = HashMap::new();
+    for (name, value) in values {
+        result.insert(name.to_owned(), eval_all_expressions(exec, regex, value)?);
     }
     Ok(result)
 }

--- a/crates/bld_runner/src/lib.rs
+++ b/crates/bld_runner/src/lib.rs
@@ -6,6 +6,7 @@ pub mod external;
 pub mod files;
 pub mod inputs;
 pub mod job;
+pub mod outputs;
 pub mod pipeline;
 pub mod registry;
 pub mod runs_on;

--- a/crates/bld_runner/src/outputs/mod.rs
+++ b/crates/bld_runner/src/outputs/mod.rs
@@ -1,0 +1,1 @@
+pub mod v3;

--- a/crates/bld_runner/src/outputs/v3.rs
+++ b/crates/bld_runner/src/outputs/v3.rs
@@ -1,0 +1,96 @@
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "all")]
+use {
+    crate::validator::v3::{ExprScope, Validate, ValidatorContext},
+    tracing::debug,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Output {
+    Simple(String),
+    Complex {
+        description: Option<String>,
+        value: String,
+    },
+}
+
+impl Output {
+    pub fn value(&self) -> &str {
+        match self {
+            Output::Simple(v) => v,
+            Output::Complex { value, .. } => value,
+        }
+    }
+
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Output::Simple(_) => None,
+            Output::Complex { description, .. } => description.as_deref(),
+        }
+    }
+}
+
+#[cfg(feature = "all")]
+impl<'a> Validate<'a> for Output {
+    async fn validate<C: ValidatorContext<'a>>(&'a self, ctx: &mut C) {
+        match self {
+            Output::Simple(v) => {
+                debug!("Validating output: {}", v);
+                ctx.validate_expressions(v, ExprScope::Runtime);
+            }
+            Output::Complex { value, .. } => {
+                debug!("Validating output: {}", value);
+                ctx.push_section("value");
+                ctx.validate_expressions(value, ExprScope::Runtime);
+                ctx.pop_section();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Output;
+
+    #[test]
+    pub fn simple_output_deserializes_from_a_string() {
+        let output: Output = serde_yaml_ng::from_str("${{ steps.build.outputs.digest }}").unwrap();
+
+        assert!(matches!(
+            output,
+            Output::Simple(value) if value == "${{ steps.build.outputs.digest }}"
+        ));
+    }
+
+    #[test]
+    pub fn complex_output_deserializes_with_description() {
+        let output: Output = serde_yaml_ng::from_str(
+            "description: The tag of the image\nvalue: ${{ steps.push.outputs.tag }}",
+        )
+        .unwrap();
+
+        assert!(matches!(
+            output,
+            Output::Complex {
+                description: Some(description),
+                value,
+            } if description == "The tag of the image" && value == "${{ steps.push.outputs.tag }}"
+        ));
+    }
+
+    #[test]
+    pub fn complex_output_deserializes_without_description() {
+        let output: Output =
+            serde_yaml_ng::from_str("value: ${{ steps.push.outputs.tag }}").unwrap();
+
+        assert!(matches!(
+            output,
+            Output::Complex {
+                description: None,
+                value,
+            } if value == "${{ steps.push.outputs.tag }}"
+        ));
+    }
+}

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -28,7 +28,7 @@ use crate::{
     step::v1::{BuildStep, BuildStepExec},
 };
 
-type RecursiveFuture = Pin<Box<dyn Future<Output = Result<()>>>>;
+type RecursiveFuture = Pin<Box<dyn Future<Output = Result<HashMap<String, String>>>>>;
 
 pub struct Runner {
     pub run_id: String,
@@ -340,7 +340,7 @@ impl Runner {
         Ok(())
     }
 
-    async fn execute(mut self) -> Result<()> {
+    async fn execute(mut self) -> Result<HashMap<String, String>> {
         self.start().await?;
 
         // using let expression to log the errors and let an empty string be used
@@ -351,7 +351,7 @@ impl Runner {
             self.has_faulted = true;
             Err(anyhow!(""))
         } else {
-            Ok(())
+            Ok(HashMap::new())
         };
 
         self.stop().await?;
@@ -367,7 +367,7 @@ impl Runner {
             self.signals = None;
 
             if self.is_child || signals.is_none() {
-                return self.execute().await.map(|_| ());
+                return self.execute().await;
             }
 
             let context = self.context.clone();
@@ -379,7 +379,7 @@ impl Runner {
                 sleep(Duration::from_millis(200)).await;
 
                 if runner_handle.is_finished() {
-                    break runner_handle.await?.map(|_| ());
+                    break runner_handle.await?;
                 }
 
                 if let Ok(signal) = signals.try_next() {
@@ -408,7 +408,8 @@ impl Runner {
 
                             break resp_tx
                                 .send(())
-                                .map_err(|_| anyhow!("oneshot response sender dropped"));
+                                .map_err(|_| anyhow!("oneshot response sender dropped"))
+                                .map(|_| HashMap::new());
                         }
                     }
                 }

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -35,7 +35,7 @@ use crate::{
     step::v2::{BuildStep, BuildStepExec},
 };
 
-type RecursiveFuture = Pin<Box<dyn Future<Output = Result<()>>>>;
+type RecursiveFuture = Pin<Box<dyn Future<Output = Result<HashMap<String, String>>>>>;
 
 struct Job {
     pub job_name: String,
@@ -545,7 +545,7 @@ impl Runner {
         }
     }
 
-    async fn execute(mut self) -> Result<()> {
+    async fn execute(mut self) -> Result<HashMap<String, String>> {
         self.start().await?;
 
         // using let expression to log the errors and let an empty string be used
@@ -553,7 +553,7 @@ impl Runner {
 
         let Err(e) = self.jobs().await else {
             self.stop().await?;
-            return Ok(());
+            return Ok(HashMap::new());
         };
 
         self.logger.write(e.to_string()).await?;
@@ -570,7 +570,7 @@ impl Runner {
             self.signals = None;
 
             if self.is_child || signals.is_none() {
-                return self.execute().await.map(|_| ());
+                return self.execute().await;
             }
 
             let context = self.context.clone();
@@ -582,7 +582,7 @@ impl Runner {
                 sleep(Duration::from_millis(200)).await;
 
                 if runner_handle.is_finished() {
-                    break runner_handle.await?.map(|_| ());
+                    break runner_handle.await?;
                 }
 
                 if let Ok(message) = signals.try_next() {
@@ -611,7 +611,8 @@ impl Runner {
 
                             break resp_tx
                                 .send(())
-                                .map_err(|_| anyhow!("oneshot response sender dropped"));
+                                .map_err(|_| anyhow!("oneshot response sender dropped"))
+                                .map(|_| HashMap::new());
                         }
                     }
                 }

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -269,7 +269,8 @@ impl<S: RootState> ActionRunner<S> {
 
     fn resolve_outputs(&mut self) -> Result<HashMap<String, String>> {
         let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &self.state);
-        eval_all_expressions_map(&expr_exec, &self.expr_regex, &self.action.outputs)
+        let outputs = self.action.outputs_map();
+        eval_all_expressions_map(&expr_exec, &self.expr_regex, &outputs)
     }
 
     async fn download_artifact(&mut self, download: &DownloadArtifact) -> Result<()> {
@@ -369,6 +370,7 @@ mod tests {
             traits::WritableRuntimeExprContext,
         },
         external::v3::External,
+        outputs::v3::Output,
         runner::v3::{
             ActionRunner, ActionState, RootState, State, state::MockRootState, test_utils::TempDir,
         },
@@ -931,12 +933,13 @@ mod tests {
             working_dir: None,
             strategy: None,
         })));
-        action
-            .outputs
-            .insert("image".to_string(), "${{ inputs.tag }}".to_string());
+        action.outputs.insert(
+            "image".to_string(),
+            Output::Simple("${{ inputs.tag }}".to_string()),
+        );
         action.outputs.insert(
             "digest".to_string(),
-            "${{ steps.build.outputs.digest }}".to_string(),
+            Output::Simple("${{ steps.build.outputs.digest }}".to_string()),
         );
 
         let mut state = ActionState::default();
@@ -965,6 +968,60 @@ mod tests {
         let outputs = runner.resolve_outputs().unwrap();
         assert_eq!(outputs.get("image"), Some(&"my-image:latest".to_string()));
         assert_eq!(outputs.get("digest"), Some(&"sha256:abc".to_string()));
+    }
+
+    #[test]
+    pub fn resolve_outputs_of_a_described_output_gives_only_its_value_success() {
+        let logger = Logger::mock().into_arc();
+        let mut action = Action::default();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex = Regex::new(EXPR_REGEX).unwrap();
+        let mut inputs = HashMap::new();
+        inputs.insert("tag".to_string(), "my-image:latest".to_string());
+        let rctx = CommonReadonlyRuntimeExprContext {
+            inputs: inputs.into_arc(),
+            ..Default::default()
+        };
+        let config = BldConfig::default().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        action.outputs.insert(
+            "described".to_string(),
+            Output::Complex {
+                description: Some("The tag of the image that was pushed".to_string()),
+                value: "${{ inputs.tag }}".to_string(),
+            },
+        );
+        action.outputs.insert(
+            "plain".to_string(),
+            Output::Simple("${{ inputs.tag }}".to_string()),
+        );
+
+        let mut runner = ActionRunner {
+            logger,
+            action,
+            platform,
+            artifacts,
+            expr_regex: regex,
+            expr_rctx: rctx,
+            state: ActionState::default(),
+            config,
+            fs,
+            run_ctx,
+            regex_cache,
+            package_manager,
+        };
+
+        let outputs = runner.resolve_outputs().unwrap();
+        assert_eq!(outputs.get("described"), outputs.get("plain"));
+        assert_eq!(
+            outputs.get("described"),
+            Some(&"my-image:latest".to_string())
+        );
     }
 
     #[actix_web::test]
@@ -1021,7 +1078,7 @@ steps:
         })));
         action.outputs.insert(
             "digest".to_string(),
-            "${{ steps.call_inner.outputs.echoed }}".to_string(),
+            Output::Simple("${{ steps.call_inner.outputs.echoed }}".to_string()),
         );
 
         let mut state = ActionState::default();
@@ -1114,7 +1171,7 @@ steps:
         // value.
         action.outputs.insert(
             "digest".to_string(),
-            "${{ steps.call_inner.outputs.echoed }}".to_string(),
+            Output::Simple("${{ steps.call_inner.outputs.echoed }}".to_string()),
         );
 
         let mut state = ActionState::default();

--- a/crates/bld_runner/src/runner/v3/action.rs
+++ b/crates/bld_runner/src/runner/v3/action.rs
@@ -19,7 +19,7 @@ use crate::{
     artifacts::v3::{DownloadArtifact, UploadArtifact},
     expr::v3::{
         context::CommonReadonlyRuntimeExprContext,
-        exec::{CommonExprExecutor, eval_all_expressions},
+        exec::{CommonExprExecutor, eval_all_expressions, eval_all_expressions_map},
         traits::{EvalExpr, ExprValue},
     },
     external::v3::External,
@@ -223,7 +223,13 @@ impl<S: RootState> ActionRunner<S> {
             .await?;
 
         debug!("starting child file runner");
-        runner.run().await?;
+        let outputs = runner.run().await?;
+
+        // A step with a strategy runs once per combination, each producing a different
+        // map, so no single map is representative and none is stored.
+        if details.strategy.is_none() {
+            self.state.set_outputs(&details.id, outputs)?;
+        }
 
         Ok(())
     }
@@ -257,12 +263,13 @@ impl<S: RootState> ActionRunner<S> {
         &mut self,
         vars: &HashMap<String, String>,
     ) -> Result<HashMap<String, String>> {
-        let mut result = HashMap::new();
-        for (name, value) in vars {
-            let value = self.eval_all_expr(value)?;
-            result.insert(name.to_string(), value);
-        }
-        Ok(result)
+        let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &self.state);
+        eval_all_expressions_map(&expr_exec, &self.expr_regex, vars)
+    }
+
+    fn resolve_outputs(&mut self) -> Result<HashMap<String, String>> {
+        let expr_exec = CommonExprExecutor::new(&self.action, &self.expr_rctx, &self.state);
+        eval_all_expressions_map(&expr_exec, &self.expr_regex, &self.action.outputs)
     }
 
     async fn download_artifact(&mut self, download: &DownloadArtifact) -> Result<()> {
@@ -279,7 +286,7 @@ impl<S: RootState> ActionRunner<S> {
             .await
     }
 
-    async fn execute(mut self) -> Result<()> {
+    async fn execute(mut self) -> Result<HashMap<String, String>> {
         self.state.update_state(State::Running);
         self.info().await.inspect_err(|e| {
             self.state.update_state(State::Failed {
@@ -291,8 +298,13 @@ impl<S: RootState> ActionRunner<S> {
                 error: e.to_string(),
             })
         })?;
+        let outputs = self.resolve_outputs().inspect_err(|e| {
+            self.state.update_state(State::Failed {
+                error: e.to_string(),
+            })
+        })?;
         self.state.update_state(State::Completed);
-        Ok(())
+        Ok(outputs)
     }
 }
 
@@ -352,8 +364,14 @@ mod tests {
     use crate::{
         action::v3::Action,
         artifacts::v3::{DownloadArtifact, UploadArtifact},
-        expr::v3::{context::CommonReadonlyRuntimeExprContext, parser::EXPR_REGEX},
-        runner::v3::{ActionRunner, ActionState, RootState, State, state::MockRootState},
+        expr::v3::{
+            context::CommonReadonlyRuntimeExprContext, parser::EXPR_REGEX,
+            traits::WritableRuntimeExprContext,
+        },
+        external::v3::External,
+        runner::v3::{
+            ActionRunner, ActionState, RootState, State, state::MockRootState, test_utils::TempDir,
+        },
         step::v3::{ShellCommand, Step},
         strategy::v3::{FailFastValue, MatrixValue, Strategy},
     };
@@ -818,6 +836,291 @@ mod tests {
                 fail_fast: Some(FailFastValue::Bool(false)),
             }),
         })));
+
+        let runner = ActionRunner {
+            logger,
+            action,
+            platform,
+            artifacts,
+            expr_regex: regex,
+            expr_rctx: rctx,
+            state,
+            config,
+            fs,
+            run_ctx,
+            regex_cache,
+            package_manager,
+        };
+
+        let result = runner.execute().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    pub async fn action_with_no_outputs_key_gives_empty_map_success() {
+        let logger = Logger::mock().into_arc();
+        let mut action = Action::default();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex = Regex::new(EXPR_REGEX).unwrap();
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let config = BldConfig::default().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "build".to_string(),
+            name: None,
+            run: "echo hello".to_string(),
+            condition: None,
+            working_dir: None,
+            strategy: None,
+        })));
+
+        let mut state = ActionState::default();
+        for step in &action.steps {
+            state.add_node(step.id());
+        }
+
+        let runner = ActionRunner {
+            logger,
+            action,
+            platform,
+            artifacts,
+            expr_regex: regex,
+            expr_rctx: rctx,
+            state,
+            config,
+            fs,
+            run_ctx,
+            regex_cache,
+            package_manager,
+        };
+
+        let result = runner.execute().await;
+        assert!(result.is_ok(), "error: {:?}", result.err());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    pub fn resolve_outputs_reads_input_and_step_output_success() {
+        let logger = Logger::mock().into_arc();
+        let mut action = Action::default();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex = Regex::new(EXPR_REGEX).unwrap();
+        let mut inputs = HashMap::new();
+        inputs.insert("tag".to_string(), "my-image:latest".to_string());
+        let rctx = CommonReadonlyRuntimeExprContext {
+            inputs: inputs.into_arc(),
+            ..Default::default()
+        };
+        let config = BldConfig::default().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "build".to_string(),
+            name: None,
+            run: "echo hello".to_string(),
+            condition: None,
+            working_dir: None,
+            strategy: None,
+        })));
+        action
+            .outputs
+            .insert("image".to_string(), "${{ inputs.tag }}".to_string());
+        action.outputs.insert(
+            "digest".to_string(),
+            "${{ steps.build.outputs.digest }}".to_string(),
+        );
+
+        let mut state = ActionState::default();
+        for step in &action.steps {
+            state.add_node(step.id());
+        }
+        let mut outputs = HashMap::new();
+        outputs.insert("digest".to_string(), "sha256:abc".to_string());
+        state.set_outputs("build", outputs).unwrap();
+
+        let mut runner = ActionRunner {
+            logger,
+            action,
+            platform,
+            artifacts,
+            expr_regex: regex,
+            expr_rctx: rctx,
+            state,
+            config,
+            fs,
+            run_ctx,
+            regex_cache,
+            package_manager,
+        };
+
+        let outputs = runner.resolve_outputs().unwrap();
+        assert_eq!(outputs.get("image"), Some(&"my-image:latest".to_string()));
+        assert_eq!(outputs.get("digest"), Some(&"sha256:abc".to_string()));
+    }
+
+    #[actix_web::test]
+    pub async fn action_calling_action_forwards_outputs_success() {
+        let dir = TempDir::new("calling_action_forwards_outputs");
+        dir.write(
+            "inner.yaml",
+            r#"
+version: 3
+type: action
+name: Inner
+
+inputs:
+  tag:
+    required: true
+
+outputs:
+  echoed: ${{ inputs.tag }}
+
+steps:
+  - id: noop
+    run: echo noop
+"#,
+        );
+
+        let logger = Logger::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex = Regex::new(EXPR_REGEX).unwrap();
+        let mut inputs = HashMap::new();
+        inputs.insert("tag".to_string(), "my-image:latest".to_string());
+        let rctx = CommonReadonlyRuntimeExprContext {
+            inputs: inputs.into_arc(),
+            ..Default::default()
+        };
+        let config = BldConfig {
+            root_dir: dir.root_dir(),
+            ..Default::default()
+        }
+        .into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        let mut action = Action::default();
+        let mut with = HashMap::new();
+        with.insert("tag".to_string(), "${{ inputs.tag }}".to_string());
+        action.steps.push(Step::ExternalFile(Box::new(External {
+            id: "call_inner".to_string(),
+            uses: "inner.yaml".to_string(),
+            with,
+            ..Default::default()
+        })));
+        action.outputs.insert(
+            "digest".to_string(),
+            "${{ steps.call_inner.outputs.echoed }}".to_string(),
+        );
+
+        let mut state = ActionState::default();
+        for step in &action.steps {
+            state.add_node(step.id());
+        }
+
+        let runner = ActionRunner {
+            logger,
+            action,
+            platform,
+            artifacts,
+            expr_regex: regex,
+            expr_rctx: rctx,
+            state,
+            config,
+            fs,
+            run_ctx,
+            regex_cache,
+            package_manager,
+        };
+
+        let result = runner.execute().await;
+        assert!(result.is_ok(), "error: {:?}", result.err());
+
+        let outputs = result.unwrap();
+        assert_eq!(outputs.get("digest"), Some(&"my-image:latest".to_string()));
+    }
+
+    #[actix_web::test]
+    pub async fn action_calling_action_with_strategy_stores_no_outputs_success() {
+        let dir = TempDir::new("calling_action_with_strategy_stores_no_outputs");
+        dir.write(
+            "inner.yaml",
+            r#"
+version: 3
+type: action
+name: Inner
+
+inputs:
+  tag:
+    required: true
+
+outputs:
+  echoed: ${{ inputs.tag }}
+
+steps:
+  - id: noop
+    run: echo noop
+"#,
+        );
+
+        let logger = Logger::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex = Regex::new(EXPR_REGEX).unwrap();
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let config = BldConfig {
+            root_dir: dir.root_dir(),
+            ..Default::default()
+        }
+        .into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        let mut with = HashMap::new();
+        with.insert("tag".to_string(), "static-tag".to_string());
+
+        let mut matrix = HashMap::new();
+        matrix.insert(
+            "os".to_string(),
+            MatrixValue::Array(vec!["linux".to_string(), "windows".to_string()]),
+        );
+
+        let mut action = Action::default();
+        action.steps.push(Step::ExternalFile(Box::new(External {
+            id: "call_inner".to_string(),
+            uses: "inner.yaml".to_string(),
+            with,
+            strategy: Some(Strategy {
+                matrix,
+                fail_fast: None,
+            }),
+            ..Default::default()
+        })));
+        // The calling step ran with a strategy, so no output map was stored for it and
+        // reading it back here must fail rather than silently returning one combination's
+        // value.
+        action.outputs.insert(
+            "digest".to_string(),
+            "${{ steps.call_inner.outputs.echoed }}".to_string(),
+        );
+
+        let mut state = ActionState::default();
+        for step in &action.steps {
+            state.add_node(step.id());
+        }
 
         let runner = ActionRunner {
             logger,

--- a/crates/bld_runner/src/runner/v3/common.rs
+++ b/crates/bld_runner/src/runner/v3/common.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
 use futures::Future;
-use std::pin::Pin;
+use std::{collections::HashMap, pin::Pin};
 
-pub type RecursiveFuture = Pin<Box<dyn Future<Output = Result<()>>>>;
+pub type RecursiveFuture = Pin<Box<dyn Future<Output = Result<HashMap<String, String>>>>>;

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -26,7 +26,7 @@ use crate::{
     artifacts::v3::{DownloadArtifact, UploadArtifact},
     expr::v3::{
         context::{CommonReadonlyRuntimeExprContext, START_OF_RUN_WCTX},
-        exec::{CommonExprExecutor, eval_all_expressions},
+        exec::{CommonExprExecutor, eval_all_expressions, eval_all_expressions_map},
         traits::{EvalExpr, ExprValue},
     },
     external::v3::External,
@@ -330,7 +330,13 @@ impl<S: RootState> JobRunner<S> {
             .await?;
 
         debug!("starting child file runner");
-        runner.run().await?;
+        let outputs = runner.run().await?;
+
+        // A step with a strategy runs once per combination, each producing a different
+        // map, so no single map is representative and none is stored.
+        if details.strategy.is_none() {
+            self.options.state.set_outputs(&details.id, outputs)?;
+        }
 
         Ok(())
     }
@@ -364,12 +370,12 @@ impl<S: RootState> JobRunner<S> {
         &mut self,
         vars: &HashMap<String, String>,
     ) -> Result<HashMap<String, String>> {
-        let mut result = HashMap::new();
-        for (name, value) in vars {
-            let value = self.eval_all_expr(value)?;
-            result.insert(name.to_string(), value);
-        }
-        Ok(result)
+        let expr_exec = CommonExprExecutor::new(
+            self.options.pipeline.as_ref(),
+            self.options.expr_rctx.as_ref(),
+            &self.options.state,
+        );
+        eval_all_expressions_map(&expr_exec, &self.options.expr_regex, vars)
     }
 
     fn resolve_working_dir(&mut self, working_dir: &Option<String>) -> Result<Option<String>> {
@@ -617,10 +623,15 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::{
-        expr::v3::{context::CommonReadonlyRuntimeExprContext, parser::EXPR_REGEX},
+        expr::v3::{
+            context::CommonReadonlyRuntimeExprContext,
+            parser::EXPR_REGEX,
+            traits::{ExprText, ExprValue, WritableRuntimeExprContext},
+        },
+        external::v3::External,
         job::v3::Job,
         pipeline::v3::Pipeline,
-        runner::v3::{MockRootState, RootState, State, state::JobState},
+        runner::v3::{MockRootState, RootState, State, state::JobState, test_utils::TempDir},
         runs_on::v3::RunsOn,
         step::v3::{ShellCommand, Step},
         strategy::v3::{FailFastValue, MatrixValue, Strategy},
@@ -1363,5 +1374,145 @@ mod tests {
 
         let result = runner.run().await;
         assert!(result.is_err());
+    }
+
+    const ACTION_WITH_OUTPUT: &str = r#"
+version: 3
+type: action
+name: Inner
+
+inputs:
+  tag:
+    required: true
+
+outputs:
+  echoed: ${{ inputs.tag }}
+
+steps:
+  - id: noop
+    run: echo noop
+"#;
+
+    fn job_runner_calling_action(dir: &TempDir, step: External) -> JobRunner<JobState> {
+        let job_name = "main".to_string();
+        let config = BldConfig {
+            root_dir: dir.root_dir(),
+            ..Default::default()
+        }
+        .into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        let mut state = JobState::new(&job_name);
+        state.add_node(&step.id);
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.clone(),
+            Job {
+                steps: vec![Step::ExternalFile(Box::new(step))],
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+        JobRunner {
+            options,
+            platform,
+            runs_on: RunsOn::default(),
+        }
+    }
+
+    #[actix_web::test]
+    pub async fn job_step_calling_action_stores_its_outputs_success() {
+        let dir = TempDir::new("job_step_calling_action_stores_its_outputs");
+        dir.write("inner.yaml", ACTION_WITH_OUTPUT);
+
+        let mut with = HashMap::new();
+        with.insert("tag".to_string(), "my-image:latest".to_string());
+
+        let runner = job_runner_calling_action(
+            &dir,
+            External {
+                id: "call_action".to_string(),
+                uses: "inner.yaml".to_string(),
+                with,
+                ..Default::default()
+            },
+        );
+
+        let result = runner.run().await;
+        assert!(result.is_ok(), "error: {:?}", result.err());
+
+        let runner = result.unwrap();
+        let output = runner.options.state.get_output("call_action", "echoed");
+        assert_eq!(
+            output.unwrap(),
+            ExprValue::Text(ExprText::Owned("my-image:latest".to_string()))
+        );
+    }
+
+    #[actix_web::test]
+    pub async fn job_step_with_strategy_calling_action_stores_no_outputs_success() {
+        let dir = TempDir::new("job_step_with_strategy_calling_action_stores_no_outputs");
+        dir.write("inner.yaml", ACTION_WITH_OUTPUT);
+
+        let mut with = HashMap::new();
+        with.insert("tag".to_string(), "${{ matrix.tag }}".to_string());
+
+        let mut matrix = HashMap::new();
+        matrix.insert(
+            "tag".to_string(),
+            MatrixValue::Array(vec!["one".to_string(), "two".to_string()]),
+        );
+
+        let runner = job_runner_calling_action(
+            &dir,
+            External {
+                id: "call_action".to_string(),
+                uses: "inner.yaml".to_string(),
+                with,
+                strategy: Some(Strategy {
+                    matrix,
+                    fail_fast: None,
+                }),
+                ..Default::default()
+            },
+        );
+
+        let result = runner.run().await;
+        assert!(result.is_ok(), "error: {:?}", result.err());
+
+        // Each combination produces a different map, so none is stored and reading one
+        // back gives an error instead of the value of a single combination.
+        let runner = result.unwrap();
+        assert!(
+            runner
+                .options
+                .state
+                .get_output("call_action", "echoed")
+                .is_err()
+        );
     }
 }

--- a/crates/bld_runner/src/runner/v3/mod.rs
+++ b/crates/bld_runner/src/runner/v3/mod.rs
@@ -3,10 +3,14 @@ mod common;
 mod job;
 mod pipeline;
 mod state;
+#[cfg(test)]
+mod test_utils;
 
 pub use action::*;
 pub use pipeline::*;
 pub use state::*;
+
+use std::collections::HashMap;
 
 use anyhow::Result;
 
@@ -16,7 +20,7 @@ pub enum FileRunner {
 }
 
 impl FileRunner {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(self) -> Result<HashMap<String, String>> {
         match self {
             Self::Action(runner) => runner.run().await,
             Self::Pipeline(runner) => runner.run().await.await,

--- a/crates/bld_runner/src/runner/v3/pipeline.rs
+++ b/crates/bld_runner/src/runner/v3/pipeline.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Write, sync::Arc, time::Duration};
 
 use actix_web::rt::spawn;
 use anyhow::{Result, anyhow, bail};
@@ -236,7 +236,7 @@ impl PipelineRunner {
         }
     }
 
-    async fn execute(mut self) -> Result<()> {
+    async fn execute(mut self) -> Result<HashMap<String, String>> {
         self.start().await?;
 
         // using let expression to log the errors and let an empty string be used
@@ -244,7 +244,7 @@ impl PipelineRunner {
 
         let Err(e) = self.jobs().await else {
             self.stop().await?;
-            return Ok(());
+            return Ok(HashMap::new());
         };
 
         self.logger.write(e.to_string()).await?;
@@ -261,7 +261,7 @@ impl PipelineRunner {
             self.signals = None;
 
             if self.is_child || signals.is_none() {
-                return self.execute().await.map(|_| ());
+                return self.execute().await;
             }
 
             let context = self.run_ctx.clone();
@@ -273,7 +273,7 @@ impl PipelineRunner {
                 sleep(Duration::from_millis(200)).await;
 
                 if runner_handle.is_finished() {
-                    break runner_handle.await?.map(|_| ());
+                    break runner_handle.await?;
                 }
 
                 if let Ok(message) = signals.try_next() {
@@ -302,7 +302,8 @@ impl PipelineRunner {
 
                             break resp_tx
                                 .send(())
-                                .map_err(|_| anyhow!("oneshot response sender dropped"));
+                                .map_err(|_| anyhow!("oneshot response sender dropped"))
+                                .map(|_| HashMap::new());
                         }
                     }
                 }

--- a/crates/bld_runner/src/runner/v3/test_utils.rs
+++ b/crates/bld_runner/src/runner/v3/test_utils.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+/// A directory under the system's temp dir that holds the files a child runner needs and
+/// that is removed once the test is done with it.
+pub struct TempDir(PathBuf);
+
+impl TempDir {
+    pub fn new(name: &str) -> Self {
+        let path = std::env::temp_dir().join(format!("bld_runner_test_{name}"));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("unable to create temp dir");
+        Self(path)
+    }
+
+    pub fn write(&self, name: &str, content: &str) {
+        std::fs::write(self.0.join(name), content).expect("unable to write file");
+    }
+
+    pub fn root_dir(&self) -> String {
+        self.0.to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}

--- a/crates/bld_runner/src/runner/versioned.rs
+++ b/crates/bld_runner/src/runner/versioned.rs
@@ -2,6 +2,7 @@ use crate::runner::v1;
 use crate::runner::v2;
 use crate::runner::v3;
 use anyhow::Result;
+use std::collections::HashMap;
 
 pub enum VersionedRunner {
     V1(Box<v1::Runner>),
@@ -10,7 +11,7 @@ pub enum VersionedRunner {
 }
 
 impl VersionedRunner {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(self) -> Result<HashMap<String, String>> {
         match self {
             Self::V1(runner) => runner.run().await.await,
             Self::V2(runner) => runner.run().await.await,

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -72,10 +72,7 @@ pub enum Step {
 
 impl Step {
     pub fn is(&self, id: &str) -> bool {
-        let Self::ComplexSh(complex) = self else {
-            return false;
-        };
-        complex.id == id
+        self.id() == id
     }
 
     pub fn id(&self) -> &str {
@@ -243,10 +240,17 @@ impl<'a> EvalObject<'a> for Step {
                 value => bail!("invalid steps field: {value}"),
             },
 
-            Self::ExternalFile(_) => {
+            Self::ExternalFile(external) => match key {
+                "outputs" => {
+                    let Some(object) = path.next() else {
+                        bail!("no output variable name provided");
+                    };
+                    let name = object.as_span().as_str();
+                    wctx.get_output(&external.id, name)?
+                }
                 // TODO: Remove once external section is removed.
-                bail!("invalid expression for step");
-            }
+                value => bail!("invalid expression for step: {value}"),
+            },
 
             Self::DownloadArtifact(_) => {
                 bail!("invalid expression for step");
@@ -934,5 +938,69 @@ mod tests {
         let result = validate_action(&action).await;
 
         assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn output_reading_input_and_declared_step_output_passes_validation() {
+        let mut action = Action::default();
+        action.inputs.insert(
+            "tag".to_string(),
+            crate::inputs::v3::Input::Simple(String::new()),
+        );
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "build".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo \"digest=abc\" >> $BLD_OUTPUTS".to_string(),
+            condition: None,
+            strategy: None,
+        })));
+        action
+            .outputs
+            .insert("image".to_string(), "${{ inputs.tag }}".to_string());
+        action.outputs.insert(
+            "digest".to_string(),
+            "${{ steps.build.outputs.digest }}".to_string(),
+        );
+
+        let config = BldConfig::default().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+        let mut inputs = HashMap::new();
+        inputs.insert("tag".to_string(), String::new());
+        let expr_rctx = CommonReadonlyRuntimeExprContext {
+            inputs: inputs.into_arc(),
+            ..Default::default()
+        };
+        let expr_wctx = vec![ValidatorWritableRuntimeExprContext::new("action")];
+
+        let result =
+            CommonValidator::new(&action, config, fs, package_manager, &expr_rctx, &expr_wctx)
+                .unwrap()
+                .validate()
+                .await;
+
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn output_naming_undeclared_step_fails_validation() {
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "build".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo hello".to_string(),
+            condition: None,
+            strategy: None,
+        })));
+        action.outputs.insert(
+            "digest".to_string(),
+            "${{ steps.missing.outputs.digest }}".to_string(),
+        );
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_err());
     }
 }

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -248,7 +248,6 @@ impl<'a> EvalObject<'a> for Step {
                     let name = object.as_span().as_str();
                     wctx.get_output(&external.id, name)?
                 }
-                // TODO: Remove once external section is removed.
                 value => bail!("invalid expression for step: {value}"),
             },
 
@@ -353,6 +352,7 @@ mod tests {
             traits::{EvalExpr, ExprText, ExprValue, MockWritableRuntimeExprContext},
         },
         job::v3::Job,
+        outputs::v3::Output,
         pipeline::v3::Pipeline,
         step::v3::{ShellCommand, Step},
         strategy::v3::{MatrixValue, Strategy},
@@ -955,12 +955,16 @@ mod tests {
             condition: None,
             strategy: None,
         })));
-        action
-            .outputs
-            .insert("image".to_string(), "${{ inputs.tag }}".to_string());
+        action.outputs.insert(
+            "image".to_string(),
+            Output::Simple("${{ inputs.tag }}".to_string()),
+        );
         action.outputs.insert(
             "digest".to_string(),
-            "${{ steps.build.outputs.digest }}".to_string(),
+            Output::Complex {
+                description: Some("The digest of the built image".to_string()),
+                value: "${{ steps.build.outputs.digest }}".to_string(),
+            },
         );
 
         let config = BldConfig::default().into_arc();
@@ -996,7 +1000,7 @@ mod tests {
         })));
         action.outputs.insert(
             "digest".to_string(),
-            "${{ steps.missing.outputs.digest }}".to_string(),
+            Output::Simple("${{ steps.missing.outputs.digest }}".to_string()),
         );
 
         let result = validate_action(&action).await;


### PR DESCRIPTION
### In this PR

- Added an `outputs` key to a version 3 action, holding a map of a name to an expression.
- The action runner resolves that map after all of its steps are complete and before it reports success, and returns it in place of nothing.
- A step with `uses` stores the map it gets back on its own state, so a caller reads a value with `${{ steps.<id>.outputs.<name> }}`. This is done both in the runner of a pipeline job and in the runner of an action, so an action that calls a second action gets its values too.
- A step with a strategy stores no map, since each combination gives a different one and none of them is representative.
- Pipelines and version 1 and version 2 files give an empty map, so their callers keep their current behaviour.
- Moved the resolution of a map of a name to an expression into a single `eval_all_expressions_map` helper, reused for the `with` and `env` values of a child file and for the outputs of an action.
- Expressions of the `outputs` key are validated in the run time scope, so an output that names a step the action does not declare gives an error.
- A step that uses an external file can now be named in a `steps.<id>` expression, which previously only resolved for shell steps.
- Added tests for an action with no outputs, an output reading an input and a step output, an action calling a second action, a job step reading the outputs of an action, a calling step with a strategy, and the validation of an output that names a missing step.

Closes #376
