### PR TITLE
feat(runner): Add an outputs key to version 3 jobs

### DIFF
--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -3,7 +3,9 @@ use crate::expr::v3::parser;
 use crate::expr::v3::traits::EvalObject;
 use crate::inputs::v3::Input;
 
-use super::traits::{ExprValue, ReadonlyRuntimeExprContext, WritableRuntimeExprContext};
+use super::traits::{
+    ExprValue, OutputScope, ReadonlyRuntimeExprContext, WritableRuntimeExprContext,
+};
 use anyhow::{Context, Error, Result, anyhow};
 use bld_config::BldConfig;
 use bld_config::definitions::{
@@ -28,8 +30,11 @@ impl WritableRuntimeExprContext for StartOfRunWritableExprContext {
         None
     }
 
-    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<ExprValue<'a>> {
-        Err(out_of_scope(&format!("steps.{id}.outputs.{name}")))
+    fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>> {
+        match scope {
+            OutputScope::Step => Err(out_of_scope(&format!("steps.{id}.outputs.{name}"))),
+            OutputScope::Job => Err(out_of_scope(&format!("jobs.{id}.outputs.{name}"))),
+        }
     }
 
     fn set_output(&mut self, _id: &str, name: String, _value: String) -> Result<()> {
@@ -42,10 +47,6 @@ impl WritableRuntimeExprContext for StartOfRunWritableExprContext {
 
     fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str> {
         Err(out_of_scope(&format!("matrix.{name}")))
-    }
-
-    fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>> {
-        Err(out_of_scope(&format!("jobs.{job}.outputs.{name}")))
     }
 }
 

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -43,6 +43,10 @@ impl WritableRuntimeExprContext for StartOfRunWritableExprContext {
     fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str> {
         Err(out_of_scope(&format!("matrix.{name}")))
     }
+
+    fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>> {
+        Err(out_of_scope(&format!("jobs.{job}.outputs.{name}")))
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -275,6 +275,7 @@ pub trait WritableRuntimeExprContext {
     fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;
     #[allow(clippy::needless_lifetimes)]
     fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str>;
+    fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>>;
 }
 
 pub trait EvalObject<'a> {

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -257,6 +257,12 @@ impl Display for ExprValue<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputScope {
+    Step,
+    Job,
+}
+
 pub trait ReadonlyRuntimeExprContext<'a> {
     fn get_root_dir(&'a self) -> &'a str;
     fn get_project_dir(&'a self) -> &'a str;
@@ -270,12 +276,11 @@ pub trait ReadonlyRuntimeExprContext<'a> {
 pub trait WritableRuntimeExprContext {
     #[allow(clippy::needless_lifetimes)]
     fn get_exec_id<'a>(&'a self) -> Option<&'a str>;
-    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<ExprValue<'a>>;
+    fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>>;
     fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
     fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;
     #[allow(clippy::needless_lifetimes)]
     fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str>;
-    fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>>;
 }
 
 pub trait EvalObject<'a> {

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "all")]
 use crate::expr::v3::traits::ExprText;
-use crate::{runs_on::v3::RunsOn, step::v3::Step, strategy::v3::Strategy};
+use crate::{outputs::v3::Output, runs_on::v3::RunsOn, step::v3::Step, strategy::v3::Strategy};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 #[cfg(feature = "all")]
@@ -45,6 +45,8 @@ pub struct Job {
     pub dispose: bool,
     pub strategy: Option<Strategy>,
     pub steps: Vec<Step>,
+    #[serde(default)]
+    pub outputs: HashMap<String, Output>,
 }
 
 impl Job {
@@ -63,6 +65,13 @@ impl Job {
             None => Box::new(std::iter::empty()),
         }
     }
+
+    pub fn outputs_map(&self) -> HashMap<String, String> {
+        self.outputs
+            .iter()
+            .map(|(name, output)| (name.to_owned(), output.value().to_owned()))
+            .collect()
+    }
 }
 
 impl Default for Job {
@@ -75,6 +84,7 @@ impl Default for Job {
             dispose: Self::default_dispose(),
             strategy: None,
             steps: vec![],
+            outputs: HashMap::new(),
         }
     }
 }
@@ -210,6 +220,16 @@ impl<'a> Validate<'a> for Job {
             }
             step.validate(ctx).await;
             step.validate_matrix(ctx, Some(&job_matrix_keys)).await;
+        }
+        ctx.pop_section();
+
+        debug!("Validating job's {} outputs section", self.id);
+        ctx.push_section("outputs");
+        for (name, output) in self.outputs.iter() {
+            debug!("Validating output: {}", name);
+            ctx.push_section(name);
+            output.validate(ctx).await;
+            ctx.pop_section();
         }
         ctx.pop_section();
     }

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -256,6 +256,27 @@ impl<'a> EvalObject<'a> for Pipeline {
                 Ok(ExprValue::Text(ExprText::Ref(rctx.get_run_start_time())))
             }
 
+            "jobs" => {
+                let Some(job_name) = object_parts.nth(1) else {
+                    bail!("expected name of job in object path");
+                };
+                let job_name = job_name.as_span().as_str();
+
+                let Some(part) = object_parts.next() else {
+                    bail!("expected 'outputs' in jobs object path");
+                };
+                if part.as_span().as_str() != "outputs" {
+                    bail!("invalid jobs field: {}", part.as_span().as_str());
+                }
+
+                let Some(part) = object_parts.next() else {
+                    bail!("expected name of output in object path");
+                };
+                let name = part.as_span().as_str();
+
+                wctx.get_job_output(job_name, name)
+            }
+
             // Move evaluation to the job level
             _ => {
                 let Some(exec_id) = wctx.get_exec_id() else {
@@ -390,6 +411,10 @@ mod tests {
         fn validate_array_expression(&mut self, _symbol: &'a str, _scope: ExprScope) {}
 
         fn matrix_refs(&self, _value: &str) -> Vec<String> {
+            vec![]
+        }
+
+        fn job_output_refs(&self, _value: &str) -> Vec<String> {
             vec![]
         }
     }
@@ -573,6 +598,27 @@ mod tests {
     }
 
     #[test]
+    pub fn jobs_output_expr_eval_success() {
+        let mut wctx = MockWritableRuntimeExprContext::new();
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = Pipeline::default();
+
+        wctx.expect_get_job_output()
+            .with(
+                mockall::predicate::eq("build"),
+                mockall::predicate::eq("version"),
+            )
+            .returning(|_, _| Ok(ExprValue::Text(ExprText::Ref("1.2.3"))));
+
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+        let actual = exec.eval("${{ jobs.build.outputs.version }}").unwrap();
+        assert!(matches!(
+            actual.try_eq(&ExprValue::Text(ExprText::Ref("1.2.3"))),
+            Ok(ExprValue::Boolean(true))
+        ));
+    }
+
+    #[test]
     pub fn matrix_expr_eval_success() {
         let mut wctx = MockWritableRuntimeExprContext::new();
         let rctx = CommonReadonlyRuntimeExprContext::default();
@@ -738,6 +784,104 @@ mod tests {
                 .any(|e| e.contains("undefined job") || e.contains("cyclic dependency")),
             "did not expect dependency errors, got: {:?}",
             ctx.errors
+        );
+    }
+
+    fn job_reading_output_of(name: &str, needs: Option<Needs>) -> Job {
+        Job {
+            needs,
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                run: format!("echo ${{{{ jobs.{name}.outputs.version }}}}"),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        }
+    }
+
+    fn job_reading_other_job_output(needs: Option<Needs>) -> Job {
+        job_reading_output_of("build", needs)
+    }
+
+    #[tokio::test]
+    pub async fn validate_accepts_job_output_ref_when_job_in_needs() {
+        let mut pipeline = Pipeline::default();
+        pipeline
+            .jobs
+            .insert("build".to_string(), job_with_needs(None));
+        pipeline.jobs.insert(
+            "publish".to_string(),
+            job_reading_other_job_output(Some(Needs::Single("build".to_string()))),
+        );
+
+        let result = validate_pipeline(pipeline).await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn validate_rejects_job_output_ref_when_job_not_in_needs() {
+        let mut pipeline = Pipeline::default();
+        pipeline
+            .jobs
+            .insert("build".to_string(), job_with_needs(None));
+        pipeline
+            .jobs
+            .insert("publish".to_string(), job_reading_other_job_output(None));
+
+        let Err(e) = validate_pipeline(pipeline).await else {
+            panic!("expected an error for a job output reference outside of needs");
+        };
+        let error = e.to_string();
+        assert!(
+            error.contains("job 'build' is not defined in the needs of job 'publish'"),
+            "{error}"
+        );
+    }
+
+    /// A job name is free to hold any character that an object path allows, so the needs
+    /// rule has to hold for a name with a hyphen just as it does for a plain one.
+    #[tokio::test]
+    pub async fn validate_rejects_job_output_ref_of_hyphenated_job_not_in_needs() {
+        let mut pipeline = Pipeline::default();
+        pipeline
+            .jobs
+            .insert("build-image".to_string(), job_with_needs(None));
+        pipeline.jobs.insert(
+            "publish".to_string(),
+            job_reading_output_of("build-image", None),
+        );
+
+        let Err(e) = validate_pipeline(pipeline).await else {
+            panic!("expected an error for a job output reference outside of needs");
+        };
+        let error = e.to_string();
+        assert!(
+            error.contains("job 'build-image' is not defined in the needs of job 'publish'"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    pub async fn validate_rejects_job_output_ref_in_condition() {
+        let mut pipeline = Pipeline::default();
+        pipeline
+            .jobs
+            .insert("build".to_string(), job_with_needs(None));
+        pipeline.jobs.insert(
+            "publish".to_string(),
+            Job {
+                needs: Some(Needs::Single("build".to_string())),
+                condition: Some("${{ jobs.build.outputs.version == \"1.0\" }}".to_string()),
+                ..job_with_needs(Some(Needs::Single("build".to_string())))
+            },
+        );
+
+        let Err(e) = validate_pipeline(pipeline).await else {
+            panic!("expected an error for reading job outputs in a condition");
+        };
+        let error = e.to_string();
+        assert!(
+            error.contains("is not available at the start of a run"),
+            "{error}"
         );
     }
 }

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -14,7 +14,7 @@ use {
             context::out_of_scope,
             parser::Rule,
             traits::{
-                EvalObject, ExprText, ExprValue, ReadonlyRuntimeExprContext,
+                EvalObject, ExprText, ExprValue, OutputScope, ReadonlyRuntimeExprContext,
                 WritableRuntimeExprContext,
             },
         },
@@ -274,7 +274,7 @@ impl<'a> EvalObject<'a> for Pipeline {
                 };
                 let name = part.as_span().as_str();
 
-                wctx.get_job_output(job_name, name)
+                wctx.get_output(OutputScope::Job, job_name, name)
             }
 
             // Move evaluation to the job level
@@ -339,7 +339,7 @@ mod tests {
         expr::v3::{
             context::CommonReadonlyRuntimeExprContext,
             exec::CommonExprExecutor,
-            traits::{EvalExpr, ExprText, ExprValue, MockWritableRuntimeExprContext},
+            traits::{EvalExpr, ExprText, ExprValue, MockWritableRuntimeExprContext, OutputScope},
         },
         inputs::v3::Input,
         job::v3::{Job, Needs},
@@ -603,12 +603,13 @@ mod tests {
         let rctx = CommonReadonlyRuntimeExprContext::default();
         let pipeline = Pipeline::default();
 
-        wctx.expect_get_job_output()
+        wctx.expect_get_output()
             .with(
+                mockall::predicate::eq(OutputScope::Job),
                 mockall::predicate::eq("build"),
                 mockall::predicate::eq("version"),
             )
-            .returning(|_, _| Ok(ExprValue::Text(ExprText::Ref("1.2.3"))));
+            .returning(|_, _, _| Ok(ExprValue::Text(ExprText::Ref("1.2.3"))));
 
         let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
         let actual = exec.eval("${{ jobs.build.outputs.version }}").unwrap();

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -58,6 +58,7 @@ pub struct JobRunner<S: RootState> {
     pub options: JobRunnerOptions<S>,
     pub platform: Arc<Platform>,
     pub runs_on: RunsOn,
+    pub outputs: HashMap<String, String>,
 }
 
 impl<S: RootState> JobRunner<S> {
@@ -91,6 +92,7 @@ impl<S: RootState> JobRunner<S> {
             options,
             platform,
             runs_on,
+            outputs: HashMap::new(),
         })
     }
 
@@ -128,18 +130,33 @@ impl<S: RootState> JobRunner<S> {
         self.options.state.update_state(State::Running);
 
         debug!("starting execution of pipeline steps");
-        let result = self.run_job_steps(job).await;
-
-        match &result {
-            Ok(()) => self.options.state.update_state(State::Completed),
-            Err(e) => self.options.state.update_state(State::Failed {
+        self.run_job_steps(job).await.inspect_err(|e| {
+            self.options.state.update_state(State::Failed {
                 error: e.to_string(),
-            }),
-        }
-        result?;
+            })
+        })?;
+
+        let outputs = self.resolve_outputs(job).inspect_err(|e| {
+            self.options.state.update_state(State::Failed {
+                error: e.to_string(),
+            })
+        })?;
+        self.outputs = outputs;
+
+        self.options.state.update_state(State::Completed);
 
         self.dispose_platform(job).await?;
         Ok(self)
+    }
+
+    fn resolve_outputs(&mut self, job: &Job) -> Result<HashMap<String, String>> {
+        let expr_exec = CommonExprExecutor::new(
+            self.options.pipeline.as_ref(),
+            self.options.expr_rctx.as_ref(),
+            &self.options.state,
+        );
+        let outputs = job.outputs_map();
+        eval_all_expressions_map(&expr_exec, &self.options.expr_regex, &outputs)
     }
 
     async fn run_job_steps(&mut self, job: &Job) -> Result<()> {
@@ -630,6 +647,7 @@ mod tests {
         },
         external::v3::External,
         job::v3::Job,
+        outputs::v3::Output,
         pipeline::v3::Pipeline,
         runner::v3::{MockRootState, RootState, State, state::JobState, test_utils::TempDir},
         runs_on::v3::RunsOn,
@@ -674,6 +692,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         assert!(matches!(job.condition(None), Ok(true)));
@@ -736,6 +755,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         assert_eq!(job.resolve_working_dir(&None).unwrap(), None);
@@ -1010,6 +1030,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         // Act
@@ -1078,6 +1099,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         let result = runner.run().await;
@@ -1142,6 +1164,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         let result = runner.run().await;
@@ -1216,6 +1239,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         let result = runner.run().await;
@@ -1293,6 +1317,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         let result = runner.run().await;
@@ -1370,6 +1395,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         };
 
         let result = runner.run().await;
@@ -1441,6 +1467,7 @@ steps:
             options,
             platform,
             runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
         }
     }
 
@@ -1513,6 +1540,183 @@ steps:
                 .state
                 .get_output("call_action", "echoed")
                 .is_err()
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn job_runner_with_outputs(
+        dir: &TempDir,
+        job_name: &str,
+        step: External,
+        job_outputs: HashMap<String, Output>,
+        needs: Option<crate::job::v3::Needs>,
+        incoming_job_outputs: HashMap<String, HashMap<String, String>>,
+    ) -> JobRunner<JobState> {
+        let config = BldConfig {
+            root_dir: dir.root_dir(),
+            ..Default::default()
+        }
+        .into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let expr_rctx = CommonReadonlyRuntimeExprContext::default().into_arc();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        let mut state = JobState::new(job_name);
+        state.add_node(&step.id);
+        state.set_job_outputs(incoming_job_outputs).unwrap();
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job_name.to_string(),
+            Job {
+                needs,
+                steps: vec![Step::ExternalFile(Box::new(step))],
+                outputs: job_outputs,
+                ..Default::default()
+            },
+        );
+
+        let options = JobRunnerOptions {
+            job_name: job_name.to_string(),
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline: pipeline.into_arc(),
+            regex_cache,
+            expr_regex,
+            expr_rctx,
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+        JobRunner {
+            options,
+            platform,
+            runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
+        }
+    }
+
+    /// Two jobs, the second in the needs of the first: the second job's own `outputs` key
+    /// reads a value produced by the first job through `jobs.<name>.outputs.<name>`, and the
+    /// value it resolves is exactly the one the first job produced.
+    #[actix_web::test]
+    pub async fn job_reads_output_of_a_job_listed_in_its_needs_success() {
+        let dir = TempDir::new("job_reads_output_of_a_job_listed_in_its_needs");
+        dir.write("inner.yaml", ACTION_WITH_OUTPUT);
+
+        let mut with = HashMap::new();
+        with.insert("tag".to_string(), "my-image:latest".to_string());
+
+        let mut build_outputs = HashMap::new();
+        build_outputs.insert(
+            "version".to_string(),
+            Output::Simple("${{ steps.call_action.outputs.echoed }}".to_string()),
+        );
+
+        let build = job_runner_with_outputs(
+            &dir,
+            "build",
+            External {
+                id: "call_action".to_string(),
+                uses: "inner.yaml".to_string(),
+                with,
+                ..Default::default()
+            },
+            build_outputs,
+            None,
+            HashMap::new(),
+        );
+
+        let build = build.run().await.unwrap();
+        assert_eq!(
+            build.outputs.get("version").map(String::as_str),
+            Some("my-image:latest")
+        );
+
+        let mut incoming = HashMap::new();
+        incoming.insert("build".to_string(), build.outputs.clone());
+
+        let mut publish_outputs = HashMap::new();
+        publish_outputs.insert(
+            "got".to_string(),
+            Output::Simple("${{ jobs.build.outputs.version }}".to_string()),
+        );
+
+        let publish = job_runner_with_outputs(
+            &dir,
+            "publish",
+            External {
+                id: "call_action".to_string(),
+                uses: "inner.yaml".to_string(),
+                with: {
+                    let mut with = HashMap::new();
+                    with.insert("tag".to_string(), "unrelated".to_string());
+                    with
+                },
+                ..Default::default()
+            },
+            publish_outputs,
+            Some(crate::job::v3::Needs::Single("build".to_string())),
+            incoming,
+        );
+
+        let publish = publish.run().await.unwrap();
+        assert_eq!(
+            publish.outputs.get("got").map(String::as_str),
+            Some("my-image:latest")
+        );
+    }
+
+    /// A job that never runs because its condition fails still resolves to an empty map of
+    /// outputs, and a job that reads one of its values gets a clear error rather than a
+    /// stale or default value.
+    #[actix_web::test]
+    pub async fn job_reading_output_of_a_skipped_job_fails_clearly() {
+        let dir = TempDir::new("job_reading_output_of_a_skipped_job");
+        dir.write("inner.yaml", ACTION_WITH_OUTPUT);
+
+        let mut incoming = HashMap::new();
+        // Mirrors what the pipeline runner stores for a job that was skipped: present in
+        // the map, but with no outputs of its own.
+        incoming.insert("build".to_string(), HashMap::new());
+
+        let mut publish_outputs = HashMap::new();
+        publish_outputs.insert(
+            "got".to_string(),
+            Output::Simple("${{ jobs.build.outputs.version }}".to_string()),
+        );
+
+        let mut with = HashMap::new();
+        with.insert("tag".to_string(), "unrelated".to_string());
+
+        let publish = job_runner_with_outputs(
+            &dir,
+            "publish",
+            External {
+                id: "call_action".to_string(),
+                uses: "inner.yaml".to_string(),
+                with,
+                ..Default::default()
+            },
+            publish_outputs,
+            Some(crate::job::v3::Needs::Single("build".to_string())),
+            incoming,
+        );
+
+        let result = publish.run().await;
+        let error = result.err().expect("expected an error").to_string();
+        assert!(
+            error.contains("version") && error.contains("build"),
+            "{error}"
         );
     }
 }

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -643,7 +643,7 @@ mod tests {
         expr::v3::{
             context::CommonReadonlyRuntimeExprContext,
             parser::EXPR_REGEX,
-            traits::{ExprText, ExprValue, WritableRuntimeExprContext},
+            traits::{ExprText, ExprValue, OutputScope, WritableRuntimeExprContext},
         },
         external::v3::External,
         job::v3::Job,
@@ -1493,7 +1493,10 @@ steps:
         assert!(result.is_ok(), "error: {:?}", result.err());
 
         let runner = result.unwrap();
-        let output = runner.options.state.get_output("call_action", "echoed");
+        let output = runner
+            .options
+            .state
+            .get_output(OutputScope::Step, "call_action", "echoed");
         assert_eq!(
             output.unwrap(),
             ExprValue::Text(ExprText::Owned("my-image:latest".to_string()))
@@ -1538,7 +1541,7 @@ steps:
             runner
                 .options
                 .state
-                .get_output("call_action", "echoed")
+                .get_output(OutputScope::Step, "call_action", "echoed")
                 .is_err()
         );
     }

--- a/crates/bld_runner/src/runner/v3/pipeline.rs
+++ b/crates/bld_runner/src/runner/v3/pipeline.rs
@@ -138,7 +138,11 @@ impl PipelineRunner {
         JobRunner::new(options).await
     }
 
-    fn create_job_state(&self, name: &str) -> Result<JobState> {
+    fn create_job_state(
+        &self,
+        name: &str,
+        job_outputs: &HashMap<String, HashMap<String, String>>,
+    ) -> Result<JobState> {
         let mut state = JobState::new(name);
         let Some(job) = self.pipeline.jobs.get(name) else {
             bail!("job with name {name} not found");
@@ -146,17 +150,22 @@ impl PipelineRunner {
         for step in &job.steps {
             state.add_node(step.id());
         }
+        state.set_job_outputs(job_outputs.clone())?;
         Ok(state)
     }
 
-    async fn prepare_jobs(&self, names: &[String]) -> Result<Vec<Option<RunningJob>>> {
+    async fn prepare_jobs(
+        &self,
+        names: &[String],
+        job_outputs: &HashMap<String, HashMap<String, String>>,
+    ) -> Result<Vec<Option<RunningJob>>> {
         let mut jobs = Vec::new();
         for name in names {
             self.logger
                 .write_line(format!("{:<15}: {}", "Running job", name))
                 .await?;
             let logger = Logger::in_memory().into_arc();
-            let state = self.create_job_state(name)?;
+            let state = self.create_job_state(name, job_outputs)?;
             let job = self.create_job(name, logger.clone(), state).await?;
             let handle = spawn(job.run());
             jobs.push(Some(RunningJob::new(name, handle, logger)));
@@ -169,7 +178,7 @@ impl PipelineRunner {
             bail!("unable to retrieve job");
         };
         debug!("found only one job so running it in the current context");
-        let state = self.create_job_state(name)?;
+        let state = self.create_job_state(name, &HashMap::new())?;
         self.create_job(name, self.logger.clone(), state)
             .await?
             .run()
@@ -177,9 +186,14 @@ impl PipelineRunner {
             .map(|_| ())
     }
 
-    async fn run_layer(&self, names: &[String]) -> Result<()> {
+    async fn run_layer(
+        &self,
+        names: &[String],
+        job_outputs: &HashMap<String, HashMap<String, String>>,
+    ) -> Result<HashMap<String, HashMap<String, String>>> {
         let mut errors: Vec<String> = Vec::new();
-        let mut running_jobs = self.prepare_jobs(names).await?;
+        let mut collected: HashMap<String, HashMap<String, String>> = HashMap::new();
+        let mut running_jobs = self.prepare_jobs(names, job_outputs).await?;
 
         while running_jobs.iter().any(|x| x.is_some()) {
             for job in running_jobs.iter_mut() {
@@ -196,7 +210,10 @@ impl PipelineRunner {
                     let handle_result = running_job.handle.await.map_err(|e| anyhow!(e))?;
 
                     let message = match &handle_result {
-                        Ok(_) => format!("{:<15}: {}", "Completed job", running_job.name),
+                        Ok(runner) => {
+                            collected.insert(running_job.name.clone(), runner.outputs.clone());
+                            format!("{:<15}: {}", "Completed job", running_job.name)
+                        }
                         Err(e) => {
                             errors.push(format!("[{}] {e}", running_job.name));
                             format!("{:<15}: {} ({e})", "Erroneous job", running_job.name)
@@ -215,15 +232,17 @@ impl PipelineRunner {
         }
 
         if errors.is_empty() {
-            Ok(())
+            Ok(collected)
         } else {
             Err(anyhow!(errors.join("\n")))
         }
     }
 
     async fn run_all_jobs(&self) -> Result<()> {
+        let mut job_outputs: HashMap<String, HashMap<String, String>> = HashMap::new();
         for layer in self.dag.layers() {
-            self.run_layer(&layer).await?;
+            let layer_outputs = self.run_layer(&layer, &job_outputs).await?;
+            job_outputs.extend(layer_outputs);
         }
         Ok(())
     }
@@ -327,7 +346,8 @@ mod tests {
     use crate::{
         dag::Dag,
         expr::v3::{context::CommonReadonlyRuntimeExprContext, parser::EXPR_REGEX},
-        job::v3::Job,
+        job::v3::{Job, Needs},
+        outputs::v3::Output,
         pipeline::v3::Pipeline,
     };
 
@@ -380,7 +400,9 @@ mod tests {
         );
 
         let names = vec!["producer".to_string(), "consumer".to_string()];
-        let result = runner.run_layer(&names).await;
+        let result = runner
+            .run_layer(&names, &std::collections::HashMap::new())
+            .await;
 
         let error = result.expect_err("expected the failing job to produce an error");
         let message = error.to_string();
@@ -421,7 +443,9 @@ mod tests {
         );
 
         let names = vec!["producer".to_string(), "consumer".to_string()];
-        let result = runner.run_layer(&names).await;
+        let result = runner
+            .run_layer(&names, &std::collections::HashMap::new())
+            .await;
 
         let error = result.expect_err("expected the failing jobs to produce an error");
         let message = error.to_string();
@@ -446,6 +470,122 @@ mod tests {
 
         let names = vec!["producer".to_string(), "consumer".to_string()];
 
-        assert!(runner.run_layer(&names).await.is_ok());
+        assert!(
+            runner
+                .run_layer(&names, &std::collections::HashMap::new())
+                .await
+                .is_ok()
+        );
+    }
+
+    fn job_with_outputs(needs: Option<Needs>, outputs: Vec<(&str, &str)>) -> Job {
+        Job {
+            needs,
+            outputs: outputs
+                .into_iter()
+                .map(|(name, value)| (name.to_string(), Output::Simple(value.to_string())))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// Three layers: build (layer 1), publish (layer 2, needs build) and deploy (layer 3,
+    /// needs both build and publish). Deploy reads a value straight from build even though
+    /// it is two layers away, because build is listed directly in its own needs.
+    #[actix_web::test]
+    async fn three_layers_collect_and_forward_job_outputs() {
+        let logger = Logger::in_memory().into_arc();
+        let runner = create_runner(
+            vec![
+                ("build", job_with_outputs(None, vec![("version", "1.2.3")])),
+                (
+                    "publish",
+                    job_with_outputs(
+                        Some(Needs::Single("build".to_string())),
+                        vec![("got", "${{ jobs.build.outputs.version }}")],
+                    ),
+                ),
+                (
+                    "deploy",
+                    job_with_outputs(
+                        Some(Needs::Multiple(
+                            ["build", "publish"].iter().map(|x| x.to_string()).collect(),
+                        )),
+                        vec![("final", "${{ jobs.build.outputs.version }}")],
+                    ),
+                ),
+            ],
+            logger.clone(),
+        );
+
+        let mut job_outputs = std::collections::HashMap::new();
+
+        let layer1 = runner
+            .run_layer(&["build".to_string()], &job_outputs)
+            .await
+            .unwrap();
+        job_outputs.extend(layer1);
+        assert_eq!(
+            job_outputs.get("build").and_then(|m| m.get("version")),
+            Some(&"1.2.3".to_string())
+        );
+
+        let layer2 = runner
+            .run_layer(&["publish".to_string()], &job_outputs)
+            .await
+            .unwrap();
+        job_outputs.extend(layer2);
+        assert_eq!(
+            job_outputs.get("publish").and_then(|m| m.get("got")),
+            Some(&"1.2.3".to_string())
+        );
+
+        let layer3 = runner
+            .run_layer(&["deploy".to_string()], &job_outputs)
+            .await
+            .unwrap();
+        job_outputs.extend(layer3);
+        assert_eq!(
+            job_outputs.get("deploy").and_then(|m| m.get("final")),
+            Some(&"1.2.3".to_string())
+        );
+    }
+
+    /// A job that is skipped because its condition fails still shows up in the outputs map
+    /// as an empty entry, so a job in the next layer that reads one of its values gets a
+    /// clear error naming the job and the missing output, instead of an order violation.
+    #[actix_web::test]
+    async fn job_skipped_by_condition_gives_empty_outputs_to_the_next_layer() {
+        let logger = Logger::in_memory().into_arc();
+        let runner = create_runner(
+            vec![
+                ("build", failing_job("${{ false }}")),
+                (
+                    "publish",
+                    job_with_outputs(
+                        Some(Needs::Single("build".to_string())),
+                        vec![("got", "${{ jobs.build.outputs.version }}")],
+                    ),
+                ),
+            ],
+            logger.clone(),
+        );
+
+        // The condition of "build" doesn't fail the run, it just evaluates to false, so the
+        // job is skipped rather than erroring.
+        let layer1 = runner
+            .run_layer(&["build".to_string()], &std::collections::HashMap::new())
+            .await
+            .unwrap();
+        assert_eq!(layer1.get("build"), Some(&std::collections::HashMap::new()));
+
+        let result = runner.run_layer(&["publish".to_string()], &layer1).await;
+        let error = result
+            .expect_err("expected an error reading the output of a skipped job")
+            .to_string();
+        assert!(
+            error.contains("version") && error.contains("build"),
+            "{error}"
+        );
     }
 }

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -601,7 +601,9 @@ mod tests {
 
         state.set_job_outputs(job_outputs).unwrap();
 
-        let value = state.get_output(OutputScope::Job, "build", "version").unwrap();
+        let value = state
+            .get_output(OutputScope::Job, "build", "version")
+            .unwrap();
         assert_eq!(value, ExprValue::Text(ExprText::Owned("1.2.3".to_string())));
     }
 

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -99,6 +99,10 @@ impl WritableRuntimeExprContext for StepState {
     fn get_matrix_value<'a>(&'a self, _name: &str) -> Result<&'a str> {
         bail!("matrix values are not accessible from step state")
     }
+
+    fn get_job_output<'a>(&'a self, _job: &str, _name: &str) -> Result<ExprValue<'a>> {
+        bail!("job outputs are not accessible from step state")
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -107,6 +111,9 @@ pub struct JobState {
     state: State,
     steps: HashMap<String, StepState>,
     matrix: HashMap<String, String>,
+    // TECH DEBT: Change 'static lifetime to a specific lifetime.
+    // Changing this will require a lot of type annotation changes.
+    job_outputs: HashMap<String, HashMap<String, ExprValue<'static>>>,
 }
 
 impl JobState {
@@ -115,6 +122,22 @@ impl JobState {
             id: id.to_string(),
             ..Default::default()
         }
+    }
+
+    pub fn set_job_outputs(
+        &mut self,
+        job_outputs: HashMap<String, HashMap<String, String>>,
+    ) -> Result<()> {
+        let mut map = HashMap::new();
+        for (job, outputs) in job_outputs {
+            let mut inner = HashMap::new();
+            for (name, value) in outputs {
+                inner.insert(name, value.try_into()?);
+            }
+            map.insert(job, inner);
+        }
+        self.job_outputs = map;
+        Ok(())
     }
 }
 
@@ -125,6 +148,7 @@ impl Default for JobState {
             state: State::default(),
             steps: HashMap::new(),
             matrix: HashMap::new(),
+            job_outputs: HashMap::new(),
         }
     }
 }
@@ -190,6 +214,18 @@ impl WritableRuntimeExprContext for JobState {
             .get(name)
             .map(|x| x.as_str())
             .ok_or_else(|| anyhow!("matrix value '{name}' not found"))
+    }
+
+    fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>> {
+        let Some(outputs) = self.job_outputs.get(job) else {
+            bail!(
+                "job '{job}' not found, only jobs listed in 'needs' have their outputs available"
+            );
+        };
+        outputs
+            .get(name)
+            .cloned()
+            .ok_or_else(|| anyhow!("output '{name}' not found for job '{job}'"))
     }
 }
 
@@ -273,6 +309,10 @@ impl WritableRuntimeExprContext for ActionState {
             .map(|x| x.as_str())
             .ok_or_else(|| anyhow!("matrix value '{name}' not found"))
     }
+
+    fn get_job_output<'a>(&'a self, _job: &str, _name: &str) -> Result<ExprValue<'a>> {
+        bail!("jobs are not accessible from an action")
+    }
 }
 
 mock! {
@@ -293,6 +333,7 @@ mock! {
         fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
         fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;
         fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str>;
+        fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>>;
     }
 }
 
@@ -423,6 +464,7 @@ mod tests {
                 state: state.clone(),
                 steps: HashMap::new(),
                 matrix: HashMap::new(),
+                job_outputs: HashMap::new(),
             };
             let mut actual = JobState::new(&id);
             actual.update_state(state);
@@ -462,6 +504,7 @@ mod tests {
             state: State::Default,
             steps: HashMap::new(),
             matrix: HashMap::new(),
+            job_outputs: HashMap::new(),
         };
         state.steps.insert(
             step_id.clone(),
@@ -498,6 +541,7 @@ mod tests {
             state: State::Default,
             steps: HashMap::new(),
             matrix: HashMap::new(),
+            job_outputs: HashMap::new(),
         };
         state.steps.insert(
             step_id.clone(),
@@ -531,6 +575,7 @@ mod tests {
             state: State::Default,
             steps: HashMap::new(),
             matrix: HashMap::new(),
+            job_outputs: HashMap::new(),
         };
         state.steps.insert(
             step_id.clone(),
@@ -542,6 +587,45 @@ mod tests {
         );
         let result = state.set_outputs(&step_id, outputs);
         assert!(result.is_ok())
+    }
+
+    #[test]
+    pub fn job_state_get_job_output_success() {
+        let mut state = JobState::new("consumer");
+        let mut build_outputs = HashMap::new();
+        build_outputs.insert("version".to_string(), "1.2.3".to_string());
+        let mut job_outputs = HashMap::new();
+        job_outputs.insert("build".to_string(), build_outputs);
+
+        state.set_job_outputs(job_outputs).unwrap();
+
+        let value = state.get_job_output("build", "version").unwrap();
+        assert_eq!(value, ExprValue::Text(ExprText::Owned("1.2.3".to_string())));
+    }
+
+    #[test]
+    pub fn job_state_get_job_output_unknown_job_failure() {
+        let state = JobState::new("consumer");
+        let error = state.get_job_output("missing", "version").unwrap_err();
+        assert!(error.to_string().contains("missing"), "{error}");
+    }
+
+    #[test]
+    pub fn job_state_get_job_output_unknown_output_failure() {
+        let mut state = JobState::new("consumer");
+        let mut job_outputs = HashMap::new();
+        job_outputs.insert("build".to_string(), HashMap::new());
+
+        state.set_job_outputs(job_outputs).unwrap();
+
+        let error = state.get_job_output("build", "version").unwrap_err();
+        assert!(error.to_string().contains("version"), "{error}");
+    }
+
+    #[test]
+    pub fn action_state_get_job_output_failure() {
+        let state = ActionState::default();
+        assert!(state.get_job_output("build", "version").is_err());
     }
 
     #[test]

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow, bail};
 use mockall::{automock, mock};
 use uuid::Uuid;
 
-use crate::expr::v3::traits::{ExprValue, WritableRuntimeExprContext};
+use crate::expr::v3::traits::{ExprValue, OutputScope, WritableRuntimeExprContext};
 
 #[automock]
 pub trait NodeState {
@@ -66,7 +66,10 @@ impl WritableRuntimeExprContext for StepState {
         Some(self.id.as_str())
     }
 
-    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<ExprValue<'a>> {
+    fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>> {
+        if scope != OutputScope::Step {
+            bail!("job outputs are not accessible from step state");
+        }
         if self.id != id {
             bail!("id {id} has no outputs");
         }
@@ -99,15 +102,11 @@ impl WritableRuntimeExprContext for StepState {
     fn get_matrix_value<'a>(&'a self, _name: &str) -> Result<&'a str> {
         bail!("matrix values are not accessible from step state")
     }
-
-    fn get_job_output<'a>(&'a self, _job: &str, _name: &str) -> Result<ExprValue<'a>> {
-        bail!("job outputs are not accessible from step state")
-    }
 }
 
 #[derive(Debug, PartialEq)]
 pub struct JobState {
-    id: String,
+    name: String,
     state: State,
     steps: HashMap<String, StepState>,
     matrix: HashMap<String, String>,
@@ -117,9 +116,9 @@ pub struct JobState {
 }
 
 impl JobState {
-    pub fn new(id: &str) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            id: id.to_string(),
+            name: name.to_string(),
             ..Default::default()
         }
     }
@@ -144,7 +143,7 @@ impl JobState {
 impl Default for JobState {
     fn default() -> Self {
         Self {
-            id: Uuid::new_v4().to_string(),
+            name: Uuid::new_v4().to_string(),
             state: State::default(),
             steps: HashMap::new(),
             matrix: HashMap::new(),
@@ -185,14 +184,29 @@ impl RootState for JobState {
 
 impl WritableRuntimeExprContext for JobState {
     fn get_exec_id(&self) -> Option<&str> {
-        Some(self.id.as_str())
+        Some(self.name.as_str())
     }
 
-    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<ExprValue<'a>> {
-        let Some(step_state) = self.steps.get(id) else {
-            bail!("outputs for id {id} weren't found");
-        };
-        step_state.get_output(id, name)
+    fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>> {
+        match scope {
+            OutputScope::Job => {
+                let Some(outputs) = self.job_outputs.get(id) else {
+                    bail!(
+                        "job '{id}' not found, only jobs listed in 'needs' have their outputs available"
+                    );
+                };
+                outputs
+                    .get(name)
+                    .cloned()
+                    .ok_or_else(|| anyhow!("output '{name}' not found for job '{id}'"))
+            }
+            OutputScope::Step => {
+                let Some(step_state) = self.steps.get(id) else {
+                    bail!("outputs for id {id} weren't found");
+                };
+                step_state.get_output(OutputScope::Step, id, name)
+            }
+        }
     }
 
     fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()> {
@@ -214,18 +228,6 @@ impl WritableRuntimeExprContext for JobState {
             .get(name)
             .map(|x| x.as_str())
             .ok_or_else(|| anyhow!("matrix value '{name}' not found"))
-    }
-
-    fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>> {
-        let Some(outputs) = self.job_outputs.get(job) else {
-            bail!(
-                "job '{job}' not found, only jobs listed in 'needs' have their outputs available"
-            );
-        };
-        outputs
-            .get(name)
-            .cloned()
-            .ok_or_else(|| anyhow!("output '{name}' not found for job '{job}'"))
     }
 }
 
@@ -282,11 +284,14 @@ impl WritableRuntimeExprContext for ActionState {
         Some(self.id.as_str())
     }
 
-    fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<ExprValue<'a>> {
+    fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>> {
+        if scope != OutputScope::Step {
+            bail!("jobs are not accessible from an action");
+        }
         let Some(step_state) = self.steps.get(id) else {
             bail!("outputs for id {id} weren't found");
         };
-        step_state.get_output(id, name)
+        step_state.get_output(OutputScope::Step, id, name)
     }
 
     fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()> {
@@ -309,10 +314,6 @@ impl WritableRuntimeExprContext for ActionState {
             .map(|x| x.as_str())
             .ok_or_else(|| anyhow!("matrix value '{name}' not found"))
     }
-
-    fn get_job_output<'a>(&'a self, _job: &str, _name: &str) -> Result<ExprValue<'a>> {
-        bail!("jobs are not accessible from an action")
-    }
 }
 
 mock! {
@@ -329,11 +330,10 @@ mock! {
 
     impl WritableRuntimeExprContext for RootState {
         fn get_exec_id<'a> (&'a self) -> Option<&'a str>;
-        fn get_output<'a>(&'a self, id: &str, name: &str) -> Result<ExprValue<'a>>;
+        fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>>;
         fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
         fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;
         fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str>;
-        fn get_job_output<'a>(&'a self, job: &str, name: &str) -> Result<ExprValue<'a>>;
     }
 }
 
@@ -344,7 +344,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
-        expr::v3::traits::{ExprText, ExprValue, WritableRuntimeExprContext},
+        expr::v3::traits::{ExprText, ExprValue, OutputScope, WritableRuntimeExprContext},
         runner::v3::state::{ActionState, JobState, NodeState, RootState, State, StepState},
     };
 
@@ -403,7 +403,7 @@ mod tests {
             outputs: expr_outputs,
         };
         for (name, expected_value) in outputs {
-            let actual_value = state.get_output(&id, &name).unwrap();
+            let actual_value = state.get_output(OutputScope::Step, &id, &name).unwrap();
             assert_eq!(
                 actual_value,
                 ExprValue::Text(ExprText::Owned(expected_value))
@@ -460,7 +460,7 @@ mod tests {
         for state in states {
             let id = Uuid::new_v4().to_string();
             let expected = JobState {
-                id: id.clone(),
+                name: id.clone(),
                 state: state.clone(),
                 steps: HashMap::new(),
                 matrix: HashMap::new(),
@@ -477,7 +477,7 @@ mod tests {
         let data = vec!["123", "hello", "world", "john", "doe"];
         for id in data {
             let state = JobState {
-                id: id.to_string(),
+                name: id.to_string(),
                 ..Default::default()
             };
             let exec_id = state.get_exec_id();
@@ -500,7 +500,7 @@ mod tests {
             .map(|(k, v)| (k.clone(), ExprValue::Text(ExprText::Owned(v.clone()))))
             .collect();
         let mut state = JobState {
-            id: job_id.clone(),
+            name: job_id.clone(),
             state: State::Default,
             steps: HashMap::new(),
             matrix: HashMap::new(),
@@ -515,7 +515,9 @@ mod tests {
             },
         );
         for (name, expected_value) in outputs {
-            let actual_value = state.get_output(&step_id, &name).unwrap();
+            let actual_value = state
+                .get_output(OutputScope::Step, &step_id, &name)
+                .unwrap();
             assert_eq!(
                 actual_value,
                 ExprValue::Text(ExprText::Owned(expected_value))
@@ -537,7 +539,7 @@ mod tests {
             .map(|(k, v)| (k.clone(), ExprValue::Text(ExprText::Owned(v.clone()))))
             .collect();
         let mut state = JobState {
-            id: job_id.clone(),
+            name: job_id.clone(),
             state: State::Default,
             steps: HashMap::new(),
             matrix: HashMap::new(),
@@ -571,7 +573,7 @@ mod tests {
             .map(|(k, v)| (k.clone(), ExprValue::Text(ExprText::Owned(v.clone()))))
             .collect();
         let mut state = JobState {
-            id: job_id.clone(),
+            name: job_id.clone(),
             state: State::Default,
             steps: HashMap::new(),
             matrix: HashMap::new(),
@@ -599,14 +601,16 @@ mod tests {
 
         state.set_job_outputs(job_outputs).unwrap();
 
-        let value = state.get_job_output("build", "version").unwrap();
+        let value = state.get_output(OutputScope::Job, "build", "version").unwrap();
         assert_eq!(value, ExprValue::Text(ExprText::Owned("1.2.3".to_string())));
     }
 
     #[test]
     pub fn job_state_get_job_output_unknown_job_failure() {
         let state = JobState::new("consumer");
-        let error = state.get_job_output("missing", "version").unwrap_err();
+        let error = state
+            .get_output(OutputScope::Job, "missing", "version")
+            .unwrap_err();
         assert!(error.to_string().contains("missing"), "{error}");
     }
 
@@ -618,14 +622,20 @@ mod tests {
 
         state.set_job_outputs(job_outputs).unwrap();
 
-        let error = state.get_job_output("build", "version").unwrap_err();
+        let error = state
+            .get_output(OutputScope::Job, "build", "version")
+            .unwrap_err();
         assert!(error.to_string().contains("version"), "{error}");
     }
 
     #[test]
     pub fn action_state_get_job_output_failure() {
         let state = ActionState::default();
-        assert!(state.get_job_output("build", "version").is_err());
+        assert!(
+            state
+                .get_output(OutputScope::Job, "build", "version")
+                .is_err()
+        );
     }
 
     #[test]
@@ -670,7 +680,9 @@ mod tests {
             },
         );
         for (name, expected_value) in outputs {
-            let actual_value = state.get_output(&step_id, &name).unwrap();
+            let actual_value = state
+                .get_output(OutputScope::Step, &step_id, &name)
+                .unwrap();
             assert_eq!(
                 actual_value,
                 ExprValue::Text(ExprText::Owned(expected_value))

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -13,7 +13,7 @@ use {
         expr::v3::{
             parser::Rule,
             traits::{
-                EvalObject, ExprText, ExprValue, ReadonlyRuntimeExprContext,
+                EvalObject, ExprText, ExprValue, OutputScope, ReadonlyRuntimeExprContext,
                 WritableRuntimeExprContext,
             },
         },
@@ -235,7 +235,7 @@ impl<'a> EvalObject<'a> for Step {
                         bail!("no output variable name provided");
                     };
                     let name = object.as_span().as_str();
-                    wctx.get_output(&command.id, name)?
+                    wctx.get_output(OutputScope::Step, &command.id, name)?
                 }
                 value => bail!("invalid steps field: {value}"),
             },
@@ -246,7 +246,7 @@ impl<'a> EvalObject<'a> for Step {
                         bail!("no output variable name provided");
                     };
                     let name = object.as_span().as_str();
-                    wctx.get_output(&external.id, name)?
+                    wctx.get_output(OutputScope::Step, &external.id, name)?
                 }
                 value => bail!("invalid expression for step: {value}"),
             },
@@ -349,7 +349,7 @@ mod tests {
         expr::v3::{
             context::CommonReadonlyRuntimeExprContext,
             exec::CommonExprExecutor,
-            traits::{EvalExpr, ExprText, ExprValue, MockWritableRuntimeExprContext},
+            traits::{EvalExpr, ExprText, ExprValue, MockWritableRuntimeExprContext, OutputScope},
         },
         job::v3::Job,
         outputs::v3::Output,
@@ -702,9 +702,13 @@ mod tests {
 
                 for (name, value) in outputs.iter() {
                     wctx.expect_get_output()
-                        .with(predicate::eq(*step), predicate::eq(*name))
+                        .with(
+                            predicate::eq(OutputScope::Step),
+                            predicate::eq(*step),
+                            predicate::eq(*name),
+                        )
                         .times(1)
-                        .returning(|_, _| Ok(ExprValue::Text(ExprText::Ref(value))));
+                        .returning(|_, _, _| Ok(ExprValue::Text(ExprText::Ref(value))));
                 }
             }
         }
@@ -768,9 +772,13 @@ mod tests {
             }
             for (name, value) in outputs.iter() {
                 wctx.expect_get_output()
-                    .with(predicate::eq(*step), predicate::eq(*name))
+                    .with(
+                        predicate::eq(OutputScope::Step),
+                        predicate::eq(*step),
+                        predicate::eq(*name),
+                    )
                     .times(1)
-                    .returning(|_, _| Ok(ExprValue::Text(ExprText::Ref(value))));
+                    .returning(|_, _, _| Ok(ExprValue::Text(ExprText::Ref(value))));
             }
         }
 

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -53,7 +53,12 @@ impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> 
         Some(self.exec_id)
     }
 
-    fn get_output<'b>(&'b self, _scope: OutputScope, _id: &str, _name: &str) -> Result<ExprValue<'b>> {
+    fn get_output<'b>(
+        &'b self,
+        _scope: OutputScope,
+        _id: &str,
+        _name: &str,
+    ) -> Result<ExprValue<'b>> {
         Ok(ExprValue::Unknown)
     }
 

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fmt::Write, path::PathBuf, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write,
+    path::PathBuf,
+    sync::Arc,
+};
 
 use anyhow::{Result, bail};
 use bld_config::{BldConfig, path};
@@ -65,6 +70,10 @@ impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> 
     fn get_matrix_value<'b>(&'b self, _name: &str) -> Result<&'b str> {
         Ok("")
     }
+
+    fn get_job_output<'b>(&'b self, _job: &str, _name: &str) -> Result<ExprValue<'b>> {
+        Ok(ExprValue::Unknown)
+    }
 }
 
 pub struct CommonValidator<'a, V: Validate<'a> + for<'x> EvalObject<'x>> {
@@ -75,6 +84,7 @@ pub struct CommonValidator<'a, V: Validate<'a> + for<'x> EvalObject<'x>> {
     expr_regex: Regex,
     expr_rctx: &'a CommonReadonlyRuntimeExprContext,
     expr_wctx: &'a [ValidatorWritableRuntimeExprContext<'a>],
+    job_needs: HashMap<&'a str, HashSet<&'a str>>,
     section: Vec<Section<'a>>,
     current_job: Option<Section<'a>>,
     errors: String,
@@ -97,10 +107,39 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
             expr_regex: parser::new_regex()?,
             expr_rctx,
             expr_wctx,
+            job_needs: HashMap::new(),
             section: Vec::new(),
             current_job: None,
             errors: String::new(),
         })
+    }
+
+    /// Declares, for every job, which other jobs it may read outputs from through
+    /// `jobs.<name>.outputs.<name>`. A pipeline validator supplies the `needs` of every
+    /// job here; other validatable types (e.g. an action) leave this empty, since none of
+    /// their jobs exist.
+    pub fn with_job_needs(mut self, job_needs: HashMap<&'a str, HashSet<&'a str>>) -> Self {
+        self.job_needs = job_needs;
+        self
+    }
+
+    fn validate_job_output_refs(&mut self, value: &'a str) {
+        let Some(current_job) = self.current_job.as_ref().map(|x| x.inner()) else {
+            return;
+        };
+        let needs = self.job_needs.get(current_job);
+        for job_name in self.job_output_refs(value) {
+            let allowed = needs
+                .map(|n| n.contains(job_name.as_str()))
+                .unwrap_or(false);
+            if !allowed {
+                let section = self.section_txt();
+                let _ = writeln!(
+                    self.errors,
+                    "[{section}] job '{job_name}' is not defined in the needs of job '{current_job}', only jobs listed in needs can have their outputs read"
+                );
+            }
+        }
     }
 
     fn section_txt(&self) -> String {
@@ -211,6 +250,7 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
         match scope {
             ExprScope::StartOfRun => self.eval_expressions(value, &START_OF_RUN_WCTX),
             ExprScope::Runtime => {
+                self.validate_job_output_refs(value);
                 let Some(expr_wctx) = self.runtime_wctx() else {
                     return;
                 };
@@ -223,6 +263,7 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
         match scope {
             ExprScope::StartOfRun => self.eval_array_expression(value, &START_OF_RUN_WCTX),
             ExprScope::Runtime => {
+                self.validate_job_output_refs(value);
                 let Some(expr_wctx) = self.runtime_wctx() else {
                     return;
                 };
@@ -242,6 +283,28 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
                     .unwrap_or(after.len());
                 let name = &after[..end];
                 if !name.is_empty() {
+                    result.push(name.to_string());
+                }
+                rest = &after[end..];
+            }
+        }
+        result
+    }
+
+    fn job_output_refs(&self, value: &str) -> Vec<String> {
+        let mut result = Vec::new();
+        for entry in self.expr_regex.find_iter(value) {
+            let mut rest = entry.as_str();
+            while let Some(pos) = rest.find("jobs.") {
+                let after = &rest[pos + "jobs.".len()..];
+                // A job name is a part of an object path, so it keeps every character
+                // that the grammar allows in one, hyphens included.
+                let end = after
+                    .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == '-'))
+                    .unwrap_or(after.len());
+                let name = &after[..end];
+                let remainder = &after[end..];
+                if !name.is_empty() && remainder.starts_with(".outputs.") {
                     result.push(name.to_string());
                 }
                 rest = &after[end..];

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -16,7 +16,7 @@ use crate::expr::v3::{
     context::{CommonReadonlyRuntimeExprContext, START_OF_RUN_WCTX},
     exec::CommonExprExecutor,
     parser,
-    traits::{EvalExpr, EvalObject, ExprValue, WritableRuntimeExprContext},
+    traits::{EvalExpr, EvalObject, ExprValue, OutputScope, WritableRuntimeExprContext},
 };
 
 use super::{ConsumeValidator, ExprScope, Validate, ValidatorContext};
@@ -53,7 +53,7 @@ impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> 
         Some(self.exec_id)
     }
 
-    fn get_output<'b>(&'b self, _id: &str, _name: &str) -> Result<ExprValue<'b>> {
+    fn get_output<'b>(&'b self, _scope: OutputScope, _id: &str, _name: &str) -> Result<ExprValue<'b>> {
         Ok(ExprValue::Unknown)
     }
 
@@ -69,10 +69,6 @@ impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> 
 
     fn get_matrix_value<'b>(&'b self, _name: &str) -> Result<&'b str> {
         Ok("")
-    }
-
-    fn get_job_output<'b>(&'b self, _job: &str, _name: &str) -> Result<ExprValue<'b>> {
-        Ok(ExprValue::Unknown)
     }
 }
 

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use anyhow::Result;
 use bld_config::BldConfig;
@@ -57,6 +60,11 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                     .keys()
                     .map(|k| ValidatorWritableRuntimeExprContext::new(k.as_str()))
                     .collect();
+                let job_needs: HashMap<&str, HashSet<&str>> = pip
+                    .jobs
+                    .iter()
+                    .map(|(name, job)| (name.as_str(), job.needs_iter().collect()))
+                    .collect();
                 CommonValidator::new(
                     pip.as_ref(),
                     self.config,
@@ -65,6 +73,7 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                     &expr_rctx,
                     &expr_wctx,
                 )?
+                .with_job_needs(job_needs)
                 .validate()
                 .await
             }

--- a/crates/bld_runner/src/validator/v3/traits.rs
+++ b/crates/bld_runner/src/validator/v3/traits.rs
@@ -26,6 +26,7 @@ pub trait ValidatorContext<'a> {
     fn validate_expressions(&mut self, symbol: &'a str, scope: ExprScope);
     fn validate_array_expression(&mut self, symbol: &'a str, scope: ExprScope);
     fn matrix_refs(&self, value: &str) -> Vec<String>;
+    fn job_output_refs(&self, value: &str) -> Vec<String>;
     fn validate_file_path(&mut self, value: &'a str);
     fn validate_env(&mut self, env: &'a HashMap<String, String>, scope: ExprScope);
 }


### PR DESCRIPTION
### In this PR

- Added an `outputs` key to a version 3 job, holding a map of a name to an expression, with the same simple and complex entries that an action's outputs accept.
- Resolved that map in the job runner once every step has completed and before the platform is disposed, reusing the expression map resolution added for actions rather than adding a second one.
- Added a map of job outputs to the state of a job, along with a lookup that gives one error when the job is unknown and a different one when the name is not among its values.
- Made the same lookup fail with a clear message on the state of an action, on the state of a step and on the values available at the start of a run.
- Collected the outputs of every job at the end of its layer in the pipeline runner and gave a copy of everything gathered so far to the jobs of the next layer, so every job of a layer sees the same values.
- Gave an empty map to a job that is skipped by its condition, and kept the single job path resolving its own outputs with an empty map of other jobs.
- Added the `jobs.<name>.outputs.<name>` path to the expressions of a pipeline, with an error for any other shape of the path.
- Validated the new key with the run time scope and rejected a reference to a job that is not in the `needs` of the job holding the expression, hyphenated job names included.
- Added tests for two jobs, three layers, a reference outside of `needs`, a reference in the `if` of a job and a job skipped by its condition.

Closes #377
