### PR TITLE
fix(bld_runner): Keep the original text of numeric step outputs

### DIFF
--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -360,14 +360,14 @@ mod tests {
     #[test]
     pub fn number_eval_success() {
         let data = vec![
-            ("${{ 100 }}", ExprValue::Number(100.0)),
-            ("${{ 100.0 }}", ExprValue::Number(100.0)),
-            ("${{ 150.20 }}", ExprValue::Number(150.20)),
-            ("${{ 0.0 }}", ExprValue::Number(0.0)),
-            ("${{ 0 }}", ExprValue::Number(0.0)),
-            ("${{ -100 }}", ExprValue::Number(-100.0)),
-            ("${{ -100.0 }}", ExprValue::Number(-100.0)),
-            ("${{ -150.20 }}", ExprValue::Number(-150.20)),
+            ("${{ 100 }}", ExprValue::number(100.0)),
+            ("${{ 100.0 }}", ExprValue::number(100.0)),
+            ("${{ 150.20 }}", ExprValue::number(150.20)),
+            ("${{ 0.0 }}", ExprValue::number(0.0)),
+            ("${{ 0 }}", ExprValue::number(0.0)),
+            ("${{ -100 }}", ExprValue::number(-100.0)),
+            ("${{ -100.0 }}", ExprValue::number(-100.0)),
+            ("${{ -150.20 }}", ExprValue::number(-150.20)),
         ];
 
         let wctx = MockWritableRuntimeExprContext::new();
@@ -380,11 +380,14 @@ mod tests {
                 panic!("failed to parse expression: {expr}");
             };
 
-            let ExprValue::Number(value) = value else {
+            let ExprValue::Number { value, .. } = value else {
                 panic!("expected number, found {:?}", value);
             };
 
-            let ExprValue::Number(expected) = expected else {
+            let ExprValue::Number {
+                value: expected, ..
+            } = expected
+            else {
                 panic!("expected number, found {:?}", expected);
             };
 
@@ -493,9 +496,9 @@ mod tests {
             (
                 "${{ [100, 200, 300] }}",
                 vec![
-                    ExprValue::Number(100.0),
-                    ExprValue::Number(200.0),
-                    ExprValue::Number(300.0),
+                    ExprValue::number(100.0),
+                    ExprValue::number(200.0),
+                    ExprValue::number(300.0),
                 ],
             ),
             (
@@ -696,7 +699,7 @@ mod tests {
             panic!("failed to eval indexed expression");
         };
         assert!(matches!(
-            value.try_eq(&ExprValue::Number(300.0)),
+            value.try_eq(&ExprValue::number(300.0)),
             Ok(ExprValue::Boolean(true))
         ));
 

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -329,7 +329,7 @@ mod tests {
     use crate::{
         expr::v3::{
             context::CommonReadonlyRuntimeExprContext,
-            traits::{ExprText, MockWritableRuntimeExprContext},
+            traits::{ExprText, MockWritableRuntimeExprContext, tests::expr_number},
         },
         pipeline::v3::Pipeline,
     };
@@ -360,14 +360,14 @@ mod tests {
     #[test]
     pub fn number_eval_success() {
         let data = vec![
-            ("${{ 100 }}", ExprValue::number(100.0)),
-            ("${{ 100.0 }}", ExprValue::number(100.0)),
-            ("${{ 150.20 }}", ExprValue::number(150.20)),
-            ("${{ 0.0 }}", ExprValue::number(0.0)),
-            ("${{ 0 }}", ExprValue::number(0.0)),
-            ("${{ -100 }}", ExprValue::number(-100.0)),
-            ("${{ -100.0 }}", ExprValue::number(-100.0)),
-            ("${{ -150.20 }}", ExprValue::number(-150.20)),
+            ("${{ 100 }}", expr_number(100.0)),
+            ("${{ 100.0 }}", expr_number(100.0)),
+            ("${{ 150.20 }}", expr_number(150.20)),
+            ("${{ 0.0 }}", expr_number(0.0)),
+            ("${{ 0 }}", expr_number(0.0)),
+            ("${{ -100 }}", expr_number(-100.0)),
+            ("${{ -100.0 }}", expr_number(-100.0)),
+            ("${{ -150.20 }}", expr_number(-150.20)),
         ];
 
         let wctx = MockWritableRuntimeExprContext::new();
@@ -495,11 +495,7 @@ mod tests {
         let data = vec![
             (
                 "${{ [100, 200, 300] }}",
-                vec![
-                    ExprValue::number(100.0),
-                    ExprValue::number(200.0),
-                    ExprValue::number(300.0),
-                ],
+                vec![expr_number(100.0), expr_number(200.0), expr_number(300.0)],
             ),
             (
                 "${{ [\"hello\", \"world\"] }}",
@@ -699,7 +695,7 @@ mod tests {
             panic!("failed to eval indexed expression");
         };
         assert!(matches!(
-            value.try_eq(&ExprValue::number(300.0)),
+            value.try_eq(&expr_number(300.0)),
             Ok(ExprValue::Boolean(true))
         ));
 

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -73,7 +73,14 @@ impl<'a> ExprText<'a> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExprValue<'a> {
     Boolean(bool),
-    Number(f64),
+    /// `raw` keeps the original text the number was parsed from, so that
+    /// formatting it back to text does not lose information (leading or
+    /// trailing zeros, digits beyond `f64` precision, etc). `value` is used
+    /// for numeric comparisons.
+    Number {
+        value: f64,
+        raw: ExprText<'a>,
+    },
     Text(ExprText<'a>),
     Array(Vec<ExprValue<'a>>),
     /// Placeholder used only during validation, when the real value of a
@@ -84,10 +91,17 @@ pub enum ExprValue<'a> {
 }
 
 impl<'a, 'b> ExprValue<'a> {
+    pub fn number(value: f64) -> Self {
+        Self::Number {
+            value,
+            raw: ExprText::Owned(value.to_string()),
+        }
+    }
+
     pub fn type_as_string(&self) -> &'static str {
         match self {
             Self::Boolean(_) => "boolean",
-            Self::Number(_) => "number",
+            Self::Number { .. } => "number",
             Self::Text(_) => "text",
             Self::Array(_) => "array",
             Self::Unknown => "unknown",
@@ -101,7 +115,7 @@ impl<'a, 'b> ExprValue<'a> {
 
         let value = match (self, other) {
             (Self::Boolean(l), Self::Boolean(r)) => l == r,
-            (Self::Number(l), Self::Number(r)) => l == r,
+            (Self::Number { value: l, .. }, Self::Number { value: r, .. }) => l == r,
             (Self::Text(l), Self::Text(r)) => l.inner() == r.inner(),
             (Self::Array(l), Self::Array(r)) => {
                 if l.len() != r.len() {
@@ -142,7 +156,7 @@ impl<'a, 'b> ExprValue<'a> {
         }
 
         let value = match (self, other) {
-            (Self::Number(l), Self::Number(r)) => l > r,
+            (Self::Number { value: l, .. }, Self::Number { value: r, .. }) => l > r,
             (Self::Text(l), Self::Text(r)) => l.inner() > r.inner(),
             (Self::Boolean(l), Self::Boolean(r)) => l > r,
             _ => bail!(
@@ -191,9 +205,15 @@ impl<'b> TryFrom<&'b str> for ExprValue<'_> {
     type Error = anyhow::Error;
 
     fn try_from(value: &'b str) -> Result<Self> {
-        // Try number
-        if let Ok(num) = value.parse::<f64>() {
-            return Ok(ExprValue::Number(num));
+        // Try number. Reject inf, -inf and NaN, they are not the numbers a
+        // step output is meant to convey and should stay text instead.
+        if let Ok(num) = value.parse::<f64>()
+            && num.is_finite()
+        {
+            return Ok(ExprValue::Number {
+                value: num,
+                raw: ExprText::Owned(value.to_string()),
+            });
         }
 
         // Try boolean
@@ -240,7 +260,7 @@ impl Display for ExprValue<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = match self {
             Self::Boolean(value) => value.to_string(),
-            Self::Number(value) => value.to_string(),
+            Self::Number { raw, .. } => raw.inner().to_string(),
             Self::Text(ExprText::Ref(value)) => value.to_string(),
             Self::Text(ExprText::Owned(value)) => value.to_string(),
             Self::Array(items) => format!(
@@ -292,4 +312,48 @@ pub trait EvalExpr<'a> {
     fn eval_expr(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
     fn eval_logical_expr(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>>;
     fn eval(&self, expr: &'a str) -> Result<ExprValue<'a>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn number_conversion_keeps_leading_and_trailing_zeros() {
+        let value: ExprValue = "007".try_into().unwrap();
+        assert_eq!(value.to_string(), "007");
+        let ExprValue::Number { value: num, .. } = value else {
+            panic!("expected number");
+        };
+        assert_eq!(num, 7.0);
+
+        let value: ExprValue = "1.10".try_into().unwrap();
+        assert_eq!(value.to_string(), "1.10");
+        let ExprValue::Number { value: num, .. } = value else {
+            panic!("expected number");
+        };
+        assert_eq!(num, 1.1);
+    }
+
+    #[test]
+    fn number_conversion_rejects_non_finite_values() {
+        for input in ["NaN", "inf", "-inf", "infinity"] {
+            let value: ExprValue = input.try_into().unwrap();
+            assert!(
+                matches!(value, ExprValue::Text(_)),
+                "expected {input} to stay text, got {value:?}"
+            );
+            assert_eq!(value.to_string(), input);
+        }
+    }
+
+    #[test]
+    fn numbers_still_compare_by_value() {
+        let count: ExprValue = "10".try_into().unwrap();
+        let threshold = ExprValue::number(3.0);
+        let ExprValue::Boolean(greater) = count.try_ord(&threshold).unwrap() else {
+            panic!("expected boolean");
+        };
+        assert!(greater);
+    }
 }

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -74,8 +74,7 @@ impl<'a> ExprText<'a> {
 pub enum ExprValue<'a> {
     Boolean(bool),
     /// `raw` keeps the original text the number was parsed from, so that
-    /// formatting it back to text does not lose information (leading or
-    /// trailing zeros, digits beyond `f64` precision, etc). `value` is used
+    /// formatting it back to text does not lose information. `value` is used
     /// for numeric comparisons.
     Number {
         value: f64,
@@ -91,13 +90,6 @@ pub enum ExprValue<'a> {
 }
 
 impl<'a, 'b> ExprValue<'a> {
-    pub fn number(value: f64) -> Self {
-        Self::Number {
-            value,
-            raw: ExprText::Owned(value.to_string()),
-        }
-    }
-
     pub fn type_as_string(&self) -> &'static str {
         match self {
             Self::Boolean(_) => "boolean",
@@ -315,8 +307,15 @@ pub trait EvalExpr<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
+
+    pub fn expr_number<'a>(value: f64) -> ExprValue<'a> {
+        ExprValue::Number {
+            value,
+            raw: ExprText::Owned(value.to_string()),
+        }
+    }
 
     #[test]
     fn number_conversion_keeps_leading_and_trailing_zeros() {
@@ -350,7 +349,7 @@ mod tests {
     #[test]
     fn numbers_still_compare_by_value() {
         let count: ExprValue = "10".try_into().unwrap();
-        let threshold = ExprValue::number(3.0);
+        let threshold = expr_number(3.0);
         let ExprValue::Boolean(greater) = count.try_ord(&threshold).unwrap() else {
             panic!("expected boolean");
         };

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -197,8 +197,7 @@ impl<'b> TryFrom<&'b str> for ExprValue<'_> {
     type Error = anyhow::Error;
 
     fn try_from(value: &'b str) -> Result<Self> {
-        // Try number. Reject inf, -inf and NaN, they are not the numbers a
-        // step output is meant to convey and should stay text instead.
+        // Try number
         if let Ok(num) = value.parse::<f64>()
             && num.is_finite()
         {

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -407,6 +407,43 @@ mod tests {
     }
 
     #[test]
+    pub fn step_state_output_round_trip_preserves_the_original_text() {
+        let data = vec![
+            ("ver", "007"),
+            ("dec", "1.10"),
+            ("zero", "0.0"),
+            ("exp", "1e3"),
+            ("sha", "12345678901234567890123456789012"),
+            ("nan", "NaN"),
+            ("inf", "-inf"),
+            ("name", "john"),
+            ("flag", "true"),
+        ];
+
+        let id = Uuid::new_v4().to_string();
+        let mut state = StepState {
+            id: id.clone(),
+            state: State::Default,
+            outputs: HashMap::new(),
+        };
+
+        for (name, value) in &data {
+            state
+                .set_output(&id, name.to_string(), value.to_string())
+                .unwrap();
+        }
+
+        for (name, value) in &data {
+            let actual = state.get_output(&id, name).unwrap();
+            assert_eq!(
+                actual.to_string(),
+                *value,
+                "output '{name}' was not preserved"
+            );
+        }
+    }
+
+    #[test]
     pub fn job_state_update_state_success() {
         let states = vec![
             State::Default,


### PR DESCRIPTION
### In this PR

- `ExprValue::Number` became a struct variant holding both the `f64` value and the raw text it was parsed from.
- `Display` for a number now writes the original text, so step outputs such as `007`, `1.10`, `1e3` and long digit identifiers survive interpolation unchanged.
- The text to value conversion rejects `inf`, `-inf` and `NaN`, which now stay text values.
- Comparisons (`==`, `!=`, `>`, `>=`, `<`, `<=`) still use the `f64` value, so numeric conditions on step outputs are unaffected.
- Added an `ExprValue::number` helper for building a number from an `f64`, used by the expression tests.
- New tests cover the conversion of values with leading and trailing zeros, the non finite inputs, numeric comparison and a round trip of step outputs through the runner state.

Closes #352
