### PR TITLE
feat(runner): Add an env key to version 3 jobs

### DIFF
--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -50,7 +50,7 @@ impl WritableRuntimeExprContext for StartOfRunWritableExprContext {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CommonReadonlyRuntimeExprContext {
     pub config: Arc<BldConfig>,
     pub inputs: Arc<HashMap<String, String>>,
@@ -74,6 +74,12 @@ impl CommonReadonlyRuntimeExprContext {
             run_id,
             run_start_time,
         }
+    }
+
+    pub fn clone_with(&self, closure: impl FnOnce(&mut Self) -> ()) -> Self {
+        let mut clone = self.clone();
+        closure(&mut clone);
+        clone
     }
 }
 

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -76,7 +76,7 @@ impl CommonReadonlyRuntimeExprContext {
         }
     }
 
-    pub fn clone_with(&self, closure: impl FnOnce(&mut Self) -> ()) -> Self {
+    pub fn clone_with(&self, closure: impl FnOnce(&mut Self)) -> Self {
         let mut clone = self.clone();
         closure(&mut clone);
         clone

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -44,6 +44,8 @@ pub struct Job {
     #[serde(default = "Job::default_dispose")]
     pub dispose: bool,
     pub strategy: Option<Strategy>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
     pub steps: Vec<Step>,
     #[serde(default)]
     pub outputs: HashMap<String, Output>,
@@ -83,6 +85,7 @@ impl Default for Job {
             needs: None,
             dispose: Self::default_dispose(),
             strategy: None,
+            env: HashMap::new(),
             steps: vec![],
             outputs: HashMap::new(),
         }
@@ -199,6 +202,11 @@ impl<'a> Validate<'a> for Job {
             validate_matrix_refs(ctx, condition, &HashSet::new());
             ctx.pop_section();
         }
+
+        debug!("Validating job's {} env section", self.id);
+        ctx.push_section("env");
+        ctx.validate_env(&self.env, ExprScope::StartOfRun);
+        ctx.pop_section();
 
         debug!("Validating job's {} steps", self.id);
         ctx.push_section("steps");
@@ -448,6 +456,76 @@ mod tests {
 
         let result = validate_job(job).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    pub async fn job_env_with_start_of_run_value_validation_success() {
+        let job = Job {
+            env: [(
+                "LOG_LEVEL".to_string(),
+                "${{ bld_project_dir }}".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let result = validate_job(job).await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn job_env_with_runtime_value_validation_failure() {
+        let job = Job {
+            env: [(
+                "LOG_LEVEL".to_string(),
+                "${{ steps.build.outputs.level }}".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let Err(e) = validate_job(job).await else {
+            panic!("expected a validation error for a runtime expression in job env");
+        };
+        assert!(
+            e.to_string()
+                .contains("is not available at the start of a run"),
+            "{e}"
+        );
+    }
+
+    #[tokio::test]
+    pub async fn job_env_with_empty_name_validation_failure() {
+        let job = Job {
+            env: [(String::new(), "value".to_string())].into_iter().collect(),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let Err(e) = validate_job(job).await else {
+            panic!("expected a validation error for an empty env name");
+        };
+        assert!(
+            e.to_string()
+                .contains("Environment variable name must not be empty"),
+            "{e}"
+        );
     }
 
     #[test]

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -45,6 +45,8 @@ pub struct Job {
     pub dispose: bool,
     pub strategy: Option<Strategy>,
     pub working_dir: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
     pub steps: Vec<Step>,
     #[serde(default)]
     pub outputs: HashMap<String, Output>,
@@ -85,6 +87,7 @@ impl Default for Job {
             dispose: Self::default_dispose(),
             strategy: None,
             working_dir: None,
+            env: HashMap::new(),
             steps: vec![],
             outputs: HashMap::new(),
         }
@@ -208,6 +211,11 @@ impl<'a> Validate<'a> for Job {
             ctx.validate_expressions(wd, ExprScope::Runtime);
             ctx.pop_section();
         }
+
+        debug!("Validating job's {} env section", self.id);
+        ctx.push_section("env");
+        ctx.validate_env(&self.env, ExprScope::StartOfRun);
+        ctx.pop_section();
 
         debug!("Validating job's {} steps", self.id);
         ctx.push_section("steps");
@@ -491,6 +499,76 @@ mod tests {
 
         let result = validate_job(job).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    pub async fn job_env_with_start_of_run_value_validation_success() {
+        let job = Job {
+            env: [(
+                "LOG_LEVEL".to_string(),
+                "${{ bld_project_dir }}".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let result = validate_job(job).await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn job_env_with_runtime_value_validation_failure() {
+        let job = Job {
+            env: [(
+                "LOG_LEVEL".to_string(),
+                "${{ steps.build.outputs.level }}".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let Err(e) = validate_job(job).await else {
+            panic!("expected a validation error for a runtime expression in job env");
+        };
+        assert!(
+            e.to_string()
+                .contains("is not available at the start of a run"),
+            "{e}"
+        );
+    }
+
+    #[tokio::test]
+    pub async fn job_env_with_empty_name_validation_failure() {
+        let job = Job {
+            env: [(String::new(), "value".to_string())].into_iter().collect(),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let Err(e) = validate_job(job).await else {
+            panic!("expected a validation error for an empty env name");
+        };
+        assert!(
+            e.to_string()
+                .contains("Environment variable name must not be empty"),
+            "{e}"
+        );
     }
 
     #[test]

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -568,6 +568,105 @@ mod tests {
         );
     }
 
+    /// A value declared on a job is available to the expressions of that job, so a step
+    /// that reads one passes validation even when the file declares no such value.
+    #[tokio::test]
+    pub async fn job_env_value_used_by_expression_of_same_job_validation_success() {
+        let mut pipeline = Pipeline::default();
+        pipeline
+            .env
+            .insert("LOG_LEVEL".to_string(), "info".to_string());
+        pipeline.jobs.insert(
+            "build".to_string(),
+            Job {
+                env: [("RUSTFLAGS".to_string(), "-D warnings".to_string())]
+                    .into_iter()
+                    .collect(),
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "build".to_string(),
+                    run: "echo ${{ env.RUSTFLAGS }} ${{ env.LOG_LEVEL }}".to_string(),
+                    condition: Some("${{ env.RUSTFLAGS }}".to_string()),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let result = validate_pipeline(pipeline).await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    /// The values of a job are resolved in one step, before any of them exists, so one
+    /// value of a job cannot read another value of the same job.
+    #[tokio::test]
+    pub async fn job_env_value_reading_another_value_of_the_same_job_validation_failure() {
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            "build".to_string(),
+            Job {
+                env: [
+                    ("LEVEL".to_string(), "info".to_string()),
+                    ("LOG".to_string(), "${{ env.LEVEL }}".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "build".to_string(),
+                    run: "echo hello".to_string(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let Err(e) = validate_pipeline(pipeline).await else {
+            panic!("expected a validation error for a value that reads a value of its own job");
+        };
+        let error = e.to_string();
+        assert!(error.contains("env variable 'LEVEL' not found"), "{error}");
+    }
+
+    /// The values of one job never reach another job, so an expression that reads the env
+    /// of a different job is an error.
+    #[tokio::test]
+    pub async fn env_value_of_another_job_validation_failure() {
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            "build".to_string(),
+            Job {
+                env: [("RUSTFLAGS".to_string(), "-D warnings".to_string())]
+                    .into_iter()
+                    .collect(),
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "build".to_string(),
+                    run: "echo hello".to_string(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+        pipeline.jobs.insert(
+            "docs".to_string(),
+            Job {
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "docs".to_string(),
+                    run: "echo ${{ env.RUSTFLAGS }}".to_string(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let Err(e) = validate_pipeline(pipeline).await else {
+            panic!("expected a validation error for the env of another job");
+        };
+        let error = e.to_string();
+        assert!(
+            error.contains("env variable 'RUSTFLAGS' not found"),
+            "{error}"
+        );
+    }
+
     #[test]
     pub fn name_expr_eval_success() {
         let wctx = MockWritableRuntimeExprContext::new();

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -76,14 +76,10 @@ impl<S: RootState> JobRunner<S> {
                 })
             })?;
 
-        // A job's env is merged on top of the file's env once, before any step runs, so
-        // its expressions are limited to the start of run context. From this point on the
-        // job's own expr context carries the merge, so every command and expression of the
-        // job sees it with no further change needed.
-        options.expr_rctx = Self::resolve_job_expr_rctx(job, &options)?;
+        // Extending the provided expr_rctx with the currents job's internally evaluated scope
+        options.expr_rctx = Self::extend_expr_rctx(job, &options)?;
 
-        // Every runs_on field is consumed when building the platform, before any step has
-        // run, so its expressions are limited to the start of run context.
+        // Evaluate the runs_on value before building the job platform
         let runs_on = Self::resolve_runs_on(job, &options)?;
 
         let platform = build_platform(
@@ -106,7 +102,7 @@ impl<S: RootState> JobRunner<S> {
         })
     }
 
-    fn resolve_job_expr_rctx(
+    fn extend_expr_rctx(
         job: &Job,
         options: &JobRunnerOptions<S>,
     ) -> Result<Arc<CommonReadonlyRuntimeExprContext>> {
@@ -124,14 +120,12 @@ impl<S: RootState> JobRunner<S> {
         let mut env = (*options.expr_rctx.env).clone();
         env.extend(job_env);
 
-        Ok(CommonReadonlyRuntimeExprContext {
-            config: options.expr_rctx.config.clone(),
-            inputs: options.expr_rctx.inputs.clone(),
-            env: env.into_arc(),
-            run_id: options.expr_rctx.run_id.clone(),
-            run_start_time: options.expr_rctx.run_start_time.clone(),
-        }
-        .into_arc())
+        let expr_rctx = options
+            .expr_rctx
+            .clone_with(|x| x.env = env.into_arc())
+            .into_arc();
+
+        Ok(expr_rctx)
     }
 
     fn resolve_runs_on(job: &Job, options: &JobRunnerOptions<S>) -> Result<RunsOn> {
@@ -947,7 +941,7 @@ mod tests {
 
         let mut runner = job_runner_for_env_test(&job, CommonReadonlyRuntimeExprContext::default());
         runner.options.expr_rctx =
-            JobRunner::<JobState>::resolve_job_expr_rctx(&job, &runner.options).unwrap();
+            JobRunner::<JobState>::extend_expr_rctx(&job, &runner.options).unwrap();
 
         assert_eq!(
             runner.eval_all_expr("echo ${{ env.GREETING }}").unwrap(),
@@ -975,7 +969,7 @@ mod tests {
 
         let mut runner = job_runner_for_env_test(&job, expr_rctx);
         runner.options.expr_rctx =
-            JobRunner::<JobState>::resolve_job_expr_rctx(&job, &runner.options).unwrap();
+            JobRunner::<JobState>::extend_expr_rctx(&job, &runner.options).unwrap();
 
         assert_eq!(
             runner.eval_all_expr("${{ env.NAME }}").unwrap(),

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -76,6 +76,12 @@ impl<S: RootState> JobRunner<S> {
                 })
             })?;
 
+        // A job's env is merged on top of the file's env once, before any step runs, so
+        // its expressions are limited to the start of run context. From this point on the
+        // job's own expr context carries the merge, so every command and expression of the
+        // job sees it with no further change needed.
+        options.expr_rctx = Self::resolve_job_expr_rctx(job, &options)?;
+
         // Every runs_on field is consumed when building the platform, before any step has
         // run, so its expressions are limited to the start of run context.
         let runs_on = Self::resolve_runs_on(job, &options)?;
@@ -98,6 +104,34 @@ impl<S: RootState> JobRunner<S> {
             working_dir,
             outputs: HashMap::new(),
         })
+    }
+
+    fn resolve_job_expr_rctx(
+        job: &Job,
+        options: &JobRunnerOptions<S>,
+    ) -> Result<Arc<CommonReadonlyRuntimeExprContext>> {
+        if job.env.is_empty() {
+            return Ok(options.expr_rctx.clone());
+        }
+
+        let exec = CommonExprExecutor::new(
+            options.pipeline.as_ref(),
+            options.expr_rctx.as_ref(),
+            &START_OF_RUN_WCTX,
+        );
+        let job_env = eval_all_expressions_map(&exec, &options.expr_regex, &job.env)?;
+
+        let mut env = (*options.expr_rctx.env).clone();
+        env.extend(job_env);
+
+        Ok(CommonReadonlyRuntimeExprContext {
+            config: options.expr_rctx.config.clone(),
+            inputs: options.expr_rctx.inputs.clone(),
+            env: env.into_arc(),
+            run_id: options.expr_rctx.run_id.clone(),
+            run_start_time: options.expr_rctx.run_start_time.clone(),
+        }
+        .into_arc())
     }
 
     fn resolve_runs_on(job: &Job, options: &JobRunnerOptions<S>) -> Result<RunsOn> {
@@ -852,6 +886,100 @@ mod tests {
         assert_eq!(
             job.resolve_working_dir(&None).unwrap(),
             Some("/tmp/some-worktree".to_string())
+        );
+    }
+
+    fn job_runner_for_env_test(
+        job: &Job,
+        expr_rctx: CommonReadonlyRuntimeExprContext,
+    ) -> JobRunner<JobState> {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let state = JobState::default();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(job_name.clone(), job.clone());
+        let pipeline = pipeline.into_arc();
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline,
+            regex_cache,
+            expr_regex,
+            expr_rctx: expr_rctx.into_arc(),
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+
+        JobRunner {
+            options,
+            platform,
+            runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
+        }
+    }
+
+    /// A job's env value is merged into the expr context that builds every command of the
+    /// job, so a value declared on the job reaches the text of a shell command the same way
+    /// a value declared on the file already does.
+    #[test]
+    pub fn job_env_value_reaches_command_success() {
+        let job = Job {
+            env: [("GREETING".to_string(), "hello from job".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        let mut runner = job_runner_for_env_test(&job, CommonReadonlyRuntimeExprContext::default());
+        runner.options.expr_rctx =
+            JobRunner::<JobState>::resolve_job_expr_rctx(&job, &runner.options).unwrap();
+
+        assert_eq!(
+            runner.eval_all_expr("echo ${{ env.GREETING }}").unwrap(),
+            "echo hello from job"
+        );
+    }
+
+    /// The two levels merge in the order file, job: a job value with the same name as a
+    /// file value replaces it, so an expression sees the job's value, not the file's.
+    #[test]
+    pub fn job_env_value_replaces_file_env_with_same_name_success() {
+        let job = Job {
+            env: [("NAME".to_string(), "job-value".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let file_env: HashMap<String, String> = [("NAME".to_string(), "file-value".to_string())]
+            .into_iter()
+            .collect();
+        let expr_rctx = CommonReadonlyRuntimeExprContext {
+            env: file_env.into_arc(),
+            ..Default::default()
+        };
+
+        let mut runner = job_runner_for_env_test(&job, expr_rctx);
+        runner.options.expr_rctx =
+            JobRunner::<JobState>::resolve_job_expr_rctx(&job, &runner.options).unwrap();
+
+        assert_eq!(
+            runner.eval_all_expr("${{ env.NAME }}").unwrap(),
+            "job-value"
         );
     }
 

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -75,6 +75,12 @@ impl<S: RootState> JobRunner<S> {
                 })
             })?;
 
+        // A job's env is merged on top of the file's env once, before any step runs, so
+        // its expressions are limited to the start of run context. From this point on the
+        // job's own expr context carries the merge, so every command and expression of the
+        // job sees it with no further change needed.
+        options.expr_rctx = Self::resolve_job_expr_rctx(job, &options)?;
+
         // Every runs_on field is consumed when building the platform, before any step has
         // run, so its expressions are limited to the start of run context.
         let runs_on = Self::resolve_runs_on(job, &options)?;
@@ -94,6 +100,34 @@ impl<S: RootState> JobRunner<S> {
             runs_on,
             outputs: HashMap::new(),
         })
+    }
+
+    fn resolve_job_expr_rctx(
+        job: &Job,
+        options: &JobRunnerOptions<S>,
+    ) -> Result<Arc<CommonReadonlyRuntimeExprContext>> {
+        if job.env.is_empty() {
+            return Ok(options.expr_rctx.clone());
+        }
+
+        let exec = CommonExprExecutor::new(
+            options.pipeline.as_ref(),
+            options.expr_rctx.as_ref(),
+            &START_OF_RUN_WCTX,
+        );
+        let job_env = eval_all_expressions_map(&exec, &options.expr_regex, &job.env)?;
+
+        let mut env = (*options.expr_rctx.env).clone();
+        env.extend(job_env);
+
+        Ok(CommonReadonlyRuntimeExprContext {
+            config: options.expr_rctx.config.clone(),
+            inputs: options.expr_rctx.inputs.clone(),
+            env: env.into_arc(),
+            run_id: options.expr_rctx.run_id.clone(),
+            run_start_time: options.expr_rctx.run_start_time.clone(),
+        }
+        .into_arc())
     }
 
     fn resolve_runs_on(job: &Job, options: &JobRunnerOptions<S>) -> Result<RunsOn> {
@@ -820,6 +854,100 @@ mod tests {
             job.resolve_working_dir(&Some("${{ inputs.worktree_dir }}".to_string()))
                 .unwrap(),
             Some("/tmp/some-worktree".to_string())
+        );
+    }
+
+    fn job_runner_for_env_test(
+        job: &Job,
+        expr_rctx: CommonReadonlyRuntimeExprContext,
+    ) -> JobRunner<JobState> {
+        let job_name = "main".to_string();
+        let config = BldConfig::default().into_arc();
+        let logger = Logger::mock().into_arc();
+        let fs = FileSystem::local(config.clone()).into_arc();
+        let run_ctx = Context::mock().into_arc();
+        let platform = Platform::mock().into_arc();
+        let artifacts = Artifacts::mock().into_arc();
+        let regex_cache = RegexCache::mock().into_arc();
+        let expr_regex = Regex::new(EXPR_REGEX).unwrap().into_arc();
+        let state = JobState::default();
+        let package_manager = PackageManager::new(config.clone()).into_arc();
+
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(job_name.clone(), job.clone());
+        let pipeline = pipeline.into_arc();
+
+        let options = JobRunnerOptions {
+            job_name,
+            logger,
+            config,
+            fs,
+            run_ctx,
+            pipeline,
+            regex_cache,
+            expr_regex,
+            expr_rctx: expr_rctx.into_arc(),
+            package_manager,
+            artifacts,
+            is_child: false,
+            state,
+        };
+
+        JobRunner {
+            options,
+            platform,
+            runs_on: RunsOn::default(),
+            outputs: HashMap::new(),
+        }
+    }
+
+    /// A job's env value is merged into the expr context that builds every command of the
+    /// job, so a value declared on the job reaches the text of a shell command the same way
+    /// a value declared on the file already does.
+    #[test]
+    pub fn job_env_value_reaches_command_success() {
+        let job = Job {
+            env: [("GREETING".to_string(), "hello from job".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        let mut runner = job_runner_for_env_test(&job, CommonReadonlyRuntimeExprContext::default());
+        runner.options.expr_rctx =
+            JobRunner::<JobState>::resolve_job_expr_rctx(&job, &runner.options).unwrap();
+
+        assert_eq!(
+            runner.eval_all_expr("echo ${{ env.GREETING }}").unwrap(),
+            "echo hello from job"
+        );
+    }
+
+    /// The two levels merge in the order file, job: a job value with the same name as a
+    /// file value replaces it, so an expression sees the job's value, not the file's.
+    #[test]
+    pub fn job_env_value_replaces_file_env_with_same_name_success() {
+        let job = Job {
+            env: [("NAME".to_string(), "job-value".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let file_env: HashMap<String, String> = [("NAME".to_string(), "file-value".to_string())]
+            .into_iter()
+            .collect();
+        let expr_rctx = CommonReadonlyRuntimeExprContext {
+            env: file_env.into_arc(),
+            ..Default::default()
+        };
+
+        let mut runner = job_runner_for_env_test(&job, expr_rctx);
+        runner.options.expr_rctx =
+            JobRunner::<JobState>::resolve_job_expr_rctx(&job, &runner.options).unwrap();
+
+        assert_eq!(
+            runner.eval_all_expr("${{ env.NAME }}").unwrap(),
+            "job-value"
         );
     }
 

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -924,6 +924,7 @@ mod tests {
             platform,
             runs_on: RunsOn::default(),
             outputs: HashMap::new(),
+            working_dir: None,
         }
     }
 

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -84,6 +84,7 @@ pub struct CommonValidator<'a, V: Validate<'a> + for<'x> EvalObject<'x>> {
     package_manager: Arc<PackageManager>,
     expr_regex: Regex,
     expr_rctx: &'a CommonReadonlyRuntimeExprContext,
+    job_expr_rctx: HashMap<&'a str, &'a CommonReadonlyRuntimeExprContext>,
     expr_wctx: &'a [ValidatorWritableRuntimeExprContext<'a>],
     job_needs: HashMap<&'a str, HashSet<&'a str>>,
     section: Vec<Section<'a>>,
@@ -107,6 +108,7 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
             package_manager,
             expr_regex: parser::new_regex()?,
             expr_rctx,
+            job_expr_rctx: HashMap::new(),
             expr_wctx,
             job_needs: HashMap::new(),
             section: Vec::new(),
@@ -122,6 +124,27 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
     pub fn with_job_needs(mut self, job_needs: HashMap<&'a str, HashSet<&'a str>>) -> Self {
         self.job_needs = job_needs;
         self
+    }
+
+    /// Declares the context of every job that has its own env, since the values of a job
+    /// are merged on top of the values of the file for that job alone. A job with no env
+    /// of its own is left out and keeps the context of the file.
+    pub fn with_job_expr_rctx(
+        mut self,
+        job_expr_rctx: HashMap<&'a str, &'a CommonReadonlyRuntimeExprContext>,
+    ) -> Self {
+        self.job_expr_rctx = job_expr_rctx;
+        self
+    }
+
+    /// The context of the job that is being validated, or the context of the file when no
+    /// job is being validated or the job has no env of its own.
+    fn rctx(&self) -> &'a CommonReadonlyRuntimeExprContext {
+        self.current_job
+            .as_ref()
+            .and_then(|job| self.job_expr_rctx.get(job.inner()))
+            .copied()
+            .unwrap_or(self.expr_rctx)
     }
 
     fn validate_job_output_refs(&mut self, value: &'a str) {
@@ -159,7 +182,7 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
     }
 
     fn eval_expressions<W: WritableRuntimeExprContext>(&mut self, value: &'a str, wctx: &'a W) {
-        let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, wctx);
+        let expr_exec = CommonExprExecutor::new(self.validatable, self.rctx(), wctx);
         for entry in self.expr_regex.find_iter(value) {
             let Err(e) = expr_exec.eval(entry.as_str()) else {
                 continue;
@@ -174,7 +197,7 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
         value: &'a str,
         wctx: &'a W,
     ) {
-        let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, wctx);
+        let expr_exec = CommonExprExecutor::new(self.validatable, self.rctx(), wctx);
         for entry in self.expr_regex.find_iter(value) {
             match expr_exec.eval(entry.as_str()) {
                 // The value of a step output isn't known during validation, so an
@@ -201,7 +224,7 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
         value: &'a str,
         wctx: &'a W,
     ) {
-        let expr_exec = CommonExprExecutor::new(self.validatable, self.expr_rctx, wctx);
+        let expr_exec = CommonExprExecutor::new(self.validatable, self.rctx(), wctx);
         for entry in self.expr_regex.find_iter(value) {
             match expr_exec.eval(entry.as_str()) {
                 Ok(ExprValue::Boolean(_)) | Ok(ExprValue::Text(_)) | Ok(ExprValue::Unknown) => {}
@@ -351,11 +374,28 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
     }
 
     fn validate_env(&mut self, env: &'a HashMap<String, String>, scope: ExprScope) {
+        // A declared env section is resolved before the values of that section exist, so
+        // its own values are not available to it. The env of a job is validated with the
+        // context of the file for that reason, while the env of a call to another file is
+        // resolved when the step runs and keeps the context of the job.
+        let current_job = match scope {
+            ExprScope::StartOfRun => self.current_job.take(),
+            ExprScope::Runtime => None,
+        };
+
         for (k, v) in env.iter() {
             debug!("Validating env: {}", k);
+            if k.is_empty() {
+                self.append_error("Environment variable name must not be empty");
+                continue;
+            }
             self.section.push(Section::Other(k));
             self.validate_expressions(v, scope);
             self.section.pop();
+        }
+
+        if current_job.is_some() {
+            self.current_job = current_job;
         }
     }
 

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -48,13 +48,41 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
         };
         match self.file {
             RunnerFile::PipelineFileType(pip) => {
+                let inputs = with_blank_values(pip.inputs.keys().collect()).into_arc();
+                let env = with_blank_values(pip.env.keys().collect());
                 let expr_rctx = CommonReadonlyRuntimeExprContext::new(
                     self.config.clone(),
-                    with_blank_values(pip.inputs.keys().collect()).into_arc(),
-                    with_blank_values(pip.env.keys().collect()).into_arc(),
+                    inputs.clone(),
+                    env.clone().into_arc(),
                     String::new(),
                     String::new(),
                 );
+                // The env of a job is merged on top of the env of the file for that job
+                // alone, so every job that declares one gets a context of its own.
+                let job_expr_rctx_values: Vec<(&str, CommonReadonlyRuntimeExprContext)> = pip
+                    .jobs
+                    .iter()
+                    .filter(|(_, job)| !job.env.is_empty())
+                    .map(|(name, job)| {
+                        let mut job_env = env.clone();
+                        job_env.extend(with_blank_values(job.env.keys().collect()));
+                        (
+                            name.as_str(),
+                            CommonReadonlyRuntimeExprContext::new(
+                                self.config.clone(),
+                                inputs.clone(),
+                                job_env.into_arc(),
+                                String::new(),
+                                String::new(),
+                            ),
+                        )
+                    })
+                    .collect();
+                let job_expr_rctx: HashMap<&str, &CommonReadonlyRuntimeExprContext> =
+                    job_expr_rctx_values
+                        .iter()
+                        .map(|(name, rctx)| (*name, rctx))
+                        .collect();
                 let expr_wctx: Vec<ValidatorWritableRuntimeExprContext<'_>> = pip
                     .jobs
                     .keys()
@@ -74,6 +102,7 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                     &expr_wctx,
                 )?
                 .with_job_needs(job_needs)
+                .with_job_expr_rctx(job_expr_rctx)
                 .validate()
                 .await
             }

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -57,8 +57,7 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                     String::new(),
                     String::new(),
                 );
-                // The env of a job is merged on top of the env of the file for that job
-                // alone, so every job that declares one gets a context of its own.
+                // Create expr_rctx for each job's scope
                 let job_expr_rctx_values: Vec<(&str, CommonReadonlyRuntimeExprContext)> = pip
                     .jobs
                     .iter()


### PR DESCRIPTION
### In this PR

- A version 3 job accepts the key `env`, with the same shape as the `env` of the file.
- The runner evaluates the values of a job with the start of run scope and merges them on top of the values of the file once, before any step of the job runs.
- The merged map becomes the expression context of the job and the environment given to the platform of the job, so every command and every `${{ env.NAME }}` of that job sees it, on the container, the machine and the ssh platform alike.
- The values of one job stay in that job, and a name of a job replaces the name of the file.
- The `env` of a call to another file keeps its behaviour and still sets the environment of the child file.
- Validation checks the values of a job with the start of run scope and rejects an empty name.
- The validator builds a context for every job that declares an env, so an expression can read a value of its own job while a value of another job is still reported as an error.
- Tests cover the merge order, a value reaching a command, the validation scope of the values of a job, and the validation of expressions that read the env of the same job and of another job.

Closes #373
