### PR TITLE
feat(runner): Add a working_dir key to version 3 jobs

### DIFF
--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -203,9 +203,6 @@ impl<'a> Validate<'a> for Job {
         }
 
         if let Some(wd) = &self.working_dir {
-            // A step falls back to the job's working_dir at the time it runs, so the
-            // job's value is resolved in that same run time scope, not at the start of
-            // the run.
             debug!("Validating job's {} working directory", self.id);
             ctx.push_section("working_dir");
             ctx.validate_expressions(wd, ExprScope::Runtime);

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -44,6 +44,7 @@ pub struct Job {
     #[serde(default = "Job::default_dispose")]
     pub dispose: bool,
     pub strategy: Option<Strategy>,
+    pub working_dir: Option<String>,
     pub steps: Vec<Step>,
     #[serde(default)]
     pub outputs: HashMap<String, Output>,
@@ -83,6 +84,7 @@ impl Default for Job {
             needs: None,
             dispose: Self::default_dispose(),
             strategy: None,
+            working_dir: None,
             steps: vec![],
             outputs: HashMap::new(),
         }
@@ -197,6 +199,16 @@ impl<'a> Validate<'a> for Job {
             ctx.push_section("if");
             ctx.validate_condition(condition, ExprScope::StartOfRun);
             validate_matrix_refs(ctx, condition, &HashSet::new());
+            ctx.pop_section();
+        }
+
+        if let Some(wd) = &self.working_dir {
+            // A step falls back to the job's working_dir at the time it runs, so the
+            // job's value is resolved in that same run time scope, not at the start of
+            // the run.
+            debug!("Validating job's {} working directory", self.id);
+            ctx.push_section("working_dir");
+            ctx.validate_expressions(wd, ExprScope::Runtime);
             ctx.pop_section();
         }
 
@@ -426,6 +438,40 @@ mod tests {
                 "{e}"
             );
         }
+    }
+
+    #[tokio::test]
+    pub async fn runtime_value_in_working_dir_success() {
+        let job = Job {
+            working_dir: Some("${{ steps.build.outputs.dir }}".to_string()),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let result = validate_job(job).await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn unavailable_value_in_working_dir_failure() {
+        let job = Job {
+            working_dir: Some("${{ jobs.other.outputs.dir }}".to_string()),
+            steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                id: "build".to_string(),
+                run: "echo hello".to_string(),
+                ..Default::default()
+            }))],
+            ..Default::default()
+        };
+
+        let Err(e) = validate_job(job).await else {
+            panic!("expected an error for a value that isn't available");
+        };
+        assert!(e.to_string().contains("working_dir"), "{e}");
     }
 
     #[tokio::test]

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -402,8 +402,6 @@ impl<S: RootState> JobRunner<S> {
         eval_all_expressions_map(&expr_exec, &self.options.expr_regex, vars)
     }
 
-    /// The working directory of a step falls back to the one of the job. The chosen value
-    /// is the only one evaluated, since a step runs in one directory only.
     fn resolve_working_dir(&mut self, working_dir: &Option<String>) -> Result<Option<String>> {
         let working_dir = working_dir
             .as_deref()

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -58,6 +58,7 @@ pub struct JobRunner<S: RootState> {
     pub options: JobRunnerOptions<S>,
     pub platform: Arc<Platform>,
     pub runs_on: RunsOn,
+    pub working_dir: Option<String>,
     pub outputs: HashMap<String, String>,
 }
 
@@ -88,10 +89,13 @@ impl<S: RootState> JobRunner<S> {
         )
         .await?;
 
+        let working_dir = job.working_dir.clone();
+
         Ok(JobRunner {
             options,
             platform,
             runs_on,
+            working_dir,
             outputs: HashMap::new(),
         })
     }
@@ -398,11 +402,14 @@ impl<S: RootState> JobRunner<S> {
         eval_all_expressions_map(&expr_exec, &self.options.expr_regex, vars)
     }
 
+    /// The working directory of a step falls back to the one of the job. The chosen value
+    /// is the only one evaluated, since a step runs in one directory only.
     fn resolve_working_dir(&mut self, working_dir: &Option<String>) -> Result<Option<String>> {
-        working_dir
+        let working_dir = working_dir
             .as_deref()
-            .map(|wd| self.eval_all_expr(wd))
-            .transpose()
+            .or(self.working_dir.as_deref())
+            .map(str::to_owned);
+        working_dir.map(|wd| self.eval_all_expr(&wd)).transpose()
     }
 
     async fn shell(
@@ -696,6 +703,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -751,6 +759,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -811,14 +820,39 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
+        // Neither the step nor the job has a value: there is no result.
         assert_eq!(job.resolve_working_dir(&None).unwrap(), None);
 
+        // The step has a value and the job has none: the result is the value of the step.
         assert_eq!(
             job.resolve_working_dir(&Some("${{ inputs.worktree_dir }}".to_string()))
                 .unwrap(),
+            Some("/tmp/some-worktree".to_string())
+        );
+
+        job.working_dir = Some("/job/working/dir".to_string());
+
+        // The step has no value and the job has a value: the result is the value of the job.
+        assert_eq!(
+            job.resolve_working_dir(&None).unwrap(),
+            Some("/job/working/dir".to_string())
+        );
+
+        // The step has a value and the job has a value: the result is the value of the step.
+        assert_eq!(
+            job.resolve_working_dir(&Some("/step/working/dir".to_string()))
+                .unwrap(),
+            Some("/step/working/dir".to_string())
+        );
+
+        // The value of the job holds an expression: the runner evaluates it.
+        job.working_dir = Some("${{ inputs.worktree_dir }}".to_string());
+        assert_eq!(
+            job.resolve_working_dir(&None).unwrap(),
             Some("/tmp/some-worktree".to_string())
         );
     }
@@ -1086,6 +1120,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1155,6 +1190,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1220,6 +1256,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1295,6 +1332,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1368,6 +1406,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1441,6 +1480,7 @@ mod tests {
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1513,6 +1553,7 @@ steps:
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         }
     }
@@ -1566,6 +1607,7 @@ steps:
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1628,6 +1670,7 @@ steps:
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         };
 
@@ -1774,6 +1817,7 @@ steps:
             options,
             platform,
             runs_on: RunsOn::default(),
+            working_dir: None,
             outputs: HashMap::new(),
         }
     }


### PR DESCRIPTION
### In this PR

- A version 3 job accepts the new key `working_dir`, which gives the default directory for all of its steps.
- The job runner keeps that value and the resolution of a step's directory falls back to it, so a step without a `working_dir` of its own runs in the directory of the job.
- A step that sets `working_dir` still wins over the value of the job.
- Only the chosen value is evaluated, and it is evaluated for each step, so the expressions of the job have the run time scope.
- The validator checks the expressions of the new key with the run time scope.
- The test of the resolution covers the four combinations of a value on the step and on the job, plus a job value that holds an expression, and new validation tests cover an accepted run time value and a rejected one.

Closes #374
