### PR TITLE
fix(bld_runner): Find matrix references with the parser instead of a text search

### DIFF
--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -1126,6 +1126,76 @@ mod tests {
     }
 
     #[tokio::test]
+    pub async fn strategy_matrix_key_with_hyphen_passes_validation() {
+        let mut matrix = HashMap::new();
+        matrix.insert(
+            "my-key".to_string(),
+            MatrixValue::Array(vec!["a".to_string(), "b".to_string()]),
+        );
+
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "s".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo ${{ matrix.my-key }}".to_string(),
+            condition: None,
+            strategy: Some(Strategy {
+                matrix,
+                fail_fast: None,
+            }),
+        })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn strategy_matrix_text_value_passes_validation() {
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "s".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo ${{ \"matrix.os\" }}".to_string(),
+            condition: None,
+            strategy: None,
+        })));
+
+        let result = validate_action(&action).await;
+
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    pub async fn strategy_matrix_undefined_key_fails_validation() {
+        let mut matrix = HashMap::new();
+        matrix.insert(
+            "os".to_string(),
+            MatrixValue::Array(vec!["linux".to_string(), "windows".to_string()]),
+        );
+
+        let mut action = Action::default();
+        action.steps.push(Step::ComplexSh(Box::new(ShellCommand {
+            id: "s".to_string(),
+            name: None,
+            working_dir: None,
+            run: "echo ${{ matrix.arch }}".to_string(),
+            condition: None,
+            strategy: Some(Strategy {
+                matrix,
+                fail_fast: None,
+            }),
+        })));
+
+        let result = validate_action(&action).await;
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("matrix key 'arch' is not defined"));
+    }
+
+    #[tokio::test]
     pub async fn output_reading_input_and_declared_step_output_passes_validation() {
         let mut action = Action::default();
         action.inputs.insert(

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -23,9 +23,6 @@ use pest::{Parser, iterators::Pairs};
 
 use super::{ConsumeValidator, ExprScope, Validate, ValidatorContext};
 
-/// Walks the pairs of a parsed expression and collects the name of every matrix
-/// reference, i.e. every `Object` whose first part is `matrix`. A `String` symbol
-/// (a text value) has no `Object` inside it, so a text value never gives a reference.
 fn collect_matrix_refs(pairs: Pairs<Rule>, result: &mut Vec<String>) {
     for pair in pairs {
         if pair.as_rule() == Rule::Object {
@@ -143,18 +140,11 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
         })
     }
 
-    /// Declares, for every job, which other jobs it may read outputs from through
-    /// `jobs.<name>.outputs.<name>`. A pipeline validator supplies the `needs` of every
-    /// job here; other validatable types (e.g. an action) leave this empty, since none of
-    /// their jobs exist.
     pub fn with_job_needs(mut self, job_needs: HashMap<&'a str, HashSet<&'a str>>) -> Self {
         self.job_needs = job_needs;
         self
     }
 
-    /// Declares the context of every job that has its own env, since the values of a job
-    /// are merged on top of the values of the file for that job alone. A job with no env
-    /// of its own is left out and keeps the context of the file.
     pub fn with_job_expr_rctx(
         mut self,
         job_expr_rctx: HashMap<&'a str, &'a CommonReadonlyRuntimeExprContext>,
@@ -163,8 +153,6 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
         self
     }
 
-    /// The context of the job that is being validated, or the context of the file when no
-    /// job is being validated or the job has no env of its own.
     fn rctx(&self) -> &'a CommonReadonlyRuntimeExprContext {
         self.current_job
             .as_ref()

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -16,10 +16,36 @@ use crate::expr::v3::{
     context::{CommonReadonlyRuntimeExprContext, START_OF_RUN_WCTX},
     exec::CommonExprExecutor,
     parser,
+    parser::{ExprParser, Rule},
     traits::{EvalExpr, EvalObject, ExprValue, OutputScope, WritableRuntimeExprContext},
 };
+use pest::{Parser, iterators::Pairs};
 
 use super::{ConsumeValidator, ExprScope, Validate, ValidatorContext};
+
+/// Walks the pairs of a parsed expression and collects the name of every matrix
+/// reference, i.e. every `Object` whose first part is `matrix`. A `String` symbol
+/// (a text value) has no `Object` inside it, so a text value never gives a reference.
+fn collect_matrix_refs(pairs: Pairs<Rule>, result: &mut Vec<String>) {
+    for pair in pairs {
+        if pair.as_rule() == Rule::Object {
+            let mut parts = pair.into_inner();
+            let Some(first) = parts.next() else {
+                continue;
+            };
+            if first.as_str() != "matrix" {
+                continue;
+            }
+            if let Some(second) = parts.next()
+                && second.as_rule() == Rule::ObjectPart
+            {
+                result.push(second.as_str().to_string());
+            }
+        } else {
+            collect_matrix_refs(pair.into_inner(), result);
+        }
+    }
+}
 
 enum Section<'a> {
     Job(&'a str),
@@ -324,18 +350,10 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> ValidatorContext<'a> for Comm
     fn matrix_refs(&self, value: &str) -> Vec<String> {
         let mut result = Vec::new();
         for entry in self.expr_regex.find_iter(value) {
-            let mut rest = entry.as_str();
-            while let Some(pos) = rest.find("matrix.") {
-                let after = &rest[pos + "matrix.".len()..];
-                let end = after
-                    .find(|c: char| !(c.is_alphanumeric() || c == '_'))
-                    .unwrap_or(after.len());
-                let name = &after[..end];
-                if !name.is_empty() {
-                    result.push(name.to_string());
-                }
-                rest = &after[end..];
-            }
+            let Ok(pairs) = ExprParser::parse(Rule::Full, entry.as_str()) else {
+                continue;
+            };
+            collect_matrix_refs(pairs, &mut result);
         }
         result
     }


### PR DESCRIPTION
### In this PR

- `matrix_refs` in the v3 validator now parses each expression with `Rule::Full` instead of searching for the text `matrix.`.
- Added `collect_matrix_refs`, which walks the parse tree and reports the second part of every `Object` whose first part is `matrix`.
- A matrix key that contains a hyphen is now read in full, so it is no longer reported as undefined.
- A text value such as `"matrix.os"` no longer produces a reference, because a string literal holds no `Object`.
- An expression that fails to parse contributes no references; the syntax error is still reported by the expression check.
- Added validator tests for a hyphenated matrix key, a `matrix.` text value, and a reference to a key that is not defined.

Closes #362
