### PR TITLE
fix(server): Stream artifact downloads instead of holding them in memory

### DIFF
--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -31,6 +31,7 @@ pub const LOCAL_SERVER_HOST: &str = "127.0.0.1";
 pub const LOCAL_SERVER_PORT: i64 = 6080;
 pub const LOCAL_SERVER_PIPELINES: &str = "server_pipelines";
 pub const LOCAL_SERVER_CLEANUP_INTERVAL: i64 = 3600;
+pub const LOCAL_SERVER_ARTIFACTS_RETENTION_DAYS: i64 = 7;
 pub const LOCAL_SUPERVISOR_HOST: &str = "127.0.0.1";
 pub const LOCAL_SUPERVISOR_PORT: i64 = 7080;
 pub const LOCAL_SUPERVISOR_WORKERS: i64 = 5;

--- a/crates/bld_config/src/server.rs
+++ b/crates/bld_config/src/server.rs
@@ -23,6 +23,9 @@ pub struct BldLocalServerConfig {
 
     #[serde(default = "BldLocalServerConfig::default_cleanup_interval")]
     pub cleanup_interval: i64,
+
+    #[serde(default = "BldLocalServerConfig::default_artifacts_retention_days")]
+    pub artifacts_retention_days: i64,
 }
 
 impl BldLocalServerConfig {
@@ -44,6 +47,10 @@ impl BldLocalServerConfig {
 
     fn default_cleanup_interval() -> i64 {
         definitions::LOCAL_SERVER_CLEANUP_INTERVAL
+    }
+
+    fn default_artifacts_retention_days() -> i64 {
+        definitions::LOCAL_SERVER_ARTIFACTS_RETENTION_DAYS
     }
 
     /// Checks the value of the tls field and returns the appropriate form
@@ -90,6 +97,7 @@ impl Default for BldLocalServerConfig {
             logs: Self::default_logs(),
             db: None,
             cleanup_interval: Self::default_cleanup_interval(),
+            artifacts_retention_days: Self::default_artifacts_retention_days(),
         }
     }
 }

--- a/crates/bld_core/src/artifacts.rs
+++ b/crates/bld_core/src/artifacts.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
-    io::Write,
+    fs::File,
+    io::{BufReader, BufWriter, Write},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -12,7 +13,7 @@ use bld_models::artifacts::{self, InsertArtifact};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use sea_orm::DatabaseConnection;
 use tar::{Archive, Builder};
-use tokio::fs::{create_dir_all, read, remove_dir_all, write};
+use tokio::fs::{create_dir_all, remove_dir_all, remove_file};
 use tokio::sync::{
     mpsc::{Receiver, Sender, channel},
     oneshot,
@@ -131,8 +132,7 @@ impl ArtifactsBackend {
             .get(name)
             .ok_or_else(|| anyhow!("artifact '{name}' not found"))?;
 
-        let compressed = read(archive_path).await?;
-        decompress_tar_gz(&compressed, staging_dir)?;
+        decompress_tar_gz(archive_path, staging_dir)?;
 
         let extracted_path = staging_dir.join(name);
 
@@ -180,10 +180,16 @@ impl ArtifactsBackend {
             create_dir_all(parent).await?;
         }
 
-        let compressed = compress_to_tar_gz(staging_dir, name)?;
-        write(&artifact_path, compressed).await?;
+        let result = compress_to_tar_gz(staging_dir, name, &artifact_path);
 
-        Ok(())
+        if result.is_err()
+            && artifact_path.is_file()
+            && let Err(e) = remove_file(&artifact_path).await
+        {
+            error!("unable to remove incomplete archive for artifact {name}: {e}");
+        }
+
+        result
     }
 
     async fn resolve_artifact_path(&self, name: &str) -> Result<PathBuf> {
@@ -194,7 +200,12 @@ impl ArtifactsBackend {
                     run_id: self.run_id.clone(),
                     name: name.to_string(),
                 };
-                let model = artifacts::insert(conn.as_ref(), insert).await?;
+                let model = artifacts::insert(
+                    conn.as_ref(),
+                    insert,
+                    self.config.local.server.artifacts_retention_days,
+                )
+                .await?;
                 model.id
             }
         };
@@ -219,15 +230,28 @@ pub fn validate_artifact_name(name: &str) -> Result<()> {
 
     let mut components = path.components();
     match (components.next(), components.next()) {
-        (Some(std::path::Component::Normal(_)), None) => Ok(()),
-        _ => Err(anyhow!(
-            "artifact name '{name}' must be a single path segment without '.', '..' or path separators"
-        )),
+        (Some(std::path::Component::Normal(_)), None) => {}
+        _ => {
+            return Err(anyhow!(
+                "artifact name '{name}' must be a single path segment without '.', '..' or path separators"
+            ));
+        }
     }
+
+    if name.chars().any(|c| c.is_control()) {
+        return Err(anyhow!(
+            "an artifact name must not contain a control character"
+        ));
+    }
+
+    Ok(())
 }
 
-fn compress_to_tar_gz(source: &Path, entry_name: &str) -> Result<Vec<u8>> {
-    let mut tar = Builder::new(Vec::new());
+/// Compresses the source path into the destination archive. The archive is written
+/// while it is created, so neither the tar nor the gzip content is kept in memory.
+fn compress_to_tar_gz(source: &Path, entry_name: &str, dest: &Path) -> Result<()> {
+    let gz = GzEncoder::new(BufWriter::new(File::create(dest)?), Compression::default());
+    let mut tar = Builder::new(gz);
 
     if source.is_file() {
         tar.append_path_with_name(source, entry_name)?;
@@ -235,14 +259,12 @@ fn compress_to_tar_gz(source: &Path, entry_name: &str) -> Result<Vec<u8>> {
         tar.append_dir_all(entry_name, source)?;
     }
 
-    let uncompressed = tar.into_inner()?;
-    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
-    gz.write_all(&uncompressed)?;
-    Ok(gz.finish()?)
+    tar.into_inner()?.finish()?.flush()?;
+    Ok(())
 }
 
-fn decompress_tar_gz(data: &[u8], dest: &Path) -> Result<()> {
-    let gz = GzDecoder::new(data);
+fn decompress_tar_gz(archive_path: &Path, dest: &Path) -> Result<()> {
+    let gz = GzDecoder::new(BufReader::new(File::open(archive_path)?));
     let mut archive = Archive::new(gz);
     archive.unpack(dest)?;
     Ok(())
@@ -347,16 +369,24 @@ mod tests {
     }
 
     #[test]
+    fn validate_artifact_name_rejects_control_characters() {
+        assert!(validate_artifact_name("foo\nbar").is_err());
+        assert!(validate_artifact_name("foo\rbar").is_err());
+        assert!(validate_artifact_name("foo\tbar").is_err());
+    }
+
+    #[test]
     fn compress_to_tar_gz_round_trip() {
         let config = BldConfig::default();
         let base = config.tmp_full_path(&format!("artifacts-test-{}", Uuid::new_v4()));
         let source = base.join("payload");
+        let archive = base.join("payload.tar.gz");
         let extracted = base.join("extracted");
         create_dir_all(&source).unwrap();
         write(source.join("hello.txt"), b"hello world").unwrap();
 
-        let compressed = compress_to_tar_gz(&source, "my-artifact").unwrap();
-        decompress_tar_gz(&compressed, &extracted).unwrap();
+        compress_to_tar_gz(&source, "my-artifact", &archive).unwrap();
+        decompress_tar_gz(&archive, &extracted).unwrap();
 
         let content = read_to_string(extracted.join("my-artifact").join("hello.txt")).unwrap();
         assert_eq!(content, "hello world");
@@ -368,13 +398,14 @@ mod tests {
     fn compress_to_tar_gz_round_trip_single_file() {
         let config = BldConfig::default();
         let base = config.tmp_full_path(&format!("artifacts-test-{}", Uuid::new_v4()));
+        let archive = base.join("payload.tar.gz");
         let extracted = base.join("extracted");
         create_dir_all(&base).unwrap();
         let source = base.join("payload.txt");
         write(&source, b"hello file").unwrap();
 
-        let compressed = compress_to_tar_gz(&source, "my-artifact").unwrap();
-        decompress_tar_gz(&compressed, &extracted).unwrap();
+        compress_to_tar_gz(&source, "my-artifact", &archive).unwrap();
+        decompress_tar_gz(&archive, &extracted).unwrap();
 
         let content = read_to_string(extracted.join("my-artifact")).unwrap();
         assert_eq!(content, "hello file");

--- a/crates/bld_core/src/artifacts.rs
+++ b/crates/bld_core/src/artifacts.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use actix_web::rt::spawn;
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use bld_config::BldConfig;
 use bld_models::artifacts::{self, InsertArtifact};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
@@ -200,12 +200,8 @@ impl ArtifactsBackend {
                     run_id: self.run_id.clone(),
                     name: name.to_string(),
                 };
-                let model = artifacts::insert(
-                    conn.as_ref(),
-                    insert,
-                    self.config.local.server.artifacts_retention_days,
-                )
-                .await?;
+                let retention = self.config.local.server.artifacts_retention_days;
+                let model = artifacts::insert(conn.as_ref(), insert, retention).await?;
                 model.id
             }
         };
@@ -218,37 +214,31 @@ impl ArtifactsBackend {
 
 pub fn validate_artifact_name(name: &str) -> Result<()> {
     if name.is_empty() {
-        return Err(anyhow!("artifact name cannot be empty"));
+        bail!("artifact name cannot be empty")
     }
 
     let path = Path::new(name);
     if path.is_absolute() {
-        return Err(anyhow!(
-            "artifact name '{name}' must not be an absolute path"
-        ));
+        bail!("artifact name '{name}' must not be an absolute path");
     }
 
     let mut components = path.components();
     match (components.next(), components.next()) {
         (Some(std::path::Component::Normal(_)), None) => {}
         _ => {
-            return Err(anyhow!(
+            bail!(
                 "artifact name '{name}' must be a single path segment without '.', '..' or path separators"
-            ));
+            );
         }
     }
 
     if name.chars().any(|c| c.is_control()) {
-        return Err(anyhow!(
-            "an artifact name must not contain a control character"
-        ));
+        bail!("an artifact name must not contain a control character");
     }
 
     Ok(())
 }
 
-/// Compresses the source path into the destination archive. The archive is written
-/// while it is created, so neither the tar nor the gzip content is kept in memory.
 fn compress_to_tar_gz(source: &Path, entry_name: &str, dest: &Path) -> Result<()> {
     let gz = GzEncoder::new(BufWriter::new(File::create(dest)?), Compression::default());
     let mut tar = Builder::new(gz);

--- a/crates/bld_models/src/queries/artifacts.rs
+++ b/crates/bld_models/src/queries/artifacts.rs
@@ -1,10 +1,10 @@
 use anyhow::{Result, anyhow};
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
     TransactionTrait,
 };
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 pub use crate::generated::artifacts::Model as Artifacts;
 use crate::generated::artifacts::{self, Entity as ArtifactsEntity};
@@ -19,11 +19,12 @@ pub struct InsertArtifact {
 pub async fn insert<C: ConnectionTrait + TransactionTrait>(
     conn: &C,
     model: InsertArtifact,
+    retention_days: i64,
 ) -> Result<Artifacts> {
     debug!("inserting artifact to the database");
 
     let date_created = Utc::now();
-    let date_expires = date_created + Duration::days(DEFAULT_RETENTION_DAYS);
+    let date_expires = expiration_date(date_created, retention_days);
     let active_model = artifacts::ActiveModel {
         id: Set(uuid::Uuid::new_v4().to_string()),
         run_id: Set(model.run_id),
@@ -36,6 +37,24 @@ pub async fn insert<C: ConnectionTrait + TransactionTrait>(
     active_model.insert(conn).await.map_err(|e| {
         error!("could not insert artifact due to: {e}");
         anyhow!(e)
+    })
+}
+
+/// Adds the configured retention period to the creation date. A value that is not
+/// positive or that would move the date out of the representable range falls back
+/// to the default retention period.
+fn expiration_date(date_created: DateTime<Utc>, retention_days: i64) -> DateTime<Utc> {
+    let expires = if retention_days > 0 {
+        Duration::try_days(retention_days).and_then(|x| date_created.checked_add_signed(x))
+    } else {
+        None
+    };
+
+    expires.unwrap_or_else(|| {
+        warn!(
+            "invalid artifacts retention of {retention_days} days, falling back to {DEFAULT_RETENTION_DAYS} days"
+        );
+        date_created + Duration::days(DEFAULT_RETENTION_DAYS)
     })
 }
 
@@ -102,4 +121,35 @@ pub async fn delete_by_id<C: ConnectionTrait + TransactionTrait>(conn: &C, id: &
             error!("could not delete artifact due to: {e}");
             anyhow!(e)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_RETENTION_DAYS, expiration_date};
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn expiration_date_uses_the_configured_retention() {
+        let date_created = Utc::now();
+        assert_eq!(
+            expiration_date(date_created, 30),
+            date_created + Duration::days(30)
+        );
+    }
+
+    #[test]
+    fn expiration_date_falls_back_for_non_positive_retention() {
+        let date_created = Utc::now();
+        let expected = date_created + Duration::days(DEFAULT_RETENTION_DAYS);
+        assert_eq!(expiration_date(date_created, 0), expected);
+        assert_eq!(expiration_date(date_created, -1), expected);
+    }
+
+    #[test]
+    fn expiration_date_falls_back_for_out_of_range_retention() {
+        let date_created = Utc::now();
+        let expected = date_created + Duration::days(DEFAULT_RETENTION_DAYS);
+        assert_eq!(expiration_date(date_created, i64::MAX), expected);
+        assert_eq!(expiration_date(date_created, 100_000_000), expected);
+    }
 }

--- a/crates/bld_models/src/queries/artifacts.rs
+++ b/crates/bld_models/src/queries/artifacts.rs
@@ -40,9 +40,6 @@ pub async fn insert<C: ConnectionTrait + TransactionTrait>(
     })
 }
 
-/// Adds the configured retention period to the creation date. A value that is not
-/// positive or that would move the date out of the representable range falls back
-/// to the default retention period.
 fn expiration_date(date_created: DateTime<Utc>, retention_days: i64) -> DateTime<Utc> {
     let expires = if retention_days > 0 {
         Duration::try_days(retention_days).and_then(|x| date_created.checked_add_signed(x))

--- a/crates/bld_server/src/endpoints/artifacts.rs
+++ b/crates/bld_server/src/endpoints/artifacts.rs
@@ -1,17 +1,25 @@
 use actix_web::{
-    HttpResponse, Responder, delete, get,
+    HttpResponse, Responder,
+    body::SizedStream,
+    delete,
+    error::ErrorInternalServerError,
+    get,
     http::header,
-    web::{Data, Path, Query},
+    web::{Bytes, Data, Path, Query},
 };
 use bld_config::BldConfig;
 use bld_models::{
     artifacts::{delete_by_id, select_by_id, select_by_run_id},
     dtos::{ArtifactResponse, ArtifactsQueryParams},
 };
+use futures::{Stream, stream::unfold};
 use sea_orm::DatabaseConnection;
+use tokio::{fs::File, io::AsyncReadExt};
 use tracing::{info, warn};
 
 use crate::extractors::User;
+
+const DOWNLOAD_CHUNK_SIZE: usize = 64 * 1024;
 
 #[get("/v1/artifacts")]
 pub async fn get(
@@ -45,28 +53,79 @@ pub async fn download(
     };
 
     let artifact_path = config.artifact_full_path(&artifact.run_id, &artifact.id);
-    match tokio::fs::read(&artifact_path).await {
-        Ok(bytes) => HttpResponse::Ok()
-            .content_type("application/gzip")
-            .insert_header((
-                header::CONTENT_DISPOSITION,
-                format!(
-                    "attachment; filename=\"{}.tar.gz\"",
-                    escape_content_disposition_filename(&artifact.name)
-                ),
-            ))
-            .body(bytes),
-        Err(e) => HttpResponse::BadRequest().body(e.to_string()),
-    }
+    let file = match File::open(&artifact_path).await {
+        Ok(file) => file,
+        Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
+    };
+
+    let size = match file.metadata().await {
+        Ok(metadata) => metadata.len(),
+        Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
+    };
+
+    HttpResponse::Ok()
+        .content_type("application/gzip")
+        .insert_header((
+            header::CONTENT_DISPOSITION,
+            format!(
+                "attachment; filename=\"{}.tar.gz\"",
+                escape_content_disposition_filename(&artifact.name)
+            ),
+        ))
+        .body(SizedStream::new(size, artifact_stream(file)))
+}
+
+/// Reads the artifact file in chunks so that the whole content is never held in
+/// memory at once.
+fn artifact_stream(file: File) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    unfold(file, |mut file| async move {
+        let mut buffer = vec![0u8; DOWNLOAD_CHUNK_SIZE];
+        match file.read(&mut buffer).await {
+            Ok(0) => None,
+            Ok(n) => {
+                buffer.truncate(n);
+                Some((Ok(Bytes::from(buffer)), file))
+            }
+            Err(e) => Some((Err(ErrorInternalServerError(e)), file)),
+        }
+    })
 }
 
 fn escape_content_disposition_filename(name: &str) -> String {
-    name.replace('\\', "\\\\").replace('"', "\\\"")
+    name.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::escape_content_disposition_filename;
+    use super::{DOWNLOAD_CHUNK_SIZE, artifact_stream, escape_content_disposition_filename};
+    use actix_web::web::Bytes;
+    use futures::StreamExt;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn artifact_stream_yields_the_full_file_in_chunks() {
+        let path = std::env::temp_dir().join(format!("bld-artifact-stream-{}", Uuid::new_v4()));
+        let content: Vec<u8> = (0..DOWNLOAD_CHUNK_SIZE * 2 + 512)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        tokio::fs::write(&path, &content).await.unwrap();
+
+        let file = tokio::fs::File::open(&path).await.unwrap();
+        let chunks: Vec<Bytes> = artifact_stream(file)
+            .map(|chunk| chunk.unwrap())
+            .collect()
+            .await;
+
+        let _ = tokio::fs::remove_file(&path).await;
+
+        assert!(chunks.len() > 1);
+        assert!(chunks.iter().all(|x| x.len() <= DOWNLOAD_CHUNK_SIZE));
+        assert_eq!(chunks.concat(), content);
+    }
 
     #[test]
     fn escape_content_disposition_filename_plain() {
@@ -90,6 +149,11 @@ mod tests {
             escape_content_disposition_filename("foo\\bar"),
             "foo\\\\bar"
         );
+    }
+
+    #[test]
+    fn escape_content_disposition_filename_strips_control_characters() {
+        assert_eq!(escape_content_disposition_filename("foo\r\nbar"), "foobar");
     }
 }
 

--- a/crates/bld_server/src/endpoints/artifacts.rs
+++ b/crates/bld_server/src/endpoints/artifacts.rs
@@ -75,8 +75,6 @@ pub async fn download(
         .body(SizedStream::new(size, artifact_stream(file)))
 }
 
-/// Reads the artifact file in chunks so that the whole content is never held in
-/// memory at once.
 fn artifact_stream(file: File) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
     unfold(file, |mut file| async move {
         let mut buffer = vec![0u8; DOWNLOAD_CHUNK_SIZE];


### PR DESCRIPTION
### In this PR

- The artifact download endpoint sends the file as a stream of 64 KB chunks, so the memory of the server does not grow with the size of the artifact.
- The response keeps a `Content-Length` header, thus a client sees the same content and the same headers as before.
- The artifacts backend writes the tar.gz archive to the disk while it is created, instead of keeping the full archive in memory before the write. A failed compression removes the incomplete archive.
- The retention period of an artifact comes from the new `artifacts_retention_days` key of the server configuration, with 7 days as the default. A value that is not usable falls back to the default and writes a warning.
- `validate_artifact_name` refuses a name with a control character, and the content disposition header drops such a character as well.
- New tests cover the chunked stream, the control character rules and the expiration date.

Closes #361
