### PR TITLE
fix(bld_runner): Keep mockall out of the release build

### DIFF
--- a/crates/bld_runner/Cargo.toml
+++ b/crates/bld_runner/Cargo.toml
@@ -50,4 +50,6 @@ regex = { version = "1.11.1", optional = true }
 cron = { version = "0.13.0", optional = true }
 pest = { version = "2.7.15", optional = true }
 pest_derive = { version = "2.7.15", optional = true }
+
+[dev-dependencies]
 mockall = "0.13.1"

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 
+use super::parser::Rule;
+use anyhow::{Result, bail};
+use pest::iterators::{Pair, Pairs};
 use std::{collections::HashMap, fmt::Display, iter::Peekable};
 
-use anyhow::{Result, bail};
+#[cfg(test)]
 use mockall::automock;
-use pest::iterators::{Pair, Pairs};
-
-use super::parser::Rule;
 
 fn unescape_string_literal(value: &str) -> String {
     let quote = value.chars().next();
@@ -299,7 +299,7 @@ pub trait ReadonlyRuntimeExprContext<'a> {
     fn get_run_start_time(&'a self) -> &'a str;
 }
 
-#[automock]
+#[cfg_attr(test, automock)]
 pub trait WritableRuntimeExprContext {
     #[allow(clippy::needless_lifetimes)]
     fn get_exec_id<'a>(&'a self) -> Option<&'a str>;

--- a/crates/bld_runner/src/runner/v3/state.rs
+++ b/crates/bld_runner/src/runner/v3/state.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 
 use anyhow::{Result, anyhow, bail};
-use mockall::{automock, mock};
 use uuid::Uuid;
 
 use crate::expr::v3::traits::{ExprValue, OutputScope, WritableRuntimeExprContext};
 
-#[automock]
+#[cfg(test)]
+use mockall::{automock, mock};
+
+#[cfg_attr(test, automock)]
 pub trait NodeState {
     fn update_state(&mut self, state: State);
     #[allow(unused)]
@@ -317,26 +319,34 @@ impl WritableRuntimeExprContext for ActionState {
     }
 }
 
-mock! {
-    pub RootState {}
+#[cfg(test)]
+mod mocks {
+    use super::*;
 
-    impl RootState for RootState {
-        fn update_state(&mut self, state: State);
-        fn get_state(&self) -> &State;
-        fn add_node(&mut self, node_id: &str);
-        fn update_node_state(&mut self, node_id: &str, state: State);
-        fn get_node_state<'a>(&'a self, node_id: &str) -> Option<&'a State>;
-        fn set_matrix(&mut self, matrix: HashMap<String, String>);
-    }
+    mock! {
+        pub RootState {}
 
-    impl WritableRuntimeExprContext for RootState {
-        fn get_exec_id<'a> (&'a self) -> Option<&'a str>;
-        fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>>;
-        fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
-        fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;
-        fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str>;
+        impl RootState for RootState {
+            fn update_state(&mut self, state: State);
+            fn get_state(&self) -> &State;
+            fn add_node(&mut self, node_id: &str);
+            fn update_node_state(&mut self, node_id: &str, state: State);
+            fn get_node_state<'a>(&'a self, node_id: &str) -> Option<&'a State>;
+            fn set_matrix(&mut self, matrix: HashMap<String, String>);
+        }
+
+        impl WritableRuntimeExprContext for RootState {
+            fn get_exec_id<'a> (&'a self) -> Option<&'a str>;
+            fn get_output<'a>(&'a self, scope: OutputScope, id: &str, name: &str) -> Result<ExprValue<'a>>;
+            fn set_output(&mut self, id: &str, name: String, value: String) -> Result<()>;
+            fn set_outputs(&mut self, id: &str, outputs: HashMap<String, String>) -> Result<()>;
+            fn get_matrix_value<'a>(&'a self, name: &str) -> Result<&'a str>;
+        }
     }
 }
+
+#[cfg(test)]
+pub use mocks::MockRootState;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
### In this PR

- Replaced the module level `#[automock]` attributes on `NodeState` and `WritableRuntimeExprContext` with `#[cfg_attr(test, automock)]`, so the mocks are only generated for test builds.
- Moved the `mock!` block for `RootState` into a `#[cfg(test)] mod mocks` and re-exported `MockRootState` from it, keeping the mock type path used by the existing tests.
- Gated the `mockall` imports in `runner/v3/state.rs` and `expr/v3/traits.rs` behind `cfg(test)`.
- Moved `mockall` from `[dependencies]` to `[dev-dependencies]` in `crates/bld_runner/Cargo.toml`.

Closes #363 
