### PR TITLE
fix(bld_core): Give each machine platform a directory of its own inside the run directory

### DIFF
--- a/crates/bld_core/src/context/local.rs
+++ b/crates/bld_core/src/context/local.rs
@@ -77,7 +77,7 @@ impl LocalContextBackend {
         }
 
         for platform in self.platforms.iter() {
-            let _ = platform.dispose(false).await.map_err(|e| error!("{e}"));
+            let _ = platform.dispose().await.map_err(|e| error!("{e}"));
         }
 
         resp_tx

--- a/crates/bld_core/src/context/server.rs
+++ b/crates/bld_core/src/context/server.rs
@@ -185,7 +185,7 @@ impl ServerContextBackend {
         }
 
         for platform in self.platforms.iter() {
-            let _ = platform.dispose(false).await.map_err(|e| error!("{e}"));
+            let _ = platform.dispose().await.map_err(|e| error!("{e}"));
         }
 
         resp_tx

--- a/crates/bld_core/src/platform/builder.rs
+++ b/crates/bld_core/src/platform/builder.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, anyhow};
 use bld_config::BldConfig;
 use bld_utils::sync::IntoArc;
 use sea_orm::DatabaseConnection;
+use uuid::Uuid;
 
 use crate::{
     logger::Logger,
@@ -120,7 +121,8 @@ impl<'a> PlatformBuilder<'a> {
             }
 
             PlatformOptions::Machine => {
-                let machine = Machine::new(run_id, config, pipeline_env, env).await?;
+                let platform_id = Uuid::new_v4().to_string();
+                let machine = Machine::new(run_id, &platform_id, config, pipeline_env, env).await?;
                 Platform::machine(Box::new(machine))
             }
         }

--- a/crates/bld_core/src/platform/machine.rs
+++ b/crates/bld_core/src/platform/machine.rs
@@ -9,7 +9,7 @@ use std::{
     process::ExitStatus,
     sync::Arc,
 };
-use tokio::fs::{copy, create_dir_all, read_dir, read_to_string, remove_dir_all};
+use tokio::fs::{copy, create_dir_all, read_dir, read_to_string, remove_dir, remove_dir_all};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -66,12 +66,13 @@ pub struct Machine {
 
 impl Machine {
     pub async fn new(
-        id: &str,
+        run_id: &str,
+        platform_id: &str,
         config: Arc<BldConfig>,
         pipeline_env: &HashMap<String, String>,
         env: Arc<HashMap<String, String>>,
     ) -> Result<Self> {
-        let tmp_path = config.tmp_full_path(id);
+        let tmp_path = config.tmp_full_path(run_id).join(platform_id);
         if !tmp_path.is_dir() {
             create_dir_all(&tmp_path).await?;
         }
@@ -164,16 +165,62 @@ impl Machine {
 
     pub async fn dispose(&self) -> Result<()> {
         remove_dir_all(&self.tmp_dir).await?;
+
+        // The directory of the run is shared with the platforms of the other jobs, so it
+        // is only removed by the last platform that is disposed. The removal fails while
+        // any other job still holds a directory there, which is the expected outcome.
+        if let Some(run_dir) = Path::new(&self.tmp_dir).parent() {
+            let _ = remove_dir(run_dir).await;
+        }
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::copy_path;
+    use super::{Machine, copy_path};
     use bld_config::BldConfig;
+    use bld_utils::sync::IntoArc;
+    use std::collections::HashMap;
     use std::fs::{create_dir_all, read_to_string, remove_dir_all, write};
+    use std::path::Path;
     use uuid::Uuid;
+
+    #[tokio::test]
+    async fn dispose_of_one_machine_platform_does_not_remove_the_directory_of_another() {
+        let config = BldConfig::default().into_arc();
+        let run_id = format!("machine-dispose-test-{}", Uuid::new_v4());
+        let pipeline_env = HashMap::new();
+        let env = HashMap::new().into_arc();
+
+        let first = Machine::new(&run_id, "first", config.clone(), &pipeline_env, env.clone())
+            .await
+            .unwrap();
+        let second = Machine::new(
+            &run_id,
+            "second",
+            config.clone(),
+            &pipeline_env,
+            env.clone(),
+        )
+        .await
+        .unwrap();
+
+        let run_dir = config.tmp_full_path(&run_id);
+        let second_marker = Path::new(&second.tmp_dir).join("marker.txt");
+        write(&second_marker, b"still here").unwrap();
+
+        first.dispose().await.unwrap();
+
+        assert!(!Path::new(&first.tmp_dir).exists());
+        assert!(second_marker.exists());
+        assert!(run_dir.is_dir());
+
+        second.dispose().await.unwrap();
+        assert!(!Path::new(&second.tmp_dir).exists());
+        assert!(!run_dir.exists());
+    }
 
     #[tokio::test]
     async fn copy_path_copies_file_into_directory_target() {

--- a/crates/bld_core/src/platform/mod.rs
+++ b/crates/bld_core/src/platform/mod.rs
@@ -258,11 +258,12 @@ impl Platform {
         }
     }
 
-    pub async fn dispose(&self, in_child_runner: bool) -> Result<()> {
+    pub async fn dispose(&self) -> Result<()> {
         match &self.inner {
-            // checking if the runner is a child in order to not cleanup the temp dir for the whole run
-            PlatformType::Machine(machine) if !in_child_runner => machine.dispose().await,
-            PlatformType::Machine(_) => Ok(()),
+            // every machine platform owns a directory of its own inside the directory of
+            // the run, so disposing one never removes the files of another platform. A
+            // child runner that received this platform from its parent doesn't dispose it.
+            PlatformType::Machine(machine) => machine.dispose().await,
             PlatformType::Container(container) => container.dispose().await,
             PlatformType::Ssh(ssh) => {
                 let (resp_tx, resp_rx) = oneshot::channel();

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -79,7 +79,7 @@ impl Runner {
     async fn dispose_platform(&self) -> Result<()> {
         if self.pipeline.dispose {
             debug!("executing dispose operations for platform");
-            self.platform.dispose(self.is_child).await?;
+            self.platform.dispose().await?;
         } else {
             debug!("keeping platform alive");
             self.platform.keep_alive().await?;

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -408,7 +408,7 @@ impl Runner {
         };
         if self.pipeline.dispose {
             debug!("executing dispose operations for platform");
-            platform.dispose(self.is_child).await?;
+            platform.dispose().await?;
         } else {
             debug!("keeping platform alive");
             platform.keep_alive().await?;

--- a/crates/bld_runner/src/runner/v3/job.rs
+++ b/crates/bld_runner/src/runner/v3/job.rs
@@ -50,7 +50,6 @@ pub struct JobRunnerOptions<S: RootState> {
     pub expr_rctx: Arc<CommonReadonlyRuntimeExprContext>,
     pub package_manager: Arc<PackageManager>,
     pub artifacts: Arc<Artifacts>,
-    pub is_child: bool,
     pub state: S,
 }
 
@@ -532,7 +531,7 @@ impl<S: RootState> JobRunner<S> {
     async fn dispose_platform(&self, job: &Job) -> Result<()> {
         if job.dispose {
             debug!("executing dispose operations for platform");
-            self.platform()?.dispose(self.options.is_child).await?;
+            self.platform()?.dispose().await?;
         } else {
             debug!("keeping platform alive");
             self.platform()?.keep_alive().await?;
@@ -743,7 +742,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let job = JobRunner {
@@ -799,7 +797,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let job = JobRunner {
@@ -860,7 +857,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let mut job = JobRunner {
@@ -936,7 +932,6 @@ mod tests {
             expr_rctx: expr_rctx.into_arc(),
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
 
@@ -1045,7 +1040,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
 
@@ -1255,7 +1249,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1325,7 +1318,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1391,7 +1383,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1467,7 +1458,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1541,7 +1531,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1615,7 +1604,6 @@ mod tests {
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1688,7 +1676,6 @@ steps:
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         JobRunner {
@@ -1742,7 +1729,6 @@ steps:
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1805,7 +1791,6 @@ steps:
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1873,7 +1858,6 @@ steps:
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         let runner = JobRunner {
@@ -1938,7 +1922,6 @@ steps:
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
 
@@ -2082,7 +2065,6 @@ steps:
             expr_rctx,
             package_manager,
             artifacts,
-            is_child: false,
             state,
         };
         JobRunner {

--- a/crates/bld_runner/src/runner/v3/pipeline.rs
+++ b/crates/bld_runner/src/runner/v3/pipeline.rs
@@ -132,7 +132,6 @@ impl PipelineRunner {
             expr_rctx: self.expr_rctx.clone(),
             package_manager: self.package_manager.clone(),
             artifacts: self.artifacts.clone(),
-            is_child: self.is_child,
             state,
         };
         JobRunner::new(options).await


### PR DESCRIPTION
### In this PR

- The machine platform now builds its temporary directory from both the run identifier and a per platform identifier (`tmp/<run id>/<platform id>`), so the parallel jobs of a run no longer share a single working directory.
- The platform builder creates a fresh identifier for every machine platform it builds.
- Disposing a machine platform removes only its own directory, and then removes the directory of the run when the last platform of that run is gone, so nothing is left behind.
- Platform disposal no longer takes a flag for child runners: each machine platform owns its directory, so a runner that built one always cleans it up, while a child that received the platform of its parent still never disposes it.
- The unused `is_child` field of the version 3 job runner options was removed.
- Added a test for two machine platforms of the same run, showing that disposing the first keeps the files of the second and keeps the directory of the run.

Closes #358
