### PR TITLE
fix(bld_runner): Accept an index into any array value of a v3 expression

### DIFF
--- a/crates/bld_runner/src/action/v3.rs
+++ b/crates/bld_runner/src/action/v3.rs
@@ -161,7 +161,6 @@ impl<'a> EvalObject<'a> for Action {
                 };
                 let name = part.as_span().as_str();
                 rctx.get_input(name)
-                    .map(|x| ExprValue::Text(ExprText::Ref(x)))
             }
 
             "matrix" => {

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -57,6 +57,8 @@ pub struct CommonReadonlyRuntimeExprContext {
     pub env: Arc<HashMap<String, String>>,
     pub run_id: String,
     pub run_start_time: String,
+    /// Set only by the validator, see [`ReadonlyRuntimeExprContext::is_validation`].
+    pub validation: bool,
 }
 
 impl CommonReadonlyRuntimeExprContext {
@@ -73,7 +75,15 @@ impl CommonReadonlyRuntimeExprContext {
             env,
             run_id,
             run_start_time,
+            validation: false,
         }
+    }
+
+    /// Marks the context as one of the validator, where every input and env
+    /// variable stands in with a blank value.
+    pub fn with_validation(mut self) -> Self {
+        self.validation = true;
+        self
     }
 
     pub fn clone_with(&self, closure: impl FnOnce(&mut Self)) -> Self {
@@ -112,6 +122,10 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
 
     fn get_run_start_time(&'a self) -> &'a str {
         &self.run_start_time
+    }
+
+    fn is_validation(&self) -> bool {
+        self.validation
     }
 }
 

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -1,6 +1,6 @@
 use crate::expr::v3::exec::{CommonExprExecutor, eval_all_expressions};
 use crate::expr::v3::parser;
-use crate::expr::v3::traits::EvalObject;
+use crate::expr::v3::traits::{EvalObject, ExprText};
 use crate::inputs::v3::Input;
 
 use super::traits::{
@@ -57,8 +57,6 @@ pub struct CommonReadonlyRuntimeExprContext {
     pub env: Arc<HashMap<String, String>>,
     pub run_id: String,
     pub run_start_time: String,
-    /// Set only by the validator, see [`ReadonlyRuntimeExprContext::is_validation`].
-    pub validation: bool,
 }
 
 impl CommonReadonlyRuntimeExprContext {
@@ -75,15 +73,7 @@ impl CommonReadonlyRuntimeExprContext {
             env,
             run_id,
             run_start_time,
-            validation: false,
         }
-    }
-
-    /// Marks the context as one of the validator, where every input and env
-    /// variable stands in with a blank value.
-    pub fn with_validation(mut self) -> Self {
-        self.validation = true;
-        self
     }
 
     pub fn clone_with(&self, closure: impl FnOnce(&mut Self)) -> Self {
@@ -102,17 +92,17 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
         &self.config.project_dir
     }
 
-    fn get_input(&'a self, name: &'a str) -> Result<&'a str> {
+    fn get_input(&'a self, name: &'a str) -> Result<ExprValue<'a>> {
         self.inputs
             .get(name)
-            .map(|x| x.as_str())
+            .map(|x| ExprValue::Text(ExprText::Ref(x.as_str())))
             .ok_or_else(|| anyhow!("input '{name}' not found"))
     }
 
-    fn get_env(&'a self, name: &'a str) -> Result<&'a str> {
+    fn get_env(&'a self, name: &'a str) -> Result<ExprValue<'a>> {
         self.env
             .get(name)
-            .map(|x| x.as_str())
+            .map(|x| ExprValue::Text(ExprText::Ref(x.as_str())))
             .ok_or_else(|| anyhow!("env variable '{name}' not found"))
     }
 
@@ -122,10 +112,6 @@ impl<'a> ReadonlyRuntimeExprContext<'a> for CommonReadonlyRuntimeExprContext {
 
     fn get_run_start_time(&'a self) -> &'a str {
         &self.run_start_time
-    }
-
-    fn is_validation(&self) -> bool {
-        self.validation
     }
 }
 

--- a/crates/bld_runner/src/expr/v3/context.rs
+++ b/crates/bld_runner/src/expr/v3/context.rs
@@ -229,7 +229,7 @@ mod tests {
         let rctx = resolve(&pipeline, vec![]).unwrap();
 
         assert_eq!(
-            rctx.get_input("worktree_root").unwrap(),
+            rctx.get_input("worktree_root").unwrap().to_string(),
             "/home/user/project/../worktrees/bld"
         );
     }
@@ -249,11 +249,11 @@ mod tests {
         let rctx = resolve(&pipeline, vec![]).unwrap();
 
         assert_eq!(
-            rctx.get_input("repo_dir").unwrap(),
+            rctx.get_input("repo_dir").unwrap().to_string(),
             "/home/user/project/repo"
         );
         assert_eq!(
-            rctx.get_env("LOGS").unwrap(),
+            rctx.get_env("LOGS").unwrap().to_string(),
             "/home/user/project/repo/logs"
         );
     }
@@ -285,7 +285,7 @@ mod tests {
 
         let rctx = resolve(&pipeline, vec![("image", "ubuntu:22.04")]).unwrap();
 
-        assert_eq!(rctx.get_input("image").unwrap(), "ubuntu:22.04");
+        assert_eq!(rctx.get_input("image").unwrap().to_string(), "ubuntu:22.04");
     }
 
     #[test]

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 use crate::expr::v3::parser::{ExprParser, Rule};
 
 use super::traits::{
-    EvalExpr, EvalObject, ExprText, ExprValue, ReadonlyRuntimeExprContext,
-    WritableRuntimeExprContext,
+    EvalExpr, EvalObject, ExprValue, ReadonlyRuntimeExprContext, WritableRuntimeExprContext,
 };
 use anyhow::{Result, anyhow, bail};
 use pest::{Parser, iterators::Pair};
@@ -158,19 +157,36 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
             .parse()
             .map_err(|_| anyhow!("invalid array index: {index_span}"))?;
 
-        let type_str = value.type_as_string();
-        let ExprValue::Text(ExprText::Ref(text)) = value else {
-            bail!("cannot index into value of type {type_str}");
-        };
+        let items = match value {
+            ExprValue::Array(items) => items,
 
-        let mut pairs = ExprParser::parse(Rule::Array, text)
-            .map_err(|_| anyhow!("value is not an array: {text}"))?;
-        let array = pairs
-            .next()
-            .ok_or_else(|| anyhow!("value is not an array: {text}"))?;
+            // The real value of a step output or an input is not known during
+            // validation, so an index into it can't be checked either.
+            ExprValue::Unknown => return Ok(ExprValue::Unknown),
 
-        let ExprValue::Array(items) = self.eval_array(array)? else {
-            bail!("expected array value");
+            ExprValue::Text(text) => {
+                let raw = text.inner();
+
+                // The validator has no real value for an input, so it stands in with
+                // an empty string. An index into that placeholder must not be
+                // reported as an error, only the run itself can check it.
+                if raw.is_empty() && self.rctx.is_validation() {
+                    return Ok(ExprValue::Unknown);
+                }
+
+                let parsed: ExprValue<'a> = raw
+                    .try_into()
+                    .map_err(|_| anyhow!("the value is not an array: '{raw}'"))?;
+                let ExprValue::Array(items) = parsed else {
+                    bail!("the value is not an array: '{raw}'");
+                };
+                items
+            }
+
+            other => bail!(
+                "cannot index into a value of type {}",
+                other.type_as_string()
+            ),
         };
 
         let len = items.len();
@@ -376,15 +392,34 @@ mod tests {
     use crate::{
         expr::v3::{
             context::CommonReadonlyRuntimeExprContext,
-            traits::{ExprText, MockWritableRuntimeExprContext, tests::expr_number},
+            traits::{ExprText, MockWritableRuntimeExprContext, OutputScope, tests::expr_number},
         },
+        job::v3::Job,
         pipeline::v3::Pipeline,
+        runner::v3::{JobState, RootState},
+        step::v3::{ShellCommand, Step},
     };
     use anyhow::Result;
     use bld_utils::sync::IntoArc;
+    use mockall::predicate;
     use std::collections::HashMap;
 
     use super::*;
+
+    fn pipeline_with_step(job: &str, step: &str) -> Pipeline {
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            job.to_string(),
+            Job {
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: step.to_string(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+        pipeline
+    }
 
     fn rctx_with(
         inputs: Vec<(&str, &str)>,
@@ -763,7 +798,147 @@ mod tests {
         let pipeline = Pipeline::default();
         let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
-        assert!(exec.eval("${{ inputs.numbers[5] }}").is_err());
+        let err = exec.eval("${{ inputs.numbers[5] }}").unwrap_err();
+        assert!(err.to_string().contains("length 3"), "error was: {err}");
+    }
+
+    #[test]
+    pub fn array_step_output_index_access_eval_success() {
+        let mut wctx = MockWritableRuntimeExprContext::new();
+        wctx.expect_get_exec_id().returning(|| Some("main"));
+        wctx.expect_get_output()
+            .with(
+                predicate::eq(OutputScope::Step),
+                predicate::eq("build"),
+                predicate::eq("items"),
+            )
+            .times(1)
+            .returning(|_, _, _| {
+                Ok(ExprValue::Array(vec![
+                    ExprValue::Text(ExprText::Ref("x")),
+                    ExprValue::Text(ExprText::Ref("y")),
+                ]))
+            });
+
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = pipeline_with_step("main", "build");
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let value = exec
+            .eval("${{ steps.build.outputs.items[0] }}")
+            .expect("failed to eval indexed step output");
+        assert!(matches!(
+            value.try_eq(&ExprValue::Text(ExprText::Owned("x".to_string()))),
+            Ok(ExprValue::Boolean(true))
+        ));
+    }
+
+    /// The state of a run converts the text of an output into a value, so an array
+    /// output has to be indexable exactly as it is stored there.
+    #[test]
+    pub fn array_step_output_of_run_state_index_access_eval_success() {
+        let mut wctx = JobState::new("main");
+        wctx.add_node("build");
+        wctx.set_output("build", "items".to_string(), "[\"x\", \"y\"]".to_string())
+            .unwrap();
+
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = pipeline_with_step("main", "build");
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let value = exec
+            .eval("${{ steps.build.outputs.items[1] }}")
+            .expect("failed to eval indexed step output");
+        assert_eq!(value.to_string(), "y");
+    }
+
+    #[test]
+    pub fn text_step_output_index_access_eval_success() {
+        let mut wctx = MockWritableRuntimeExprContext::new();
+        wctx.expect_get_exec_id().returning(|| Some("main"));
+        wctx.expect_get_output()
+            .with(
+                predicate::eq(OutputScope::Step),
+                predicate::eq("build"),
+                predicate::eq("items"),
+            )
+            .times(1)
+            .returning(|_, _, _| {
+                Ok(ExprValue::Text(ExprText::Owned(
+                    "[\"x\", \"y\"]".to_string(),
+                )))
+            });
+
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = pipeline_with_step("main", "build");
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let value = exec
+            .eval("${{ steps.build.outputs.items[1] }}")
+            .expect("failed to eval indexed step output");
+        assert!(matches!(
+            value.try_eq(&ExprValue::Text(ExprText::Owned("y".to_string()))),
+            Ok(ExprValue::Boolean(true))
+        ));
+    }
+
+    #[test]
+    pub fn index_into_number_step_output_eval_failure() {
+        let mut wctx = MockWritableRuntimeExprContext::new();
+        wctx.expect_get_exec_id().returning(|| Some("main"));
+        wctx.expect_get_output()
+            .with(
+                predicate::eq(OutputScope::Step),
+                predicate::eq("build"),
+                predicate::eq("count"),
+            )
+            .times(1)
+            .returning(|_, _, _| {
+                Ok(ExprValue::Number {
+                    value: 5.0,
+                    raw: ExprText::Owned("5".to_string()),
+                })
+            });
+
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = pipeline_with_step("main", "build");
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let err = exec
+            .eval("${{ steps.build.outputs.count[0] }}")
+            .unwrap_err();
+        assert!(err.to_string().contains("number"), "error was: {err}");
+    }
+
+    #[test]
+    pub fn index_into_blank_validation_placeholder_gives_unknown() {
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = rctx_with(vec![("list", "")], vec![]).with_validation();
+
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let value = exec
+            .eval("${{ inputs.list[0] }}")
+            .expect("indexing a blank placeholder value must not error");
+        assert!(matches!(value, ExprValue::Unknown));
+    }
+
+    /// Outside of validation a blank value is a real one, so an index into it has
+    /// to be reported instead of quietly giving an unknown value.
+    #[test]
+    pub fn index_into_blank_input_of_a_run_eval_failure() {
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = rctx_with(vec![("list", "")], vec![]);
+
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let err = exec.eval("${{ inputs.list[0] }}").unwrap_err();
+        assert!(
+            err.to_string().contains("the value is not an array: ''"),
+            "error was: {err}"
+        );
     }
 
     #[test]

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -4,6 +4,7 @@ use crate::expr::v3::parser::{ExprParser, Rule};
 
 use super::traits::{
     EvalExpr, EvalObject, ExprValue, ReadonlyRuntimeExprContext, WritableRuntimeExprContext,
+    array_from_pair,
 };
 use anyhow::{Result, anyhow, bail};
 use pest::{Parser, iterators::Pair};
@@ -58,36 +59,7 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
     }
 
     fn eval_array(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
-        let Rule::Array = expr.as_rule() else {
-            bail!("expected array rule, found {:?}", expr.as_rule());
-        };
-
-        let mut items = Vec::new();
-        let mut element_rule: Option<Rule> = None;
-
-        for element in expr.into_inner() {
-            let Rule::ArrayElement = element.as_rule() else {
-                bail!("expected array element rule, found {:?}", element.as_rule());
-            };
-
-            let element = element
-                .into_inner()
-                .next()
-                .ok_or_else(|| anyhow!("empty array element found"))?;
-            let rule = element.as_rule();
-
-            match element_rule {
-                Some(expected) if expected != rule => {
-                    bail!("array elements must all be of the same type")
-                }
-                None => element_rule = Some(rule),
-                _ => {}
-            }
-
-            items.push(element.as_span().as_str().try_into()?);
-        }
-
-        Ok(ExprValue::Array(items))
+        array_from_pair(expr)
     }
 
     fn eval_and_term(&self, expr: Pair<'a, Rule>) -> Result<ExprValue<'a>> {
@@ -166,17 +138,18 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
 
             ExprValue::Text(text) => {
                 let raw = text.inner();
-                let parsed: ExprValue<'a> = raw
-                    .try_into()
-                    .map_err(|_| anyhow!("the value is not an array: '{raw}'"))?;
-                let ExprValue::Array(items) = parsed else {
-                    bail!("the value is not an array: '{raw}'");
-                };
-                items
+                match TryInto::<ExprValue<'a>>::try_into(raw) {
+                    Ok(ExprValue::Array(items)) => items,
+                    Ok(other) => bail!(
+                        "cannot index into a value of type {}: '{raw}'",
+                        other.type_as_string()
+                    ),
+                    Err(_) => bail!("the value is not an array: '{raw}'"),
+                }
             }
 
             other => bail!(
-                "cannot index into a value of type {}",
+                "cannot index into a value of type {}: '{other}'",
                 other.type_as_string()
             ),
         };

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -363,11 +363,12 @@ mod tests {
         pipeline::v3::Pipeline,
         runner::v3::{JobState, RootState},
         step::v3::{ShellCommand, Step},
+        validator::v3::ValidatorReadonlyRuntimeExprContext,
     };
     use anyhow::Result;
     use bld_utils::sync::IntoArc;
     use mockall::predicate;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use super::*;
 
@@ -817,6 +818,75 @@ mod tests {
         assert_eq!(value.to_string(), "y");
     }
 
+    /// A step output that has no quotation marks around its elements is not an
+    /// array, because the grammar accepts a boolean, a number or a string only.
+    #[test]
+    pub fn step_output_without_quotation_marks_index_access_eval_failure() {
+        let mut wctx = JobState::new("main");
+        wctx.add_node("build");
+        wctx.set_output("build", "items".to_string(), "[a, b]".to_string())
+            .unwrap();
+
+        let rctx = CommonReadonlyRuntimeExprContext::default();
+        let pipeline = pipeline_with_step("main", "build");
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let err = exec
+            .eval("${{ steps.build.outputs.items[0] }}")
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot index into a value of type text: '[a, b]'"),
+            "error was: {err}"
+        );
+    }
+
+    #[test]
+    pub fn input_array_with_comma_index_access_eval_success() {
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = rctx_with(vec![("list", r#"["a,b", "c"]"#)], vec![]);
+
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let value = exec
+            .eval("${{ inputs.list[0] }}")
+            .expect("failed to eval indexed input");
+        assert_eq!(value.to_string(), "a,b");
+    }
+
+    #[test]
+    pub fn empty_input_array_index_access_eval_failure() {
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = rctx_with(vec![("list", "[]")], vec![]);
+
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let err = exec.eval("${{ inputs.list[0] }}").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("index 0 out of bounds for array of length 0"),
+            "error was: {err}"
+        );
+    }
+
+    #[test]
+    pub fn index_into_number_input_eval_failure() {
+        let wctx = MockWritableRuntimeExprContext::new();
+        let rctx = rctx_with(vec![("count", "5")], vec![]);
+
+        let pipeline = Pipeline::default();
+        let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
+
+        let err = exec.eval("${{ inputs.count[0] }}").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot index into a value of type number: '5'"),
+            "error was: {err}"
+        );
+    }
+
     #[test]
     pub fn text_step_output_index_access_eval_success() {
         let mut wctx = MockWritableRuntimeExprContext::new();
@@ -876,16 +946,19 @@ mod tests {
     }
 
     #[test]
-    pub fn index_into_blank_validation_placeholder_gives_unknown() {
+    pub fn index_into_unknown_validation_value_gives_unknown() {
         let wctx = MockWritableRuntimeExprContext::new();
-        let rctx = rctx_with(vec![("list", "")], vec![]).with_validation();
+        let rctx = ValidatorReadonlyRuntimeExprContext {
+            inputs: HashSet::from(["list".to_string()]),
+            ..Default::default()
+        };
 
         let pipeline = Pipeline::default();
         let exec = CommonExprExecutor::new(&pipeline, &rctx, &wctx);
 
         let value = exec
             .eval("${{ inputs.list[0] }}")
-            .expect("indexing a blank placeholder value must not error");
+            .expect("indexing an unknown value must not error");
         assert!(matches!(value, ExprValue::Unknown));
     }
 
@@ -901,7 +974,8 @@ mod tests {
 
         let err = exec.eval("${{ inputs.list[0] }}").unwrap_err();
         assert!(
-            err.to_string().contains("the value is not an array: ''"),
+            err.to_string()
+                .contains("cannot index into a value of type text: ''"),
             "error was: {err}"
         );
     }

--- a/crates/bld_runner/src/expr/v3/exec.rs
+++ b/crates/bld_runner/src/expr/v3/exec.rs
@@ -166,14 +166,6 @@ impl<'a, T: EvalObject<'a>, RCtx: ReadonlyRuntimeExprContext<'a>, WCtx: Writable
 
             ExprValue::Text(text) => {
                 let raw = text.inner();
-
-                // The validator has no real value for an input, so it stands in with
-                // an empty string. An index into that placeholder must not be
-                // reported as an error, only the run itself can check it.
-                if raw.is_empty() && self.rctx.is_validation() {
-                    return Ok(ExprValue::Unknown);
-                }
-
                 let parsed: ExprValue<'a> = raw
                     .try_into()
                     .map_err(|_| anyhow!("the value is not an array: '{raw}'"))?;

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -297,6 +297,10 @@ pub trait ReadonlyRuntimeExprContext<'a> {
     fn get_env(&'a self, name: &'a str) -> Result<&'a str>;
     fn get_run_id(&'a self) -> &'a str;
     fn get_run_start_time(&'a self) -> &'a str;
+    /// True when the context belongs to the validator, which stands in for every
+    /// input and env variable with a blank value. Evaluation that needs the real
+    /// value has to give [`ExprValue::Unknown`] instead of an error then.
+    fn is_validation(&self) -> bool;
 }
 
 #[cfg_attr(test, automock)]

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -1,16 +1,12 @@
 #![allow(dead_code)]
 
-use super::parser::Rule;
+use super::parser::{ExprParser, Rule};
 use anyhow::{Result, bail};
-use pest::iterators::{Pair, Pairs};
+use pest::{Parser, iterators::{Pair, Pairs}};
 use std::{collections::HashMap, fmt::Display, iter::Peekable};
 
 #[cfg(test)]
 use mockall::automock;
-use pest::Parser;
-use pest::iterators::{Pair, Pairs};
-
-use super::parser::{ExprParser, Rule};
 
 fn unescape_string_literal(value: &str) -> String {
     let quote = value.chars().next();

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -293,14 +293,10 @@ pub enum OutputScope {
 pub trait ReadonlyRuntimeExprContext<'a> {
     fn get_root_dir(&'a self) -> &'a str;
     fn get_project_dir(&'a self) -> &'a str;
-    fn get_input(&'a self, name: &'a str) -> Result<&'a str>;
-    fn get_env(&'a self, name: &'a str) -> Result<&'a str>;
+    fn get_input(&'a self, name: &'a str) -> Result<ExprValue<'a>>;
+    fn get_env(&'a self, name: &'a str) -> Result<ExprValue<'a>>;
     fn get_run_id(&'a self) -> &'a str;
     fn get_run_start_time(&'a self) -> &'a str;
-    /// True when the context belongs to the validator, which stands in for every
-    /// input and env variable with a blank value. Evaluation that needs the real
-    /// value has to give [`ExprValue::Unknown`] instead of an error then.
-    fn is_validation(&self) -> bool;
 }
 
 #[cfg_attr(test, automock)]

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -7,6 +7,10 @@ use std::{collections::HashMap, fmt::Display, iter::Peekable};
 
 #[cfg(test)]
 use mockall::automock;
+use pest::Parser;
+use pest::iterators::{Pair, Pairs};
+
+use super::parser::{ExprParser, Rule};
 
 fn unescape_string_literal(value: &str) -> String {
     let quote = value.chars().next();
@@ -70,23 +74,45 @@ impl<'a> ExprText<'a> {
     }
 }
 
+pub fn array_from_pair<'a>(pair: Pair<'_, Rule>) -> Result<ExprValue<'a>> {
+    let Rule::Array = pair.as_rule() else {
+        bail!("expected array rule, found {:?}", pair.as_rule());
+    };
+
+    let mut items = Vec::new();
+    let mut element_type: Option<&'static str> = None;
+
+    for element in pair.into_inner() {
+        let Rule::ArrayElement = element.as_rule() else {
+            bail!("expected array element rule, found {:?}", element.as_rule());
+        };
+
+        let value: ExprValue<'a> = element.as_span().as_str().try_into()?;
+
+        match element_type {
+            Some(expected) if expected != value.type_as_string() => {
+                bail!("array elements must all be of the same type")
+            }
+            None => element_type = Some(value.type_as_string()),
+            _ => {}
+        }
+
+        items.push(value);
+    }
+
+    Ok(ExprValue::Array(items))
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExprValue<'a> {
     Boolean(bool),
-    /// `raw` keeps the original text the number was parsed from, so that
-    /// formatting it back to text does not lose information. `value` is used
-    /// for numeric comparisons.
     Number {
         value: f64,
-        raw: ExprText<'a>,
+        raw: ExprText<'a>, // original text for formatting puprposes
     },
     Text(ExprText<'a>),
     Array(Vec<ExprValue<'a>>),
-    /// Placeholder used only during validation, when the real value of a
-    /// step output is not known yet. It is compatible with every
-    /// comparison, so a validation-time expression that compares a step
-    /// output does not fail due to a type mismatch.
-    Unknown,
+    Unknown, // Placeholder for expression results that aren't known at validation time
 }
 
 impl<'a, 'b> ExprValue<'a> {
@@ -213,23 +239,13 @@ impl<'b> TryFrom<&'b str> for ExprValue<'_> {
         }
 
         // Try array
-        if value.starts_with('[') && value.ends_with(']') {
-            let mut expr_type: Option<&'static str> = None;
-            let mut expr_value = vec![];
-            for entry in value[1..value.len() - 1].split(',') {
-                let entry_expr_value: ExprValue<'_> = entry.trim().try_into()?;
-                let entry_expr_type = entry_expr_value.type_as_string();
-
-                if let Some(expr_type) = expr_type
-                    && expr_type != entry_expr_value.type_as_string()
-                {
-                    bail!("Array expression contains entries of multiple types")
-                }
-
-                expr_type = Some(entry_expr_type);
-                expr_value.push(entry_expr_value);
-            }
-            return Ok(ExprValue::Array(expr_value));
+        if value.starts_with('[')
+            && value.ends_with(']')
+            && let Ok(mut pairs) = ExprParser::parse(Rule::Array, value)
+            && let Some(pair) = pairs.next()
+            && pair.as_span().end() == value.len()
+        {
+            return array_from_pair(pair);
         }
 
         // Fallback to test

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -384,6 +384,60 @@ pub mod tests {
         }
     }
 
+    fn array_items(value: &str) -> Vec<String> {
+        let value: ExprValue = value.try_into().unwrap();
+        let ExprValue::Array(items) = value else {
+            panic!("expected array, got {value:?}");
+        };
+        items.iter().map(|item| item.to_string()).collect()
+    }
+
+    #[test]
+    fn array_conversion_keeps_a_comma_inside_quotation_marks() {
+        assert_eq!(array_items(r#"["a,b", "c"]"#), vec!["a,b", "c"]);
+    }
+
+    #[test]
+    fn array_conversion_accepts_an_empty_array() {
+        assert!(array_items("[]").is_empty());
+    }
+
+    #[test]
+    fn array_conversion_accepts_text_and_number_elements() {
+        assert_eq!(array_items(r#"["x", "y"]"#), vec!["x", "y"]);
+        assert_eq!(array_items("[1, 2]"), vec!["1", "2"]);
+    }
+
+    #[test]
+    fn array_conversion_rejects_elements_without_quotation_marks() {
+        let value: ExprValue = "[a, b]".try_into().unwrap();
+        assert!(
+            matches!(value, ExprValue::Text(_)),
+            "expected text, got {value:?}"
+        );
+        assert_eq!(value.to_string(), "[a, b]");
+    }
+
+    #[test]
+    fn array_conversion_rejects_text_after_the_array() {
+        let value: ExprValue = r#"["a"] junk]"#.try_into().unwrap();
+        assert!(
+            matches!(value, ExprValue::Text(_)),
+            "expected text, got {value:?}"
+        );
+    }
+
+    #[test]
+    fn array_conversion_rejects_elements_of_multiple_types() {
+        let error = TryInto::<ExprValue>::try_into(r#"[1, "a"]"#).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("array elements must all be of the same type"),
+            "error was: {error}"
+        );
+    }
+
     #[test]
     fn numbers_still_compare_by_value() {
         let count: ExprValue = "10".try_into().unwrap();

--- a/crates/bld_runner/src/expr/v3/traits.rs
+++ b/crates/bld_runner/src/expr/v3/traits.rs
@@ -2,7 +2,10 @@
 
 use super::parser::{ExprParser, Rule};
 use anyhow::{Result, bail};
-use pest::{Parser, iterators::{Pair, Pairs}};
+use pest::{
+    Parser,
+    iterators::{Pair, Pairs},
+};
 use std::{collections::HashMap, fmt::Display, iter::Peekable};
 
 #[cfg(test)]

--- a/crates/bld_runner/src/job/v3.rs
+++ b/crates/bld_runner/src/job/v3.rs
@@ -259,11 +259,13 @@ mod tests {
     use bld_utils::sync::IntoArc;
 
     use crate::{
-        expr::v3::context::CommonReadonlyRuntimeExprContext,
         pipeline::v3::Pipeline,
         step::v3::{ShellCommand, Step},
         strategy::v3::{FailFastValue, MatrixValue, Strategy},
-        validator::v3::{CommonValidator, ConsumeValidator, ValidatorWritableRuntimeExprContext},
+        validator::v3::{
+            CommonValidator, ConsumeValidator, ValidatorReadonlyRuntimeExprContext,
+            ValidatorWritableRuntimeExprContext,
+        },
     };
 
     use super::{Job, Needs};
@@ -273,7 +275,7 @@ mod tests {
         let config = BldConfig::default().into_arc();
         let file_system = FileSystem::local(config.clone()).into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
-        let expr_rctx = CommonReadonlyRuntimeExprContext::default();
+        let expr_rctx = ValidatorReadonlyRuntimeExprContext::default();
         let expr_wctx = vec![ValidatorWritableRuntimeExprContext::new(job_name)];
 
         let mut pipeline = Pipeline::default();

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -541,6 +541,38 @@ mod tests {
         assert!(result.is_ok(), "unexpected error: {:?}", result.err());
     }
 
+    /// Neither the value of an input nor the value of a step output is known during
+    /// validation, so an index into either one can only be checked by the run itself.
+    #[tokio::test]
+    pub async fn index_into_input_and_step_output_validation_success() {
+        let mut pipeline = Pipeline::default();
+        pipeline
+            .inputs
+            .insert("list".to_string(), complex_input(r#"["a", "b"]"#));
+        pipeline.jobs.insert(
+            "main".to_string(),
+            Job {
+                steps: vec![
+                    Step::ComplexSh(Box::new(ShellCommand {
+                        id: "build".to_string(),
+                        run: r#"echo 'items=["x", "y"]' >> $BLD_OUTPUTS"#.to_string(),
+                        ..Default::default()
+                    })),
+                    Step::ComplexSh(Box::new(ShellCommand {
+                        id: "show".to_string(),
+                        run: r#"echo "${{ inputs.list[0] }} ${{ steps.build.outputs.items[0] }}""#
+                            .to_string(),
+                        ..Default::default()
+                    })),
+                ],
+                ..Default::default()
+            },
+        );
+
+        let result = validate_pipeline(pipeline).await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
     #[tokio::test]
     pub async fn runtime_expr_in_input_default_and_env_validation_failure() {
         let mut pipeline = Pipeline::default();

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -227,7 +227,6 @@ impl<'a> EvalObject<'a> for Pipeline {
                 };
                 let name = part.as_span().as_str();
                 rctx.get_input(name)
-                    .map(|x| ExprValue::Text(ExprText::Ref(x)))
             }
 
             "env" => {
@@ -236,7 +235,6 @@ impl<'a> EvalObject<'a> for Pipeline {
                 };
                 let name = part.as_span().as_str();
                 rctx.get_env(name)
-                    .map(|x| ExprValue::Text(ExprText::Ref(x)))
             }
 
             // Keywords section

--- a/crates/bld_runner/src/pipeline/v3.rs
+++ b/crates/bld_runner/src/pipeline/v3.rs
@@ -697,6 +697,30 @@ mod tests {
         );
     }
 
+    /// An input that is not declared must be named as an input, not as an env
+    /// variable.
+    #[tokio::test]
+    pub async fn undeclared_input_validation_failure() {
+        let mut pipeline = Pipeline::default();
+        pipeline.jobs.insert(
+            "main".to_string(),
+            Job {
+                steps: vec![Step::ComplexSh(Box::new(ShellCommand {
+                    id: "show".to_string(),
+                    run: "echo ${{ inputs.nope }}".to_string(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        );
+
+        let Err(e) = validate_pipeline(pipeline).await else {
+            panic!("expected a validation error for an undeclared input");
+        };
+        let error = e.to_string();
+        assert!(error.contains("input 'nope' not found"), "{error}");
+    }
+
     #[test]
     pub fn name_expr_eval_success() {
         let wctx = MockWritableRuntimeExprContext::new();

--- a/crates/bld_runner/src/runs_on/v3.rs
+++ b/crates/bld_runner/src/runs_on/v3.rs
@@ -608,7 +608,10 @@ mod tests {
         pipeline::v3::Pipeline,
         registry::v3::Registry,
         step::v3::{ShellCommand, Step},
-        validator::v3::{CommonValidator, ConsumeValidator, ValidatorWritableRuntimeExprContext},
+        validator::v3::{
+            CommonValidator, ConsumeValidator, ValidatorReadonlyRuntimeExprContext,
+            ValidatorWritableRuntimeExprContext,
+        },
     };
 
     use super::RunsOn;
@@ -618,7 +621,7 @@ mod tests {
         let config = BldConfig::default().into_arc();
         let file_system = FileSystem::local(config.clone()).into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
-        let expr_rctx = CommonReadonlyRuntimeExprContext::default();
+        let expr_rctx = ValidatorReadonlyRuntimeExprContext::default();
         let expr_wctx = vec![ValidatorWritableRuntimeExprContext::new(job_name)];
 
         let mut pipeline = Pipeline::default();

--- a/crates/bld_runner/src/step/v3.rs
+++ b/crates/bld_runner/src/step/v3.rs
@@ -359,7 +359,7 @@ mod tests {
     use bld_pkg::PackageManager;
     use bld_utils::sync::IntoArc;
     use mockall::predicate;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use crate::{
         action::v3::Action,
@@ -374,7 +374,10 @@ mod tests {
         pipeline::v3::Pipeline,
         step::v3::{ShellCommand, Step},
         strategy::v3::{MatrixValue, Strategy},
-        validator::v3::{CommonValidator, ConsumeValidator, ValidatorWritableRuntimeExprContext},
+        validator::v3::{
+            CommonValidator, ConsumeValidator, ValidatorReadonlyRuntimeExprContext,
+            ValidatorWritableRuntimeExprContext,
+        },
     };
 
     #[test]
@@ -871,7 +874,7 @@ mod tests {
         let config = BldConfig::default().into_arc();
         let fs = FileSystem::local(config.clone()).into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
-        let expr_rctx = CommonReadonlyRuntimeExprContext::default();
+        let expr_rctx = ValidatorReadonlyRuntimeExprContext::default();
         let expr_wctx = vec![ValidatorWritableRuntimeExprContext::new("action")];
 
         CommonValidator::new(action, config, fs, package_manager, &expr_rctx, &expr_wctx)?
@@ -1225,10 +1228,8 @@ mod tests {
         let config = BldConfig::default().into_arc();
         let fs = FileSystem::local(config.clone()).into_arc();
         let package_manager = PackageManager::new(config.clone()).into_arc();
-        let mut inputs = HashMap::new();
-        inputs.insert("tag".to_string(), String::new());
-        let expr_rctx = CommonReadonlyRuntimeExprContext {
-            inputs: inputs.into_arc(),
+        let expr_rctx = ValidatorReadonlyRuntimeExprContext {
+            inputs: HashSet::from(["tag".to_string()]),
             ..Default::default()
         };
         let expr_wctx = vec![ValidatorWritableRuntimeExprContext::new("action")];

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 use bld_config::{BldConfig, path};
 use bld_core::fs::FileSystem;
 use bld_pkg::PackageManager;
@@ -13,11 +13,14 @@ use regex::Regex;
 use tracing::debug;
 
 use crate::expr::v3::{
-    context::{CommonReadonlyRuntimeExprContext, START_OF_RUN_WCTX},
+    context::START_OF_RUN_WCTX,
     exec::CommonExprExecutor,
     parser,
     parser::{ExprParser, Rule},
-    traits::{EvalExpr, EvalObject, ExprValue, OutputScope, WritableRuntimeExprContext},
+    traits::{
+        EvalExpr, EvalObject, ExprValue, OutputScope, ReadonlyRuntimeExprContext,
+        WritableRuntimeExprContext,
+    },
 };
 use pest::{Parser, iterators::Pairs};
 
@@ -100,14 +103,72 @@ impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> 
     }
 }
 
+pub struct ValidatorReadonlyRuntimeExprContext {
+    pub config: Arc<BldConfig>,
+    pub inputs: HashSet<String>,
+    pub env: HashSet<String>,
+    pub run_id: String,
+    pub run_start_time: String,
+}
+
+impl ValidatorReadonlyRuntimeExprContext {
+    pub fn new(
+        config: Arc<BldConfig>,
+        inputs: HashSet<String>,
+        env: HashSet<String>,
+        run_id: String,
+        run_start_time: String,
+    ) -> Self {
+        Self {
+            config,
+            inputs,
+            env,
+            run_id,
+            run_start_time,
+        }
+    }
+}
+
+impl<'a> ReadonlyRuntimeExprContext<'a> for ValidatorReadonlyRuntimeExprContext {
+    fn get_root_dir(&'a self) -> &'a str {
+        &self.config.root_dir
+    }
+
+    fn get_project_dir(&'a self) -> &'a str {
+        &self.config.project_dir
+    }
+
+    fn get_input(&'a self, name: &'a str) -> Result<ExprValue<'a>> {
+        self.inputs
+            .get(name)
+            .map(|_| ExprValue::Unknown)
+            .ok_or_else(|| anyhow!("input '{name}' not found"))
+    }
+
+    fn get_env(&'a self, name: &'a str) -> Result<ExprValue<'a>> {
+        self.env
+            .get(name)
+            .map(|_| ExprValue::Unknown)
+            .ok_or_else(|| anyhow!("env variable '{name}' not found"))
+    }
+
+    fn get_run_id(&'a self) -> &'a str {
+        &self.run_id
+    }
+
+    fn get_run_start_time(&'a self) -> &'a str {
+        &self.run_start_time
+    }
+}
+
 pub struct CommonValidator<'a, V: Validate<'a> + for<'x> EvalObject<'x>> {
     validatable: &'a V,
     config: Arc<BldConfig>,
     file_system: Arc<FileSystem>,
     package_manager: Arc<PackageManager>,
     expr_regex: Regex,
-    expr_rctx: &'a CommonReadonlyRuntimeExprContext,
-    job_expr_rctx: HashMap<&'a str, &'a CommonReadonlyRuntimeExprContext>,
+    expr_rctx: &'a ValidatorReadonlyRuntimeExprContext,
+    job_expr_rctx: HashMap<&'a str, &'a ValidatorReadonlyRuntimeExprContext>,
     expr_wctx: &'a [ValidatorWritableRuntimeExprContext<'a>],
     job_needs: HashMap<&'a str, HashSet<&'a str>>,
     section: Vec<Section<'a>>,
@@ -121,7 +182,7 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
         config: Arc<BldConfig>,
         file_system: Arc<FileSystem>,
         package_manager: Arc<PackageManager>,
-        expr_rctx: &'a CommonReadonlyRuntimeExprContext,
+        expr_rctx: &'a ValidatorReadonlyRuntimeExprContext,
         expr_wctx: &'a [ValidatorWritableRuntimeExprContext],
     ) -> Result<Self> {
         Ok(Self {
@@ -147,13 +208,15 @@ impl<'a, V: Validate<'a> + for<'x> EvalObject<'x>> CommonValidator<'a, V> {
 
     pub fn with_job_expr_rctx(
         mut self,
-        job_expr_rctx: HashMap<&'a str, &'a CommonReadonlyRuntimeExprContext>,
+        job_expr_rctx: HashMap<&'a str, &'a ValidatorReadonlyRuntimeExprContext>,
     ) -> Self {
         self.job_expr_rctx = job_expr_rctx;
         self
     }
 
-    fn rctx(&self) -> &'a CommonReadonlyRuntimeExprContext {
+    /// The context of the job that is being validated, or the context of the file when no
+    /// job is being validated or the job has no env of its own.
+    fn rctx(&self) -> &'a ValidatorReadonlyRuntimeExprContext {
         self.current_job
             .as_ref()
             .and_then(|job| self.job_expr_rctx.get(job.inner()))

--- a/crates/bld_runner/src/validator/v3/common.rs
+++ b/crates/bld_runner/src/validator/v3/common.rs
@@ -103,6 +103,7 @@ impl<'a> WritableRuntimeExprContext for ValidatorWritableRuntimeExprContext<'a> 
     }
 }
 
+#[derive(Debug, Default)]
 pub struct ValidatorReadonlyRuntimeExprContext {
     pub config: Arc<BldConfig>,
     pub inputs: HashSet<String>,

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -56,7 +56,8 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                     env.clone().into_arc(),
                     String::new(),
                     String::new(),
-                );
+                )
+                .with_validation();
                 // Create expr_rctx for each job's scope
                 let job_expr_rctx_values: Vec<(&str, CommonReadonlyRuntimeExprContext)> = pip
                     .jobs
@@ -73,7 +74,8 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                                 job_env.into_arc(),
                                 String::new(),
                                 String::new(),
-                            ),
+                            )
+                            .with_validation(),
                         )
                     })
                     .collect();
@@ -112,7 +114,8 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                     HashMap::new().into_arc(),
                     String::new(),
                     String::new(),
-                );
+                )
+                .with_validation();
                 let expr_wctx = vec![ValidatorWritableRuntimeExprContext::new("action")];
                 CommonValidator::new(
                     action.as_ref(),

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -42,8 +42,8 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
     async fn validate(self) -> Result<()> {
         match self.file {
             RunnerFile::PipelineFileType(pip) => {
-                let inputs: HashSet<String> = pip.inputs.keys().map(|k| k.clone()).collect();
-                let env: HashSet<String> = pip.env.keys().map(|k| k.clone()).collect();
+                let inputs: HashSet<String> = pip.inputs.keys().cloned().collect();
+                let env: HashSet<String> = pip.env.keys().cloned().collect();
                 let expr_rctx = ValidatorReadonlyRuntimeExprContext::new(
                     self.config.clone(),
                     inputs.clone(),
@@ -58,7 +58,7 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                     .filter(|(_, job)| !job.env.is_empty())
                     .map(|(name, job)| {
                         let mut job_env = env.clone();
-                        job_env.extend(job.env.keys().map(|k| k.clone()));
+                        job_env.extend(job.env.keys().cloned());
                         (
                             name.as_str(),
                             ValidatorReadonlyRuntimeExprContext::new(
@@ -102,7 +102,7 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
             RunnerFile::ActionFileType(action) => {
                 let expr_rctx = ValidatorReadonlyRuntimeExprContext::new(
                     self.config.clone(),
-                    action.inputs.keys().map(|k| k.clone()).collect(),
+                    action.inputs.keys().cloned().collect(),
                     HashSet::new(),
                     String::new(),
                     String::new(),

--- a/crates/bld_runner/src/validator/v3/file.rs
+++ b/crates/bld_runner/src/validator/v3/file.rs
@@ -7,11 +7,10 @@ use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::fs::FileSystem;
 use bld_pkg::PackageManager;
-use bld_utils::sync::IntoArc;
 
 use crate::{
-    expr::v3::context::CommonReadonlyRuntimeExprContext, files::v3::RunnerFile,
-    validator::v3::ValidatorWritableRuntimeExprContext,
+    files::v3::RunnerFile,
+    validator::v3::{ValidatorReadonlyRuntimeExprContext, ValidatorWritableRuntimeExprContext},
 };
 
 use super::{CommonValidator, ConsumeValidator};
@@ -41,45 +40,38 @@ impl<'a> RunnerFileValidator<'a> {
 
 impl ConsumeValidator for RunnerFileValidator<'_> {
     async fn validate(self) -> Result<()> {
-        let with_blank_values = |keys: Vec<&String>| -> HashMap<String, String> {
-            keys.into_iter()
-                .map(|k| (k.clone(), String::new()))
-                .collect()
-        };
         match self.file {
             RunnerFile::PipelineFileType(pip) => {
-                let inputs = with_blank_values(pip.inputs.keys().collect()).into_arc();
-                let env = with_blank_values(pip.env.keys().collect());
-                let expr_rctx = CommonReadonlyRuntimeExprContext::new(
+                let inputs: HashSet<String> = pip.inputs.keys().map(|k| k.clone()).collect();
+                let env: HashSet<String> = pip.env.keys().map(|k| k.clone()).collect();
+                let expr_rctx = ValidatorReadonlyRuntimeExprContext::new(
                     self.config.clone(),
                     inputs.clone(),
-                    env.clone().into_arc(),
+                    env.clone(),
                     String::new(),
                     String::new(),
-                )
-                .with_validation();
+                );
                 // Create expr_rctx for each job's scope
-                let job_expr_rctx_values: Vec<(&str, CommonReadonlyRuntimeExprContext)> = pip
+                let job_expr_rctx_values: Vec<(&str, ValidatorReadonlyRuntimeExprContext)> = pip
                     .jobs
                     .iter()
                     .filter(|(_, job)| !job.env.is_empty())
                     .map(|(name, job)| {
                         let mut job_env = env.clone();
-                        job_env.extend(with_blank_values(job.env.keys().collect()));
+                        job_env.extend(job.env.keys().map(|k| k.clone()));
                         (
                             name.as_str(),
-                            CommonReadonlyRuntimeExprContext::new(
+                            ValidatorReadonlyRuntimeExprContext::new(
                                 self.config.clone(),
                                 inputs.clone(),
-                                job_env.into_arc(),
+                                job_env,
                                 String::new(),
                                 String::new(),
-                            )
-                            .with_validation(),
+                            ),
                         )
                     })
                     .collect();
-                let job_expr_rctx: HashMap<&str, &CommonReadonlyRuntimeExprContext> =
+                let job_expr_rctx: HashMap<&str, &ValidatorReadonlyRuntimeExprContext> =
                     job_expr_rctx_values
                         .iter()
                         .map(|(name, rctx)| (*name, rctx))
@@ -108,14 +100,13 @@ impl ConsumeValidator for RunnerFileValidator<'_> {
                 .await
             }
             RunnerFile::ActionFileType(action) => {
-                let expr_rctx = CommonReadonlyRuntimeExprContext::new(
+                let expr_rctx = ValidatorReadonlyRuntimeExprContext::new(
                     self.config.clone(),
-                    with_blank_values(action.inputs.keys().collect()).into_arc(),
-                    HashMap::new().into_arc(),
+                    action.inputs.keys().map(|k| k.clone()).collect(),
+                    HashSet::new(),
                     String::new(),
                     String::new(),
-                )
-                .with_validation();
+                );
                 let expr_wctx = vec![ValidatorWritableRuntimeExprContext::new("action")];
                 CommonValidator::new(
                     action.as_ref(),


### PR DESCRIPTION
### In this PR

- `eval_index` now takes an `ExprValue::Array` as it is, so an array step output can be indexed without being parsed a second time.
- A text value is accepted too, borrowed or owned, and is converted with the same `TryFrom` that the state of a run uses for an output.
- The value is quoted in the `the value is not an array: '...'` error, so a blank one is visible in the message.
- An index into a value of any other type reports that type, and an index that is too large still reports the length of the array.
- An index into an input or an env variable no longer fails during validation, where both stand in with a blank value; a run still reports a blank value as an error.
- The readonly expression context tells whether it belongs to the validator, which is how the two cases above are told apart.
- New tests cover an index into an array output, a text output, a number output, a blank value and the pipeline of the report.

Closes #359
